### PR TITLE
Auto-approve GitHub tool calls so Elaborator runs unattended

### DIFF
--- a/docs/managed-agents.md
+++ b/docs/managed-agents.md
@@ -98,6 +98,24 @@ run on it.
   in `.github/workflows/elaborate.yml`.
 - **Agent behaves oddly** — its persona is the `SYSTEM_PROMPT` in
   `ops/elaborator/setup_elaborator.py`; edit, then re-run the setup workflow.
+- **Session sits `Idle` doing nothing** — open the Console session link and
+  scroll to the end of the transcript. Unanswered **Approve / Deny** buttons
+  mean it is parked waiting for a human; the **Tools** panel shows which tool
+  is set to *Ask*. Tools are configured `always_allow` so this should not
+  happen — if it does, the tool policy in `setup_elaborator.py` has drifted.
+  The run itself now reports this and exits rather than hanging.
+
+### Reading a session in the Console
+
+1. The status pill beside the session title: **Running** (working), **Idle**
+   (stopped — finished *or* blocked), **Terminated** (ended).
+2. End of the transcript: buttons = blocked on you; plain text = finished.
+3. **Tools** panel: per-tool permission, call counts, failures. The Overview
+   box at the bottom (`Completed` vs `In flight`) tells you whether work is
+   actually progressing.
+4. **Events** tab: the raw event stream, when the transcript is ambiguous.
+5. The cost figure beside the title (`US$0.17 / US$5.00`) is spend against the
+   session budget.
 
 ## Phase 2+ (not built yet)
 

--- a/ops/elaborator/run_elaborator.py
+++ b/ops/elaborator/run_elaborator.py
@@ -90,7 +90,18 @@ def main():
             elif etype == "session.status_idle":
                 sr = stop_reason_type(event)
                 if sr == "requires_action":
-                    continue  # not expected for this agent (no custom tools / always_allow)
+                    # Should not happen: the agent has no custom tools and its
+                    # tools are always_allow. If it does, the session is parked
+                    # waiting for a human - say so rather than hanging until the
+                    # wall-clock limit.
+                    outcome = "requires_action"
+                    print(
+                        "\n!! The agent is waiting for tool approval and this run cannot answer it.\n"
+                        "   Approve it in the Console link above, or check the agent's tool "
+                        "permission policy.",
+                        flush=True,
+                    )
+                    break
                 outcome = "budget_reached" if sr == "budget_reached" else "done"
                 break
             elif etype == "session.status_terminated":
@@ -106,7 +117,7 @@ def main():
             "Session paused at its $5 budget cap before finishing. "
             "Raise the budget in the Console session view to let it finish, or review what it produced."
         )
-    if outcome in ("timeout", "unknown"):
+    if outcome in ("timeout", "unknown", "requires_action"):
         sys.exit(1)
 
 

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -70,13 +70,23 @@ Be decisive and finish in a single pass. Keep sub-issue count and wording lean:
 quality of acceptance criteria over volume of prose.
 """
 
+# Filesystem tools: read-only. No bash, write, edit, web_fetch or web_search -
+# the Elaborator reads code and writes GitHub issues, nothing else.
+# GitHub tools: always_allow, so runs are unattended. Without this they default
+# to always_ask and the session parks waiting for a human to click Approve on
+# every call. The confirmation gate is the `elaborate` label, not per-call
+# clicks; the agent's token is scoped to this repo with issues-only write.
 TOOLS = [
     {
         "type": "agent_toolset_20260401",
         "default_config": {"enabled": False},
         "configs": [{"name": n, "enabled": True} for n in ("read", "glob", "grep")],
     },
-    {"type": "mcp_toolset", "mcp_server_name": "github"},
+    {
+        "type": "mcp_toolset",
+        "mcp_server_name": "github",
+        "default_config": {"enabled": True, "permission_policy": {"type": "always_allow"}},
+    },
 ]
 
 MCP_SERVERS = [{"type": "url", "name": "github", "url": GITHUB_MCP_URL}]


### PR DESCRIPTION
The first real run (issue #10) parked at **Idle** for 7 minutes without doing anything. Cause: the `mcp_toolset` entry had no permission policy, so GitHub tool calls defaulted to `always_ask` and the session waited for a human to click **Approve** on every single call — which no unattended workflow can do.

## Changes

1. **`mcp_toolset` now sets `permission_policy: always_allow`.** Runs are unattended, as intended. The confirmation gate remains the `elaborate` label, not per-call clicks. The security posture is unchanged and still tight: the agent cannot run `bash`, write or edit files, or reach the web (all `Deny`), and its GitHub token is scoped to this repository with issues-only write.
2. **The runner fails fast on a `requires_action` idle** instead of silently waiting out its 25-minute wall-clock limit. It now prints what happened and exits non-zero, so a stuck run is visible in the Actions log rather than looking like a slow one.
3. **Docs**: added a "Reading a session in the Console" section — status pill meanings, how to tell finished from blocked, what the Tools panel and Overview box tell you — plus a troubleshooting entry for the stuck-Idle case.

## After merging

Re-run *Elaborator — one-time setup* to push the new tool policy to the agent (it updates in place to v2). The already-running session for #10 stays pinned to v1 and will keep asking — approve it manually or let it lapse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_