### PR TITLE
Document the two-engine agent team model

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,43 +1,84 @@
 # Agent Team
 
-> **Update:** the team is moving to Claude Managed Agents, starting with the
-> Elaborator — see [`managed-agents.md`](managed-agents.md). The role
-> definitions below still describe each agent's job; the "working model"
-> section reflects the earlier Copilot-based approach.
+This repository is worked on by a team of AI agents, each with a defined role.
+The team spans **two engines** — work whose output is *thinking* runs on
+Claude Managed Agents; work whose output is *a pull request* runs on GitHub
+Copilot. You are the gate between them.
 
-This repository is designed to be worked on with GitHub-based agents,
-defined in `.github/agents/*.agent.md`:
+## The roles and where each runs
 
-- [`architect`](../.github/agents/architect.agent.md)
-- [`elaborator`](../.github/agents/elaborator.agent.md)
-- [`project-manager`](../.github/agents/project-manager.agent.md)
-- [`tester`](../.github/agents/tester.agent.md)
-- [`developer`](../.github/agents/developer.agent.md)
+| Role | Engine | Trigger | Output |
+|---|---|---|---|
+| **Elaborator** | Claude Managed Agents | `elaborate` label on an issue | Sub-issues with acceptance criteria + an audit comment |
+| **Architect** | Claude Managed Agents | *(not built yet)* | A technical-approach comment on the issue |
+| **Project manager** | Claude Managed Agents | *(not built yet)* — scheduled, Perth time | A backlog status summary |
+| **Developer** | GitHub Copilot | Assign the issue to Copilot in the GitHub UI | A branch + pull request |
+| **Tester** | GitHub Copilot | Copilot code review on the PR | Review comments on the PR |
 
-## How they work
-1. `project-manager` selects and sequences backlog work.
-2. `elaborator` expands an issue into an actionable spec, splitting broad
-   issues into smaller ones.
-3. `architect` validates the technical approach and system design.
-4. `developer` implements the change.
-5. `tester` verifies the result against acceptance criteria.
+Personas live in `.github/agents/*.agent.md`. Those files are **Copilot custom
+agent definitions** — they drive the Copilot roles directly. For the Claude
+roles they are reference only: the live persona is the `SYSTEM_PROMPT` in that
+agent's setup script under `ops/`, and editing the `.agent.md` file does not
+change the Claude agent.
 
-## Working model (important)
-GitHub's Copilot coding agent only has one output mode: a branch + a pull
-request with file changes. There is no "just leave a comment" or "just
-create issues" mode, regardless of which custom agent persona is used.
+> **Naming note.** "GitHub agents" and "Copilot agents" are the same thing.
+> GitHub is the platform; Copilot is its AI product. The `.github/agents/`
+> folder and the repo's **Agents** tab both refer to Copilot custom agents.
 
-So in practice:
-- **Planning work** (`project-manager`, `elaborator`, `architect`
-  write-ups, splitting issues, docs) happens as direct commits/issues on
-  `main` — no PR needed, since there's no code being reviewed.
-- **Implementation work** (`developer`; verification via `tester`) is
-  assigned to GitHub's Copilot coding agent, which opens a real PR for
-  human review before merge — appropriate since actual code/infra is
-  changing.
+## Why the split
 
-## Suggested repo workflow
-- Track work in GitHub Issues (see `.github/ISSUE_TEMPLATE/feature.md`).
-- Small, focused PRs for implementation work.
-- Keep the repo usable entirely from GitHub web/mobile if desired.
-- Deploy from GitHub to Azure via GitHub Actions.
+Copilot's coding agent has exactly one output mode: a branch and a pull
+request. That is ideal for the developer role and wrong for a business
+analyst, who needs to create issues and comment. Claude Managed Agents can
+produce whatever the role needs, and additionally supports scheduled runs and
+multi-agent orchestration, which Copilot does not.
+
+Cost follows the same logic: Copilot is bundled in the Copilot subscription,
+so the code-heavy roles are effectively free, while metered Claude spend stays
+on the cheaper thinking roles.
+
+## The flow
+
+1. You add the `elaborate` label to a backlog issue.
+2. **Elaborator** audits the codebase, then splits the remaining work into
+   sub-issues with checkable acceptance criteria, labelled `role:developer` or
+   `role:architect`. The parent issue stays open as the umbrella.
+3. *(Future)* **Architect** reviews anything labelled `role:architect` and
+   posts the technical approach.
+4. You assign a sub-issue to **Copilot** — it writes the code and opens a PR.
+5. **Copilot code review** checks the PR against the acceptance criteria.
+6. You review and merge. Deployment to Azure follows (see issue #29 — still
+   manual today).
+
+Handoff between engines is by **label and assignment only** — there is no
+integration code between them, and neither engine calls the other.
+
+## Ground rules
+
+- **One issue per Elaborator run**, triggered deliberately. Nothing runs on a
+  schedule yet.
+- **Agents never merge.** Every code change reaches `main` through a PR you
+  approve.
+- **Claude agents never get Azure credentials.** They read the repo and write
+  GitHub issues; deployment stays outside their reach.
+- **Epics are not implementation tasks.** Once elaborated, a parent issue
+  should not carry a `role:*` label — the sub-issues do. Assigning an epic to
+  Copilot produces sprawling, unreviewable PRs.
+
+## Where things are documented
+
+| Topic | File |
+|---|---|
+| Elaborator: setup, cost controls, troubleshooting | `docs/managed-agents.md` |
+| Persona definitions | `.github/agents/*.agent.md` |
+| Product scope and rules | `docs/mvp-scope-v1.md` |
+| Deployment | `docs/deploy-app.md` |
+
+## Status
+
+- ✅ **Elaborator** — live (`docs/managed-agents.md`)
+- ⬜ **Architect**, **Project manager** — designed, not built. Deferred until
+  the Elaborator's output quality is tuned
+- ⬜ **Developer**, **Tester** — personas exist; not yet exercised under this
+  model
+- ⬜ **Automated Azure deployment** — issue #29, blocks the developer chain


### PR DESCRIPTION
Locks in the agent team model we settled on. `docs/agents.md` previously described a Copilot-only working model that no longer matches reality.

## The model

| Role | Engine |
|---|---|
| Elaborator, Architect, Project manager | Claude Managed Agents — output is thinking (issues, comments, summaries) |
| Developer, Tester | GitHub Copilot — output is a pull request |

Handoff between the two is by **label and assignment only** — no integration code, neither engine calls the other. You remain the gate at every step.

## Also captured

- Why the split: Copilot's coding agent has exactly one output mode (branch + PR), which suits a developer and not a BA; Claude agents can produce whatever the role needs, plus scheduling. Cost follows the same logic — code-heavy roles run on the bundled subscription, metered spend stays on the cheap thinking roles.
- Clarification that "GitHub agents" and "Copilot agents" are the same thing, and that `.github/agents/*.agent.md` drives the Copilot roles directly but is reference-only for the Claude ones (whose live persona is the `SYSTEM_PROMPT` in `ops/`).
- Ground rules: agents never merge; Claude agents never get Azure credentials; epics don't carry `role:*` labels once elaborated.
- An honest status list — only the Elaborator is live; architect and project manager are designed but deliberately deferred until the Elaborator's output quality is tuned.

Docs only, no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_