### PR TITLE
Azure deployment foundation: Bicep for SWA + Functions + Cosmos DB + Key Vault

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,122 @@
+# Hero Tasks App — Azure Infrastructure
+
+Bicep IaC for the Azure backend: Static Web App (frontend), Function App
+(API), Cosmos DB (data), Key Vault (secrets). This was written directly
+(not via GitHub's Copilot coding agent) and validated by compiling with
+the Bicep CLI — `bicep build main.bicep` succeeds with zero errors or
+warnings; the compiled output is checked in at `main.json`.
+
+**Nothing here has been deployed.** Writing the IaC and running it against
+a real Azure subscription are two different things — this repo has no
+Azure credentials attached, so the actual `az deployment group create`
+step is yours to run (or wire into GitHub Actions once you're ready).
+
+## Architecture
+
+| Module | File | Description |
+|--------|------|-------------|
+| **Storage Account** | `modules/storage.bicep` | Backs only the Function App's own runtime state (`AzureWebJobsStorage`) — no app data lives here |
+| **Cosmos DB** | `modules/cosmosdb.bicep` | Free-tier account, one database, containers: `households`, `people`, `chores`, `completions`, `rewards`, `planningItems` (reminders/voice notes/calendar items), `auditEvents` |
+| **Key Vault** | `modules/keyvault.bicep` | Secrets store (currently just `llm-api-key`), RBAC-only, Function App reads via managed identity |
+| **Function App** | `modules/functionapp.bicep` | Consumption-plan API, HTTP-triggered (not timer — this is an interactive app), system-assigned managed identity for all Azure access |
+| **Static Web App** | `modules/staticwebapp.bicep` | Free tier, with the Function App linked as its backend (`linkedBackends`) so auth/CORS is handled by the platform instead of hand-rolled |
+
+`main.bicep` wires these together and grants the Function App's managed
+identity exactly three roles: Storage Blob Data Contributor (its own
+runtime storage), Key Vault Secrets User (read `llm-api-key`), and Cosmos
+DB Built-in Data Contributor (read/write household data). No connection
+strings or access keys anywhere — Cosmos DB and the storage account both
+have local/key-based auth disabled (`disableLocalAuth` / `allowSharedKeyAccess: false`).
+
+## Prerequisites (before you can actually deploy)
+
+- An Azure subscription with a resource group created for this project
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), logged in (`az login`)
+- Bicep CLI (`az bicep install`, or the standalone binary — `az` will offer to install it automatically on first `az deployment` command if missing)
+
+## Deploying
+
+```bash
+az group create --name herotasks-dev-rg --location <your-region>
+
+az deployment group create \
+  --resource-group herotasks-dev-rg \
+  --template-file infra/main.bicep \
+  --parameters @infra/parameters.dev.json
+```
+
+To seed the LLM API key at deploy time instead of adding it to Key Vault
+manually afterward:
+
+```bash
+az deployment group create \
+  --resource-group herotasks-dev-rg \
+  --template-file infra/main.bicep \
+  --parameters @infra/parameters.dev.json \
+  --parameters llmApiKey=<your-llm-api-key>
+```
+
+Repeat with `parameters.prod.json` and a separate resource group for prod.
+
+## Automating deployment from GitHub Actions (optional, later)
+
+This isn't wired up yet — it needs a one-time Azure-side setup that only
+you can do (create a federated credential / service principal so GitHub
+Actions can authenticate to your subscription without a long-lived
+secret). Once you've done that and added the three
+`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets to
+this repo, tell me and I'll add the workflow — the Bicep side is already
+ready for it.
+
+## Parameter reference
+
+### `main.bicep`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|--------------|
+| `env` | string | *(required)* | `dev` or `prod` |
+| `location` | string | `resourceGroup().location` | Azure region |
+| `functionWorkerRuntime` | string | `node` | Function worker runtime |
+| `functionLinuxFxVersion` | string | `Node\|20` | Linux runtime stack |
+| `staticWebAppSku` | string | `Free` | Static Web App SKU |
+| `llmApiKey` | string (secure) | `''` | Voice-intent LLM API key; leave empty to skip seeding |
+| `enableKeyVaultPublicAccess` | bool | `false` | Leave `false` unless you specifically need it |
+| `cosmosSharedThroughput` | int | `400` | RU/s shared across all Cosmos containers (well within the 1000 RU/s free-tier allowance) |
+
+## Cosmos DB data model (v1)
+
+Matches `docs/mvp-scope-v1.md`. All containers except `households` are
+partitioned by `/householdId` — cheap, co-located queries for a
+single-household app. `households` is partitioned by its own `/id` since
+there's no higher grouping above it.
+
+| Container | Partition key | Holds |
+|-----------|----------------|-------|
+| `households` | `/id` | The household itself |
+| `people` | `/householdId` | Parent + kid profiles, roles, PINs |
+| `chores` | `/householdId` | Chore definitions, assignment, schedule |
+| `completions` | `/householdId` | Chore completion + approval history |
+| `rewards` | `/householdId` | Reward catalog + redemption history |
+| `planningItems` | `/householdId` | Reminders, voice notes, calendar events |
+| `auditEvents` | `/householdId` | Who changed what, when |
+
+## Security
+
+- **Storage account**: no public blob access, shared-key access disabled — Function App auth is managed-identity only.
+- **Cosmos DB**: `disableLocalAuth: true` — no primary/secondary keys work, only Azure AD/managed identity via the SQL role assignment.
+- **Key Vault**: RBAC authorization (no legacy access policies), 90-day soft-delete retention, public network access disabled by default.
+- **Function App**: HTTPS-only, TLS 1.2 minimum, FTPS disabled, system-assigned managed identity for every downstream call.
+
+## Troubleshooting
+
+### Function App can't read from Key Vault / Cosmos DB / Storage
+Role assignments can take a few minutes to propagate after first deploy. Re-check the resource's Access control (IAM) blade if a call fails immediately after deployment.
+
+### Deployment fails with "resource already exists"
+Role assignment names are deterministic GUIDs derived from resource IDs — redeploying updates the existing assignment in place. A real conflict means the same role is being assigned to the same principal twice somewhere.
+
+## Next steps
+1. Deploy to `dev` and confirm all five resources provision cleanly.
+2. Write the actual Function App code (HTTP-triggered endpoints for chores/rewards/reminders/voice — this is the `developer` agent's job, issue-by-issue from here).
+3. Wire up GitHub Actions deployment once Azure credentials are set up on your end.
+4. Promote to `prod` with `parameters.prod.json` after `dev` is validated.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,122 @@
+@description('Deployment environment. Supported values are dev and prod.')
+@allowed(['dev', 'prod'])
+param env string
+
+@description('Azure region where all resources are deployed.')
+param location string = resourceGroup().location
+
+@description('Function worker runtime value (for example node, dotnet-isolated, python).')
+param functionWorkerRuntime string = 'node'
+
+@description('Function App Linux runtime stack value (for example Node|20).')
+param functionLinuxFxVersion string = 'Node|20'
+
+@description('Azure Static Web App SKU. Free (F1) is sufficient for this project.')
+@allowed(['Free'])
+param staticWebAppSku string = 'Free'
+
+@description('Optional secure value for seeding the llm-api-key secret in Key Vault (the voice-note intent-validation LLM).')
+@secure()
+param llmApiKey string = ''
+
+@description('Built-in Storage Blob Data Contributor role definition ID.')
+param storageBlobDataContributorRoleDefinitionId string = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+@description('Enable public network access to Key Vault. Defaults to false (security-by-default). Only enable if explicitly required; prefer private endpoints for production.')
+param enableKeyVaultPublicAccess bool = false
+
+@description('Shared throughput (RU/s) for the Cosmos DB database.')
+param cosmosSharedThroughput int = 400
+
+var storageAccountName = toLower(replace('herotasksstorage${env}', '-', ''))
+var functionAppName = 'herotasks-func-${env}'
+var keyVaultName = 'herotasks-kv-${env}'
+var keyVaultDnsSuffix = environment().suffixes.keyvaultDns
+var llmApiKeySecretUri = 'https://${keyVaultName}.${keyVaultDnsSuffix}/secrets/llm-api-key/'
+var cosmosAccountName = toLower(replace('herotasks-cosmos-${env}', '-', ''))
+var cosmosEndpoint = 'https://${cosmosAccountName}.documents.azure.com:443/'
+var cosmosDatabaseName = 'herotasks'
+
+module storage './modules/storage.bicep' = {
+  name: 'storage-${env}'
+  params: {
+    env: env
+    location: location
+  }
+}
+
+module functionApp './modules/functionapp.bicep' = {
+  name: 'function-${env}'
+  params: {
+    env: env
+    location: location
+    storageAccountName: storage.outputs.storageAccountName
+    workerRuntime: functionWorkerRuntime
+    linuxFxVersion: functionLinuxFxVersion
+    cosmosEndpoint: cosmosEndpoint
+    cosmosDatabaseName: cosmosDatabaseName
+    llmApiKeySecretUri: llmApiKeySecretUri
+  }
+}
+
+module keyVault './modules/keyvault.bicep' = {
+  name: 'keyvault-${env}'
+  params: {
+    env: env
+    location: location
+    functionPrincipalId: functionApp.outputs.functionPrincipalId
+    llmApiKey: llmApiKey
+    enablePublicNetworkAccess: enableKeyVaultPublicAccess
+  }
+}
+
+module cosmos './modules/cosmosdb.bicep' = {
+  name: 'cosmos-${env}'
+  params: {
+    env: env
+    location: location
+    functionPrincipalId: functionApp.outputs.functionPrincipalId
+    databaseName: cosmosDatabaseName
+    sharedThroughput: cosmosSharedThroughput
+  }
+}
+
+module staticWebApp './modules/staticwebapp.bicep' = {
+  name: 'staticwebapp-${env}'
+  params: {
+    env: env
+    location: location
+    sku: staticWebAppSku
+    linkedFunctionAppId: functionApp.outputs.functionAppId
+    linkedFunctionAppLocation: location
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+// RBAC: grant the Function App's system-assigned managed identity the "Storage Blob Data
+// Contributor" role on its own runtime storage account. Required because allowSharedKeyAccess
+// is false on that account (no connection strings), so AzureWebJobsStorage must authenticate
+// via managed identity instead.
+resource functionStorageBlobDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccountName, functionAppName, storageBlobDataContributorRoleDefinitionId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleDefinitionId)
+    principalId: functionApp.outputs.functionPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output storageAccountName string = storage.outputs.storageAccountName
+output keyVaultName string = keyVault.outputs.keyVaultName
+output functionAppName string = functionApp.outputs.functionAppName
+output cosmosAccountName string = cosmos.outputs.cosmosAccountName
+output cosmosEndpoint string = cosmosEndpoint
+output cosmosDatabaseName string = cosmosDatabaseName
+@secure()
+output staticWebAppDeploymentToken string = staticWebApp.outputs.staticWebAppDeploymentToken
+output staticWebAppName string = staticWebApp.outputs.staticWebAppName
+output staticWebAppDefaultHostname string = staticWebApp.outputs.staticWebAppDefaultHostname

--- a/infra/main.json
+++ b/infra/main.json
@@ -1,0 +1,903 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.46.1.21595",
+      "templateHash": "14626833612456619636"
+    }
+  },
+  "parameters": {
+    "env": {
+      "type": "string",
+      "allowedValues": [
+        "dev",
+        "prod"
+      ],
+      "metadata": {
+        "description": "Deployment environment. Supported values are dev and prod."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region where all resources are deployed."
+      }
+    },
+    "functionWorkerRuntime": {
+      "type": "string",
+      "defaultValue": "node",
+      "metadata": {
+        "description": "Function worker runtime value (for example node, dotnet-isolated, python)."
+      }
+    },
+    "functionLinuxFxVersion": {
+      "type": "string",
+      "defaultValue": "Node|20",
+      "metadata": {
+        "description": "Function App Linux runtime stack value (for example Node|20)."
+      }
+    },
+    "staticWebAppSku": {
+      "type": "string",
+      "defaultValue": "Free",
+      "allowedValues": [
+        "Free"
+      ],
+      "metadata": {
+        "description": "Azure Static Web App SKU. Free (F1) is sufficient for this project."
+      }
+    },
+    "llmApiKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional secure value for seeding the llm-api-key secret in Key Vault (the voice-note intent-validation LLM)."
+      }
+    },
+    "storageBlobDataContributorRoleDefinitionId": {
+      "type": "string",
+      "defaultValue": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+      "metadata": {
+        "description": "Built-in Storage Blob Data Contributor role definition ID."
+      }
+    },
+    "enableKeyVaultPublicAccess": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable public network access to Key Vault. Defaults to false (security-by-default). Only enable if explicitly required; prefer private endpoints for production."
+      }
+    },
+    "cosmosSharedThroughput": {
+      "type": "int",
+      "defaultValue": 400,
+      "metadata": {
+        "description": "Shared throughput (RU/s) for the Cosmos DB database."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[toLower(replace(format('herotasksstorage{0}', parameters('env')), '-', ''))]",
+    "functionAppName": "[format('herotasks-func-{0}', parameters('env'))]",
+    "keyVaultName": "[format('herotasks-kv-{0}', parameters('env'))]",
+    "keyVaultDnsSuffix": "[environment().suffixes.keyvaultDns]",
+    "llmApiKeySecretUri": "[format('https://{0}.{1}/secrets/llm-api-key/', variables('keyVaultName'), variables('keyVaultDnsSuffix'))]",
+    "cosmosAccountName": "[toLower(replace(format('herotasks-cosmos-{0}', parameters('env')), '-', ''))]",
+    "cosmosEndpoint": "[format('https://{0}.documents.azure.com:443/', variables('cosmosAccountName'))]",
+    "cosmosDatabaseName": "herotasks"
+  },
+  "resources": {
+    "storageAccount": {
+      "existing": true,
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[variables('storageAccountName')]"
+    },
+    "functionStorageBlobDataContributorRoleAssignment": {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "scope": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+      "name": "[guid(variables('storageAccountName'), variables('functionAppName'), parameters('storageBlobDataContributorRoleDefinitionId'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('storageBlobDataContributorRoleDefinitionId'))]",
+        "principalId": "[reference('functionApp').outputs.functionPrincipalId.value]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "functionApp"
+      ]
+    },
+    "storage": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('storage-{0}', parameters('env'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "env": {
+            "value": "[parameters('env')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "8286788855793327528"
+            }
+          },
+          "parameters": {
+            "env": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment suffix (for example: dev or prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the storage account."
+              }
+            },
+            "storageSkuName": {
+              "type": "string",
+              "defaultValue": "Standard_LRS",
+              "metadata": {
+                "description": "Storage account SKU name."
+              }
+            }
+          },
+          "variables": {
+            "storageAccountName": "[toLower(replace(format('herotasksstorage{0}', parameters('env')), '-', ''))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-05-01",
+              "name": "[variables('storageAccountName')]",
+              "location": "[parameters('location')]",
+              "kind": "StorageV2",
+              "sku": {
+                "name": "[parameters('storageSkuName')]"
+              },
+              "properties": {
+                "accessTier": "Hot",
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": false,
+                "minimumTlsVersion": "TLS1_2",
+                "supportsHttpsTrafficOnly": true
+              }
+            }
+          ],
+          "outputs": {
+            "storageAccountId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            },
+            "storageAccountName": {
+              "type": "string",
+              "value": "[variables('storageAccountName')]"
+            }
+          }
+        }
+      }
+    },
+    "functionApp": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('function-{0}', parameters('env'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "env": {
+            "value": "[parameters('env')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "storageAccountName": {
+            "value": "[reference('storage').outputs.storageAccountName.value]"
+          },
+          "workerRuntime": {
+            "value": "[parameters('functionWorkerRuntime')]"
+          },
+          "linuxFxVersion": {
+            "value": "[parameters('functionLinuxFxVersion')]"
+          },
+          "cosmosEndpoint": {
+            "value": "[variables('cosmosEndpoint')]"
+          },
+          "cosmosDatabaseName": {
+            "value": "[variables('cosmosDatabaseName')]"
+          },
+          "llmApiKeySecretUri": {
+            "value": "[variables('llmApiKeySecretUri')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "11994255678477450852"
+            }
+          },
+          "parameters": {
+            "env": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment suffix (for example: dev or prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the Function App and its hosting plan."
+              }
+            },
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage account name backing the Function host runtime state."
+              }
+            },
+            "workerRuntime": {
+              "type": "string",
+              "defaultValue": "node",
+              "metadata": {
+                "description": "Function worker runtime value (for example node, dotnet-isolated, python)."
+              }
+            },
+            "linuxFxVersion": {
+              "type": "string",
+              "defaultValue": "Node|20",
+              "metadata": {
+                "description": "Linux runtime stack for the Function App."
+              }
+            },
+            "cosmosEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Cosmos DB account endpoint the API reads/writes household data through."
+              }
+            },
+            "cosmosDatabaseName": {
+              "type": "string",
+              "defaultValue": "herotasks",
+              "metadata": {
+                "description": "Cosmos DB database name."
+              }
+            },
+            "llmApiKeySecretUri": {
+              "type": "string",
+              "metadata": {
+                "description": "Key Vault secret URI for the voice-intent LLM API key."
+              }
+            }
+          },
+          "variables": {
+            "functionAppName": "[format('herotasks-func-{0}', parameters('env'))]",
+            "hostingPlanName": "[format('herotasks-plan-{0}', parameters('env'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Web/serverfarms",
+              "apiVersion": "2023-12-01",
+              "name": "[variables('hostingPlanName')]",
+              "location": "[parameters('location')]",
+              "kind": "linux",
+              "sku": {
+                "name": "Y1",
+                "tier": "Dynamic"
+              },
+              "properties": {
+                "reserved": true
+              }
+            },
+            {
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2023-12-01",
+              "name": "[variables('functionAppName')]",
+              "location": "[parameters('location')]",
+              "kind": "functionapp,linux",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "httpsOnly": true,
+                "siteConfig": {
+                  "linuxFxVersion": "[parameters('linuxFxVersion')]",
+                  "minTlsVersion": "1.2",
+                  "ftpsState": "Disabled",
+                  "cors": {
+                    "allowedOrigins": [
+                      "*"
+                    ]
+                  },
+                  "appSettings": [
+                    {
+                      "name": "FUNCTIONS_EXTENSION_VERSION",
+                      "value": "~4"
+                    },
+                    {
+                      "name": "FUNCTIONS_WORKER_RUNTIME",
+                      "value": "[parameters('workerRuntime')]"
+                    },
+                    {
+                      "name": "COSMOS_ENDPOINT",
+                      "value": "[parameters('cosmosEndpoint')]"
+                    },
+                    {
+                      "name": "COSMOS_DATABASE_NAME",
+                      "value": "[parameters('cosmosDatabaseName')]"
+                    },
+                    {
+                      "name": "LLM_API_KEY",
+                      "value": "[format('@Microsoft.KeyVault(SecretUri={0})', parameters('llmApiKeySecretUri'))]"
+                    },
+                    {
+                      "name": "AzureWebJobsStorage__accountName",
+                      "value": "[parameters('storageAccountName')]"
+                    },
+                    {
+                      "name": "AzureWebJobsStorage__credential",
+                      "value": "managedidentity"
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "functionAppId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            },
+            "functionAppName": {
+              "type": "string",
+              "value": "[variables('functionAppName')]"
+            },
+            "functionPrincipalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2023-12-01', 'full').identity.principalId]"
+            },
+            "functionDefaultHostname": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2023-12-01').defaultHostName]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "storage"
+      ]
+    },
+    "keyVault": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('keyvault-{0}', parameters('env'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "env": {
+            "value": "[parameters('env')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "functionPrincipalId": {
+            "value": "[reference('functionApp').outputs.functionPrincipalId.value]"
+          },
+          "llmApiKey": {
+            "value": "[parameters('llmApiKey')]"
+          },
+          "enablePublicNetworkAccess": {
+            "value": "[parameters('enableKeyVaultPublicAccess')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "13752764176501468457"
+            }
+          },
+          "parameters": {
+            "env": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment suffix (for example: dev or prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the Key Vault."
+              }
+            },
+            "functionPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Function App managed identity principal ID that needs secret read access."
+              }
+            },
+            "llmApiKey": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Secure value for the voice-intent LLM API key. Leave empty to skip seeding this secret."
+              }
+            },
+            "keyVaultRoleDefinitionId": {
+              "type": "string",
+              "defaultValue": "4633458b-17de-408a-b874-0445c86b69e6",
+              "metadata": {
+                "description": "Built-in Key Vault role definition ID for the Secrets User role."
+              }
+            },
+            "enablePublicNetworkAccess": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Enable public network access to Key Vault. Defaults to false (security-by-default); use private endpoints instead for production."
+              }
+            }
+          },
+          "variables": {
+            "keyVaultName": "[format('herotasks-kv-{0}', parameters('env'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[variables('keyVaultName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "tenantId": "[subscription().tenantId]",
+                "sku": {
+                  "family": "A",
+                  "name": "standard"
+                },
+                "enableRbacAuthorization": true,
+                "enabledForDeployment": false,
+                "enabledForTemplateDeployment": false,
+                "enabledForDiskEncryption": false,
+                "softDeleteRetentionInDays": 90,
+                "publicNetworkAccess": "[if(parameters('enablePublicNetworkAccess'), 'Enabled', 'Disabled')]"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+              "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), parameters('functionPrincipalId'), parameters('keyVaultRoleDefinitionId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('keyVaultRoleDefinitionId'))]",
+                "principalId": "[parameters('functionPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+              ]
+            },
+            {
+              "condition": "[not(empty(parameters('llmApiKey')))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), 'llm-api-key')]",
+              "properties": {
+                "value": "[parameters('llmApiKey')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "keyVaultId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+            },
+            "keyVaultName": {
+              "type": "string",
+              "value": "[variables('keyVaultName')]"
+            },
+            "keyVaultUri": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), '2023-07-01').vaultUri]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "functionApp"
+      ]
+    },
+    "cosmos": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('cosmos-{0}', parameters('env'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "env": {
+            "value": "[parameters('env')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "functionPrincipalId": {
+            "value": "[reference('functionApp').outputs.functionPrincipalId.value]"
+          },
+          "databaseName": {
+            "value": "[variables('cosmosDatabaseName')]"
+          },
+          "sharedThroughput": {
+            "value": "[parameters('cosmosSharedThroughput')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "13823117976463526779"
+            }
+          },
+          "parameters": {
+            "env": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment suffix (for example: dev or prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the Cosmos DB account."
+              }
+            },
+            "functionPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Function App managed identity principal ID that needs data-plane read/write access."
+              }
+            },
+            "databaseName": {
+              "type": "string",
+              "defaultValue": "herotasks",
+              "metadata": {
+                "description": "Cosmos DB SQL database name."
+              }
+            },
+            "sharedThroughput": {
+              "type": "int",
+              "defaultValue": 400,
+              "metadata": {
+                "description": "Shared throughput (RU/s) across all containers in the database. The Cosmos DB free tier covers up to 1000 RU/s and 25GB storage account-wide, comfortably above what a 2-kid household needs."
+              }
+            }
+          },
+          "variables": {
+            "cosmosDataContributorRoleId": "00000000-0000-0000-0000-000000000002",
+            "cosmosAccountName": "[toLower(replace(format('herotasks-cosmos-{0}', parameters('env')), '-', ''))]",
+            "householdScopedContainers": [
+              "people",
+              "chores",
+              "completions",
+              "rewards",
+              "planningItems",
+              "auditEvents"
+            ]
+          },
+          "resources": [
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts",
+              "apiVersion": "2024-05-15",
+              "name": "[variables('cosmosAccountName')]",
+              "location": "[parameters('location')]",
+              "kind": "GlobalDocumentDB",
+              "properties": {
+                "databaseAccountOfferType": "Standard",
+                "enableFreeTier": true,
+                "consistencyPolicy": {
+                  "defaultConsistencyLevel": "Session"
+                },
+                "locations": [
+                  {
+                    "locationName": "[parameters('location')]",
+                    "failoverPriority": 0,
+                    "isZoneRedundant": false
+                  }
+                ],
+                "disableLocalAuth": true,
+                "minimalTlsVersion": "Tls12"
+              }
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+              "apiVersion": "2024-05-15",
+              "name": "[format('{0}/{1}', variables('cosmosAccountName'), parameters('databaseName'))]",
+              "properties": {
+                "resource": {
+                  "id": "[parameters('databaseName')]"
+                },
+                "options": {
+                  "throughput": "[parameters('sharedThroughput')]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-05-15",
+              "name": "[format('{0}/{1}/{2}', variables('cosmosAccountName'), parameters('databaseName'), 'households')]",
+              "properties": {
+                "resource": {
+                  "id": "households",
+                  "partitionKey": {
+                    "paths": [
+                      "/id"
+                    ],
+                    "kind": "Hash"
+                  }
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('cosmosAccountName'), parameters('databaseName'))]"
+              ]
+            },
+            {
+              "copy": {
+                "name": "scopedContainers",
+                "count": "[length(variables('householdScopedContainers'))]"
+              },
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-05-15",
+              "name": "[format('{0}/{1}/{2}', variables('cosmosAccountName'), parameters('databaseName'), variables('householdScopedContainers')[copyIndex()])]",
+              "properties": {
+                "resource": {
+                  "id": "[variables('householdScopedContainers')[copyIndex()]]",
+                  "partitionKey": {
+                    "paths": [
+                      "/householdId"
+                    ],
+                    "kind": "Hash"
+                  }
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('cosmosAccountName'), parameters('databaseName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+              "apiVersion": "2024-05-15",
+              "name": "[format('{0}/{1}', variables('cosmosAccountName'), guid(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), parameters('functionPrincipalId'), variables('cosmosDataContributorRoleId')))]",
+              "properties": {
+                "roleDefinitionId": "[format('{0}/sqlRoleDefinitions/{1}', resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), variables('cosmosDataContributorRoleId'))]",
+                "principalId": "[parameters('functionPrincipalId')]",
+                "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "cosmosAccountName": {
+              "type": "string",
+              "value": "[variables('cosmosAccountName')]"
+            },
+            "cosmosEndpoint": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), '2024-05-15').documentEndpoint]"
+            },
+            "databaseName": {
+              "type": "string",
+              "value": "[parameters('databaseName')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "functionApp"
+      ]
+    },
+    "staticWebApp": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('staticwebapp-{0}', parameters('env'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "env": {
+            "value": "[parameters('env')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "sku": {
+            "value": "[parameters('staticWebAppSku')]"
+          },
+          "linkedFunctionAppId": {
+            "value": "[reference('functionApp').outputs.functionAppId.value]"
+          },
+          "linkedFunctionAppLocation": {
+            "value": "[parameters('location')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.46.1.21595",
+              "templateHash": "2941807685387417589"
+            }
+          },
+          "parameters": {
+            "env": {
+              "type": "string",
+              "metadata": {
+                "description": "Deployment environment suffix (for example: dev or prod)."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for the Static Web App."
+              }
+            },
+            "sku": {
+              "type": "string",
+              "defaultValue": "Free",
+              "allowedValues": [
+                "Free"
+              ],
+              "metadata": {
+                "description": "Azure Static Web App SKU. Free is sufficient at this scale."
+              }
+            },
+            "linkedFunctionAppId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource ID of the Function App to link as this Static Web App's backend (shares auth/CORS automatically, no manual CORS config needed on the frontend side)."
+              }
+            },
+            "linkedFunctionAppLocation": {
+              "type": "string",
+              "metadata": {
+                "description": "Region the linked Function App is deployed in."
+              }
+            }
+          },
+          "variables": {
+            "staticWebAppName": "[format('herotasks-swa-{0}', parameters('env'))]"
+          },
+          "resources": {
+            "staticWebApp": {
+              "type": "Microsoft.Web/staticSites",
+              "apiVersion": "2024-04-01",
+              "name": "[variables('staticWebAppName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "[parameters('sku')]",
+                "tier": "[parameters('sku')]"
+              },
+              "properties": {
+                "provider": "None"
+              }
+            },
+            "linkedBackend": {
+              "type": "Microsoft.Web/staticSites/linkedBackends",
+              "apiVersion": "2024-04-01",
+              "name": "[format('{0}/{1}', variables('staticWebAppName'), 'herotasks-api')]",
+              "properties": {
+                "backendResourceId": "[parameters('linkedFunctionAppId')]",
+                "region": "[parameters('linkedFunctionAppLocation')]"
+              },
+              "dependsOn": [
+                "staticWebApp"
+              ]
+            }
+          },
+          "outputs": {
+            "staticWebAppDeploymentToken": {
+              "type": "securestring",
+              "value": "[listSecrets('staticWebApp', '2024-04-01').properties.apiKey]"
+            },
+            "staticWebAppName": {
+              "type": "string",
+              "value": "[variables('staticWebAppName')]"
+            },
+            "staticWebAppDefaultHostname": {
+              "type": "string",
+              "value": "[reference('staticWebApp').defaultHostname]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "functionApp"
+      ]
+    }
+  },
+  "outputs": {
+    "storageAccountName": {
+      "type": "string",
+      "value": "[reference('storage').outputs.storageAccountName.value]"
+    },
+    "keyVaultName": {
+      "type": "string",
+      "value": "[reference('keyVault').outputs.keyVaultName.value]"
+    },
+    "functionAppName": {
+      "type": "string",
+      "value": "[reference('functionApp').outputs.functionAppName.value]"
+    },
+    "cosmosAccountName": {
+      "type": "string",
+      "value": "[reference('cosmos').outputs.cosmosAccountName.value]"
+    },
+    "cosmosEndpoint": {
+      "type": "string",
+      "value": "[variables('cosmosEndpoint')]"
+    },
+    "cosmosDatabaseName": {
+      "type": "string",
+      "value": "[variables('cosmosDatabaseName')]"
+    },
+    "staticWebAppDeploymentToken": {
+      "type": "securestring",
+      "value": "[listOutputsWithSecureValues('staticWebApp', '2025-04-01').staticWebAppDeploymentToken]"
+    },
+    "staticWebAppName": {
+      "type": "string",
+      "value": "[reference('staticWebApp').outputs.staticWebAppName.value]"
+    },
+    "staticWebAppDefaultHostname": {
+      "type": "string",
+      "value": "[reference('staticWebApp').outputs.staticWebAppDefaultHostname.value]"
+    }
+  }
+}

--- a/infra/modules/cosmosdb.bicep
+++ b/infra/modules/cosmosdb.bicep
@@ -1,0 +1,111 @@
+@description('Deployment environment suffix (for example: dev or prod).')
+param env string
+
+@description('Azure region for the Cosmos DB account.')
+param location string
+
+@description('Function App managed identity principal ID that needs data-plane read/write access.')
+param functionPrincipalId string
+
+@description('Cosmos DB SQL database name.')
+param databaseName string = 'herotasks'
+
+@description('Shared throughput (RU/s) across all containers in the database. The Cosmos DB free tier covers up to 1000 RU/s and 25GB storage account-wide, comfortably above what a 2-kid household needs.')
+param sharedThroughput int = 400
+
+@description('Built-in Cosmos DB Data Contributor role definition GUID — same value on every Cosmos account, not environment-specific.')
+var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
+
+var cosmosAccountName = toLower(replace('herotasks-cosmos-${env}', '-', ''))
+
+// Every non-households container is scoped to a household via this partition key,
+// which keeps all of one family's data co-located and queries cheap.
+var householdScopedContainers = [
+  'people'
+  'chores'
+  'completions'
+  'rewards'
+  'planningItems'
+  'auditEvents'
+]
+
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
+  name: cosmosAccountName
+  location: location
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    enableFreeTier: true
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    // No primary/secondary keys usable — every client (the Function App) authenticates
+    // via managed identity + the SQL role assignment below, never a connection string.
+    disableLocalAuth: true
+    minimalTlsVersion: 'Tls12'
+  }
+}
+
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' = {
+  parent: cosmosAccount
+  name: databaseName
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: {
+      throughput: sharedThroughput
+    }
+  }
+}
+
+// One household's own document — partitioned by its own id since there's no
+// higher-level grouping above a household.
+resource householdsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  parent: database
+  name: 'households'
+  properties: {
+    resource: {
+      id: 'households'
+      partitionKey: {
+        paths: ['/id']
+        kind: 'Hash'
+      }
+    }
+  }
+}
+
+resource scopedContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = [for name in householdScopedContainers: {
+  parent: database
+  name: name
+  properties: {
+    resource: {
+      id: name
+      partitionKey: {
+        paths: ['/householdId']
+        kind: 'Hash'
+      }
+    }
+  }
+}]
+
+resource dataContributorRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
+  parent: cosmosAccount
+  name: guid(cosmosAccount.id, functionPrincipalId, cosmosDataContributorRoleId)
+  properties: {
+    roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
+    principalId: functionPrincipalId
+    scope: cosmosAccount.id
+  }
+}
+
+output cosmosAccountName string = cosmosAccount.name
+output cosmosEndpoint string = cosmosAccount.properties.documentEndpoint
+output databaseName string = database.name

--- a/infra/modules/functionapp.bicep
+++ b/infra/modules/functionapp.bicep
@@ -1,0 +1,97 @@
+@description('Deployment environment suffix (for example: dev or prod).')
+param env string
+
+@description('Azure region for the Function App and its hosting plan.')
+param location string
+
+@description('Storage account name backing the Function host runtime state.')
+param storageAccountName string
+
+@description('Function worker runtime value (for example node, dotnet-isolated, python).')
+param workerRuntime string = 'node'
+
+@description('Linux runtime stack for the Function App.')
+param linuxFxVersion string = 'Node|20'
+
+@description('Cosmos DB account endpoint the API reads/writes household data through.')
+param cosmosEndpoint string
+
+@description('Cosmos DB database name.')
+param cosmosDatabaseName string = 'herotasks'
+
+@description('Key Vault secret URI for the voice-intent LLM API key.')
+param llmApiKeySecretUri string
+
+var functionAppName = 'herotasks-func-${env}'
+var hostingPlanName = 'herotasks-plan-${env}'
+
+resource hostingPlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: hostingPlanName
+  location: location
+  kind: 'linux'
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: hostingPlan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      minTlsVersion: '1.2'
+      ftpsState: 'Disabled'
+      cors: {
+        // Tightened to the real Static Web App hostname once known; '*' is fine while
+        // the SWA-linked-backend wiring (below, in main.bicep) also covers auth passthrough.
+        allowedOrigins: ['*']
+      }
+      appSettings: [
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: workerRuntime
+        }
+        {
+          name: 'COSMOS_ENDPOINT'
+          value: cosmosEndpoint
+        }
+        {
+          name: 'COSMOS_DATABASE_NAME'
+          value: cosmosDatabaseName
+        }
+        {
+          name: 'LLM_API_KEY'
+          value: '@Microsoft.KeyVault(SecretUri=${llmApiKeySecretUri})'
+        }
+        {
+          name: 'AzureWebJobsStorage__accountName'
+          value: storageAccountName
+        }
+        {
+          name: 'AzureWebJobsStorage__credential'
+          value: 'managedidentity'
+        }
+      ]
+    }
+  }
+}
+
+output functionAppId string = functionApp.id
+output functionAppName string = functionApp.name
+output functionPrincipalId string = functionApp.identity.principalId
+output functionDefaultHostname string = functionApp.properties.defaultHostName

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -1,0 +1,60 @@
+@description('Deployment environment suffix (for example: dev or prod).')
+param env string
+
+@description('Azure region for the Key Vault.')
+param location string
+
+@description('Function App managed identity principal ID that needs secret read access.')
+param functionPrincipalId string
+
+@description('Secure value for the voice-intent LLM API key. Leave empty to skip seeding this secret.')
+@secure()
+param llmApiKey string = ''
+
+@description('Built-in Key Vault role definition ID for the Secrets User role.')
+param keyVaultRoleDefinitionId string = '4633458b-17de-408a-b874-0445c86b69e6'
+
+@description('Enable public network access to Key Vault. Defaults to false (security-by-default); use private endpoints instead for production.')
+param enablePublicNetworkAccess bool = false
+
+var keyVaultName = 'herotasks-kv-${env}'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  properties: {
+    tenantId: subscription().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+    enabledForDeployment: false
+    enabledForTemplateDeployment: false
+    enabledForDiskEncryption: false
+    softDeleteRetentionInDays: 90
+    publicNetworkAccess: enablePublicNetworkAccess ? 'Enabled' : 'Disabled'
+  }
+}
+
+resource functionSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, functionPrincipalId, keyVaultRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultRoleDefinitionId)
+    principalId: functionPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource llmApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(llmApiKey)) {
+  name: 'llm-api-key'
+  parent: keyVault
+  properties: {
+    value: llmApiKey
+  }
+}
+
+output keyVaultId string = keyVault.id
+output keyVaultName string = keyVault.name
+output keyVaultUri string = keyVault.properties.vaultUri

--- a/infra/modules/staticwebapp.bicep
+++ b/infra/modules/staticwebapp.bicep
@@ -1,0 +1,43 @@
+@description('Deployment environment suffix (for example: dev or prod).')
+param env string
+
+@description('Azure region for the Static Web App.')
+param location string
+
+@description('Azure Static Web App SKU. Free is sufficient at this scale.')
+@allowed(['Free'])
+param sku string = 'Free'
+
+@description('Resource ID of the Function App to link as this Static Web App\'s backend (shares auth/CORS automatically, no manual CORS config needed on the frontend side).')
+param linkedFunctionAppId string
+
+@description('Region the linked Function App is deployed in.')
+param linkedFunctionAppLocation string
+
+var staticWebAppName = 'herotasks-swa-${env}'
+
+resource staticWebApp 'Microsoft.Web/staticSites@2024-04-01' = {
+  name: staticWebAppName
+  location: location
+  sku: {
+    name: sku
+    tier: sku
+  }
+  properties: {
+    provider: 'None'
+  }
+}
+
+resource linkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' = {
+  parent: staticWebApp
+  name: 'herotasks-api'
+  properties: {
+    backendResourceId: linkedFunctionAppId
+    region: linkedFunctionAppLocation
+  }
+}
+
+@secure()
+output staticWebAppDeploymentToken string = staticWebApp.listSecrets().properties.apiKey
+output staticWebAppName string = staticWebAppName
+output staticWebAppDefaultHostname string = staticWebApp.properties.defaultHostname

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -1,0 +1,32 @@
+@description('Deployment environment suffix (for example: dev or prod).')
+param env string
+
+@description('Azure region for the storage account.')
+param location string
+
+@description('Storage account SKU name.')
+param storageSkuName string = 'Standard_LRS'
+
+// Storage account names cannot include hyphens, so the conventional name is normalized.
+// This account backs the Function App's own runtime state (AzureWebJobsStorage) only —
+// application data lives in Cosmos DB, not here.
+var storageAccountName = toLower(replace('herotasksstorage${env}', '-', ''))
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: storageSkuName
+  }
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+output storageAccountId string = storageAccount.id
+output storageAccountName string = storageAccount.name

--- a/infra/parameters.dev.json
+++ b/infra/parameters.dev.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "env": {
+      "value": "dev"
+    },
+    "enableKeyVaultPublicAccess": {
+      "value": false
+    }
+  }
+}

--- a/infra/parameters.prod.json
+++ b/infra/parameters.prod.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "env": {
+      "value": "prod"
+    },
+    "enableKeyVaultPublicAccess": {
+      "value": false
+    }
+  }
+}


### PR DESCRIPTION
## What this is

Real Bicep infrastructure-as-code, written directly rather than through GitHub's Copilot coding agent (that path only produces PRs regardless of persona, and kept limiting what we could actually get done). Closes #3 (Azure deployment foundation) and #4 (core data model) together, since you can't design one without the other.

## Validation

Compiled with the Bicep CLI (0.46.1) — `bicep build main.bicep` succeeds with **zero errors, zero warnings**. Compiled ARM output checked in at `infra/main.json` for anyone who wants to deploy without installing Bicep locally.

**Not deployed.** This session has no Azure CLI, no Azure credentials, and no Azure MCP connector — I checked before writing any of this. The IaC is real and validated; running it against your subscription is the one part only you can do. Full deploy instructions in `infra/README.md`.

## Architecture

- **Static Web App** (Free tier) — frontend, with the Function App linked as its backend (`linkedBackends`) so auth/CORS is handled by the platform
- **Function App** (Consumption plan, HTTP-triggered) — the API
- **Cosmos DB** (free tier) — `households`, `people`, `chores`, `completions`, `rewards`, `planningItems`, `auditEvents` containers, partitioned by `/householdId` (or `/id` for `households` itself)
- **Key Vault** — `llm-api-key` secret for voice-intent validation, RBAC-only
- **Storage account** — backs only the Function App's own runtime state, no app data

Adapted from the working pattern already proven in your `fermenter-dashboard-azure` repo. Zero connection strings or access keys anywhere: Cosmos DB and the storage account both have local/key auth disabled, everything goes through the Function App's system-assigned managed identity with least-privilege role assignments (Storage Blob Data Contributor, Key Vault Secrets User, Cosmos DB Built-in Data Contributor).

## Test plan
- [x] `bicep build main.bicep` compiles clean (verified this session)
- [ ] `az deployment group create` against a real `dev` resource group (needs your Azure subscription)
- [ ] Confirm all 5 resources provision and role assignments propagate
- [ ] Function App code (next issue) can actually reach Cosmos DB + Key Vault via managed identity

---
_Generated by [Claude Code](https://claude.ai/code/session_012MpvY1KHqgxaQQuyWa4wub)_