### PR TITLE
Elaborator: link sub-issues natively and de-role the parent epic

### DIFF
--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -57,14 +57,22 @@ Work in this order:
    - List any open product questions for Peter where a decision is genuinely
      ambiguous - do not guess product policy.
 
-4. Create each sub-issue via the GitHub tools. Reuse the repository's existing
-   labels (role:developer, role:architect) where they fit; if a label does not
-   exist, skip labelling rather than failing.
+4. Create each sub-issue via the GitHub tools, then LINK EACH ONE as a native
+   GitHub sub-issue of the original (the sub-issue write tool, 'add' method,
+   with the parent's issue number and the new issue's internal id - the id
+   from the create response, not its issue number). This gives the parent a
+   real progress bar and hierarchy; a "Part of #N" line in the body alone does
+   not. Reuse the repository's existing labels (role:developer,
+   role:architect) where they fit; if a label does not exist, skip labelling
+   rather than failing.
 
 5. Comment once on the original issue with: the already-built audit summary,
    links to every sub-issue you created, and the open questions. If an
    'elaborated' label exists in the repository, add it to the original issue;
-   otherwise skip. Leave the original issue open.
+   otherwise skip. The parent is now an epic, not a task: REMOVE any 'role:*'
+   label from it, since the sub-issues carry those and an epic assigned to a
+   coding agent produces sprawling, unreviewable changes. Leave the original
+   issue open - it closes when its sub-issues are done.
 
 Be decisive and finish in a single pass. Keep sub-issue count and wording lean:
 quality of acceptance criteria over volume of prose.


### PR DESCRIPTION
The first elaboration created #32–#35 as plain issues connected to #10 only by a "Part of #10" line in the body. GitHub's native sub-issue relationship was empty, so #10 had no progress bar, no hierarchy in the issues list, and an empty Relationships panel. Across 16 more backlog items that flattens into an unnavigable pile.

## Changes

1. **The Elaborator now links each new sub-issue to its parent** using GitHub's sub-issue relationship (`add`, with the parent issue number and the new issue's internal id — not its issue number, which is the easy mistake). The instruction says explicitly why a body mention is not enough.
2. **It removes any `role:*` label from the parent.** An elaborated parent is an epic, not a task; leaving `role:developer` on it invites someone to hand the whole epic to a coding agent, which is exactly the ground rule `docs/agents.md` sets out to prevent.
3. **Docs** updated to match, plus two new ground rules: sub-issues are linked rather than mentioned, and a parent closes by hand when its children are done.

## Already applied by hand

#32–#35 are retro-linked to #10 — it now reads **0 of 4 complete**. This PR is so future elaborations do it themselves.

## After merging

Re-run *Elaborator — one-time setup* to push the updated persona (bumps the agent to v4).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_