### PR TITLE
Stop applying role:developer, and recover two docs fixes that missed the #42 merge

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,7 +12,7 @@ Copilot. You are the gate between them.
 | **Elaborator** | Claude Managed Agents | `elaborate` label | Sub-issues with acceptance criteria + an audit comment |
 | **Architect** | Claude Managed Agents | `architect` label | A technical-approach comment on the issue |
 | **Developer** | GitHub Copilot | `build` label | A branch + pull request |
-| **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments on the PR |
+| **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments on the PR — **advisory, does not block the merge** |
 
 The project-manager role was dropped — with one person and a labelled backlog
 there is nothing for it to sequence.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -46,8 +46,9 @@ on the cheaper thinking roles.
 
 1. You add the `elaborate` label to a backlog issue.
 2. **Elaborator** audits the codebase, then splits the remaining work into
-   sub-issues with checkable acceptance criteria, labelled `role:developer` or
-   `role:architect`, and links each as a **native GitHub sub-issue** of the
+   sub-issues with checkable acceptance criteria, labelling only the ones that
+   need design first (`role:architect`), and links each as a **native GitHub
+   sub-issue** of the
    parent so the parent shows a real "N of M complete" progress bar. The
    parent stays open as the umbrella and loses its `role:*` label.
 3. You add `architect` to anything with a genuine design decision — the

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,7 +12,8 @@ Copilot. You are the gate between them.
 | **Elaborator** | Claude Managed Agents | `elaborate` label | Sub-issues with acceptance criteria + an audit comment |
 | **Architect** | Claude Managed Agents | `architect` label | A technical-approach comment on the issue |
 | **Developer** | GitHub Copilot | `build` label | A branch + pull request |
-| **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments on the PR — **advisory, does not block the merge** |
+| **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments — **advisory, does not block the merge** |
+| *(CI)* | GitHub Actions | Automatic on every PR | Pass/fail — **the actual gate** |
 
 The project-manager role was dropped — with one person and a labelled backlog
 there is nothing for it to sequence.
@@ -49,8 +50,8 @@ on the cheaper thinking roles.
    `role:architect`, and links each as a **native GitHub sub-issue** of the
    parent so the parent shows a real "N of M complete" progress bar. The
    parent stays open as the umbrella and loses its `role:*` label.
-3. *(Future)* **Architect** reviews anything labelled `role:architect` and
-   posts the technical approach.
+3. You add `architect` to anything with a genuine design decision — the
+   **Architect** posts the technical approach as a comment.
 4. You add `build` to a sub-issue — **Copilot** writes the code and opens a PR.
 5. **CI** runs the tests and **Copilot review** checks the diff.
 6. The PR **auto-merges** once CI is green, and **deploys to Azure** on merge.
@@ -60,10 +61,13 @@ integration code between them, and neither engine calls the other.
 
 ## Ground rules
 
-- **One issue per Elaborator run**, triggered deliberately. Nothing runs on a
-  schedule yet.
-- **Agents never merge.** Every code change reaches `main` through a PR you
-  approve.
+- **One issue per agent run**, triggered by a label you add. Nothing runs on a
+  schedule, so no work starts that you did not ask for.
+- **Agent PRs auto-merge on green CI; your own do not.** This was originally
+  "agents never merge" — that changed deliberately when the pipeline went
+  unattended. CI is the gate, and it is the only automatic check that can stop
+  a change: Copilot's review is advisory. To put a human back in the loop,
+  turn on branch protection requiring a review, or disable `auto-merge.yml`.
 - **Claude agents never get Azure credentials.** They read the repo and write
   GitHub issues; deployment stays outside their reach.
 - **Epics are not implementation tasks.** Once elaborated, a parent issue

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -6,23 +6,35 @@ Four labels drive everything. You add a label; agents do the rest.
   backlog issue
        │  add label: elaborate
        ▼
-  ELABORATOR (Claude)  → audits the code, writes sub-issues with
-       │                  acceptance criteria, links them to the parent
+  ELABORATOR (Claude)   → audits the code, writes sub-issues with
+       │                   acceptance criteria, links them to the parent
        │  add label: architect   (only where the design isn't obvious)
        ▼
-  ARCHITECT (Claude)   → posts "Technical approach" as a comment
+  ARCHITECT (Claude)    → posts "Technical approach" as a comment
        │
        │  add label: build
        ▼
-  COPILOT CODING AGENT → branch + pull request
+  DEVELOPER (Copilot)   → branch + pull request
        │
-       ├─ CI runs the API tests and frontend checks
-       ├─ Copilot review requested automatically
-       └─ auto-merge once CI is green
+       ├── TESTER (Copilot review)  → comments on the diff
+       │       ADVISORY ONLY - does not block the merge
+       │
+       ├── CI (ci.yml)              → API tests + frontend checks
+       │       THE ACTUAL GATE - red CI stops the merge
+       │
+       └── auto-merge once CI is green
        │
        ▼
   DEPLOY → Azure (Function App and/or Static Web App, whichever changed)
 ```
+
+> **Which of those two actually stops a bad change?** Only CI. Copilot's review
+> posts comments and the merge proceeds regardless — so on a fast PR the review
+> may land *after* it has merged. Treat it as a record to read, not a gate.
+>
+> To make it a real gate, require an approving review on `main` (Settings →
+> Branches → branch protection). Expect that to stall most PRs waiting on you,
+> since the reviewer usually finds *something* — which is why it is off.
 
 ## The four labels
 
@@ -32,6 +44,9 @@ Four labels drive everything. You add a label; agents do the rest.
 | `architect` | Architect posts a technical approach | ~$0.50 |
 | `build` | Copilot writes the code and opens a PR | ~40–55 Copilot credits |
 | `elaborated` / `architected` | Applied *by* the agents — markers, not triggers | — |
+
+The tester needs no label: Copilot's review is requested automatically on every
+agent-authored PR (`request-review.yml`).
 
 **When to use `architect`:** only where a genuine technical choice exists —
 issues carrying `role:architect` (#12, #15, #16, #21, #5). CRUD-shaped work
@@ -61,7 +76,11 @@ disabled, so it hard-stops rather than billing you.
 - **Copilot's PRs auto-merge** once CI passes (`auto-merge.yml`). Your own PRs
   do not — you merge those.
 - **CI** (`ci.yml`) runs `node api/test-logic.js` plus a frontend parse check
-  on every PR. Red CI blocks the auto-merge; the PR just waits.
+  on every PR. Red CI blocks the auto-merge; the PR just waits. **This is the
+  only automatic check that can stop a change reaching the app.**
+- **Copilot's review** (`request-review.yml`) is advisory. It does not block
+  anything — read it after the fact, or turn on branch protection if you want
+  it to gate.
 - **Deployment** (`deploy.yml`) runs on push to `main` and deploys only what
   changed — API to `herotasks-func-dev`, frontend to `herotasks-swa-dev`.
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -49,8 +49,13 @@ The tester needs no label: Copilot's review is requested automatically on every
 agent-authored PR (`request-review.yml`).
 
 **When to use `architect`:** only where a genuine technical choice exists —
-issues carrying `role:architect` (#12, #15, #16, #21, #5). CRUD-shaped work
-goes straight from `elaborate` to `build`.
+issues carrying `role:architect` (#12, #15, #16, #21, #5, #43). CRUD-shaped
+work goes straight from `elaborate` to `build`.
+
+**`role:developer` is not applied any more.** Every sub-issue is developer work
+by default, so the label carried no information. `role:architect` still does:
+it means design this before building it. Older issues still carry
+`role:developer` — harmless, ignore it.
 
 **Never label an epic `build`.** The workflow refuses and says so, but the
 rule is: build the sub-issues, not the parent.

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -71,9 +71,15 @@ Work in this order:
    with the parent's issue number and the new issue's internal id - the id
    from the create response, not its issue number). This gives the parent a
    real progress bar and hierarchy; a "Part of #N" line in the body alone does
-   not. Reuse the repository's existing labels (role:developer,
-   role:architect) where they fit; if a label does not exist, skip labelling
-   rather than failing.
+   not.
+
+   LABELLING: apply 'role:architect' ONLY to sub-issues that need a design
+   decision made before coding starts - a new data shape, an external service,
+   a security or privacy choice, anything where a developer would otherwise
+   have to guess. Do NOT apply 'role:developer': every sub-issue is developer
+   work by default, so the label carries no information and only adds noise.
+   Leave a sub-issue unlabelled if it just needs building. If a label does not
+   exist in the repository, skip it rather than failing.
 
 5. Comment once on the original issue with: the already-built audit summary,
    links to every sub-issue you created, and the open questions. If an


### PR DESCRIPTION
## `role:developer` is noise now

It was a routing hint from when work was assigned by hand. Now `build` is the trigger and **every sub-issue is developer work by default**, so the label sits next to labels that actually do something and carries no information.

`role:architect` stays — it means *design this before building it*, and it's the signal for which issues need the `architect` label first.

The Elaborator now labels only what needs design, and leaves plain build work unlabelled. Existing issues keep their `role:developer`; harmless, just ignore it.

## Also recovers two commits that missed the #42 merge

`630083a` was merged while two later commits were still on the branch, so these never reached `main`:

- **The tester is named in the pipeline diagram**, and marked `ADVISORY ONLY - does not block the merge`, next to CI marked `THE ACTUAL GATE`. They look alike in a list and behave completely differently.
- **The "agents never merge" ground rule was corrected.** It said *"every code change reaches main through a PR you approve"* — flatly untrue once auto-merge went in. Now states what's actually true, why it changed, and how to reverse it.

That's the second time a merge landed while I was still pushing to the branch. Worth watching for: if you merge quickly after I say "pushed", check the branch has nothing newer before merging.

Docs and one prompt string only — no workflow or code changes, so nothing needs re-running except the Elaborator setup to pick up the new labelling rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_