### PR TITLE
Restore agent-team ground rules lost in a merge race

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -42,7 +42,9 @@ on the cheaper thinking roles.
 1. You add the `elaborate` label to a backlog issue.
 2. **Elaborator** audits the codebase, then splits the remaining work into
    sub-issues with checkable acceptance criteria, labelled `role:developer` or
-   `role:architect`. The parent issue stays open as the umbrella.
+   `role:architect`, and links each as a **native GitHub sub-issue** of the
+   parent so the parent shows a real "N of M complete" progress bar. The
+   parent stays open as the umbrella and loses its `role:*` label.
 3. *(Future)* **Architect** reviews anything labelled `role:architect` and
    posts the technical approach.
 4. You assign a sub-issue to **Copilot** — it writes the code and opens a PR.
@@ -64,6 +66,11 @@ integration code between them, and neither engine calls the other.
 - **Epics are not implementation tasks.** Once elaborated, a parent issue
   should not carry a `role:*` label — the sub-issues do. Assigning an epic to
   Copilot produces sprawling, unreviewable PRs.
+- **Sub-issues are linked, not just mentioned.** Use GitHub's native sub-issue
+  relationship, not a "Part of #N" line alone — otherwise the parent has no
+  progress bar and the backlog flattens out as it grows.
+- **A parent closes when its sub-issues are done**, by hand. Nothing closes
+  issues automatically, and no workflow moves an epic's board status.
 
 ## Where things are documented
 


### PR DESCRIPTION
PR #37 was branched from `main` before PR #30 landed, so its `docs/agents.md` edits targeted the older version of that file and silently applied to nothing. The functional change in #37 — the Elaborator linking sub-issues natively — reached `main` correctly; only these documentation lines were lost.

## Restores

- The flow step now says the Elaborator **links each sub-issue natively** so the parent shows an "N of M complete" progress bar, and that the parent loses its `role:*` label.
- Two ground rules:
  - Sub-issues are linked, not just mentioned — a "Part of #N" line alone gives no progress bar and flattens the backlog as it grows.
  - A parent closes when its sub-issues are done, by hand. Nothing closes issues automatically, and no workflow moves an epic's board status.

Docs only. Both edits were applied with assertions this time, so a missing anchor fails loudly rather than passing silently — which is what caused the original loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_