### PR TITLE
Build queue, Elaborator decides the architect, guards raised for the build-out

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -3,7 +3,8 @@ name: Architect an issue
 # Trigger: add the "architect" label to an issue, or dispatch manually with an
 # issue number. Posts a technical approach as a comment; writes no code.
 #
-# Guard: at most 10 architect runs per rolling 24h.
+# Guard: at most 20 architect runs per rolling 24h. Raised for the initial
+# build-out; drop back to ~10 for ongoing feature work.
 
 on:
   workflow_dispatch:
@@ -29,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Daily run guard (max 10 per rolling 24h)
+      - name: Daily run guard (max 20 per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
@@ -37,8 +38,8 @@ jobs:
           SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/architect.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Architect runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 10 ]; then
-            echo "Daily limit of 10 architect runs reached - skipping."
+          if [ "${COUNT}" -gt 20 ]; then
+            echo "Daily limit of 20 architect runs reached - skipping."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -13,12 +13,17 @@ name: Build queue
 # So 'build' means "queued", and this picks one at a time, in order, skipping
 # anything whose dependencies are still open.
 #
-# Pace: every 6 hours = 4 builds/day = ~200 Copilot credits/day. Change the
-# cron below to go faster or slower.
+# Pace: every 30 minutes, up to 3 builds per run. This is deliberately fast for
+# the initial build-out of the backlog, which Peter is watching. The dependency
+# check below is NOT a pacing device - it prevents Copilot writing against code
+# that does not exist yet - so it stays regardless of speed.
+#
+# To slow down for ongoing feature work later: change the cron to "0 */6 * * *"
+# and MAX_PER_RUN to 1.
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -46,11 +51,15 @@ jobs:
           CANDIDATES=$(gh api "repos/${GITHUB_REPOSITORY}/issues?labels=build&state=open&sort=created&direction=asc&per_page=100" \
             --jq '[.[] | select(has("pull_request") | not) | {number, body: (.body // ""), assignees: [.assignees[].login]}]')
 
+          MAX_PER_RUN=3
+          READY=""
+          PICKED=0
+
           COUNT=$(echo "$CANDIDATES" | jq 'length')
           echo "Issues labelled 'build': ${COUNT}"
           if [ "$COUNT" -eq 0 ]; then
             echo "Queue empty - nothing to do."
-            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "numbers=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -88,18 +97,24 @@ jobs:
             fi
 
             echo "    ready to build"
-            echo "number=${NUM}" >> "$GITHUB_OUTPUT"
-            exit 0
+            READY="${READY} ${NUM}"
+            PICKED=$((PICKED + 1))
+            if [ "$PICKED" -ge "$MAX_PER_RUN" ]; then break; fi
           done
 
-          echo "Nothing ready this round (all queued items are assigned, epics, or blocked)."
-          echo "number=" >> "$GITHUB_OUTPUT"
+          READY=$(echo "$READY" | xargs || true)
+          if [ -z "$READY" ]; then
+            echo "Nothing ready this round (all queued items are assigned, epics, or blocked)."
+          else
+            echo "Building:${READY}"
+          fi
+          echo "numbers=${READY}" >> "$GITHUB_OUTPUT"
 
       - name: Assign the Copilot coding agent
-        if: steps.pick.outputs.number != ''
+        if: steps.pick.outputs.numbers != ''
         env:
           GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
-          NUM: ${{ steps.pick.outputs.number }}
+          NUMBERS: ${{ steps.pick.outputs.numbers }}
         run: |
           set -euo pipefail
           OWNER="${GITHUB_REPOSITORY%/*}"
@@ -120,17 +135,19 @@ jobs:
             exit 1
           fi
 
-          ISSUE_ID=$(gh api graphql -f query='
-            query($owner:String!, $repo:String!, $num:Int!) {
-              repository(owner:$owner, name:$repo) { issue(number:$num) { id } }
-            }' -f owner="$OWNER" -f repo="$REPO" -F num="$NUM" \
-            --jq '.data.repository.issue.id')
+          for NUM in $NUMBERS; do
+            ISSUE_ID=$(gh api graphql -f query='
+              query($owner:String!, $repo:String!, $num:Int!) {
+                repository(owner:$owner, name:$repo) { issue(number:$num) { id } }
+              }' -f owner="$OWNER" -f repo="$REPO" -F num="$NUM" \
+              --jq '.data.repository.issue.id')
 
-          gh api graphql -f query='
-            mutation($assignable:ID!, $actor:ID!) {
-              replaceActorsForAssignable(input:{assignableId:$assignable, actorIds:[$actor]}) {
-                assignable { ... on Issue { number } }
-              }
-            }' -f assignable="$ISSUE_ID" -f actor="$BOT_ID"
+            gh api graphql -f query='
+              mutation($assignable:ID!, $actor:ID!) {
+                replaceActorsForAssignable(input:{assignableId:$assignable, actorIds:[$actor]}) {
+                  assignable { ... on Issue { number } }
+                }
+              }' -f assignable="$ISSUE_ID" -f actor="$BOT_ID"
 
-          echo "Copilot assigned to #${NUM}"
+            echo "Copilot assigned to #${NUM}"
+          done

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -1,0 +1,136 @@
+name: Build queue
+
+# Drains the build queue: every few hours, picks the next issue labelled
+# 'build' that is ready to work on, and hands it to the Copilot coding agent.
+#
+# Why a queue rather than building on the label directly:
+#   - Copilot credits are finite and monthly (~20-28 builds). Labelling four
+#     sub-issues at once would blow through a daily cap, and skipped runs never
+#     retry, so work would silently never get built.
+#   - Sub-issues have dependencies. #34 built before #33 lands means Copilot
+#     writes against an API that does not exist yet and invents one.
+#
+# So 'build' means "queued", and this picks one at a time, in order, skipping
+# anything whose dependencies are still open.
+#
+# Pace: every 6 hours = 4 builds/day = ~200 Copilot credits/day. Change the
+# cron below to go faster or slower.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: copilot-build
+  cancel-in-progress: false
+
+jobs:
+  next:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Pick the next buildable issue
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Open issues labelled 'build', oldest first so sub-issues are built
+          # in the order the Elaborator created them.
+          CANDIDATES=$(gh api "repos/${GITHUB_REPOSITORY}/issues?labels=build&state=open&sort=created&direction=asc&per_page=100" \
+            --jq '[.[] | select(has("pull_request") | not) | {number, body: (.body // ""), assignees: [.assignees[].login]}]')
+
+          COUNT=$(echo "$CANDIDATES" | jq 'length')
+          echo "Issues labelled 'build': ${COUNT}"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Queue empty - nothing to do."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          for NUM in $(echo "$CANDIDATES" | jq -r '.[].number'); do
+            echo "--- considering #${NUM}"
+
+            # Already handed to Copilot? Skip.
+            ASSIGNED=$(echo "$CANDIDATES" | jq -r --argjson n "$NUM" '.[] | select(.number==$n) | .assignees | join(",")')
+            if echo "$ASSIGNED" | grep -qi 'copilot'; then
+              echo "    already assigned to Copilot - skipping"
+              continue
+            fi
+
+            # An epic (has sub-issues) is never built directly.
+            SUBS=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUM}/sub_issues" --jq 'length' 2>/dev/null || echo 0)
+            if [ "$SUBS" -gt 0 ]; then
+              echo "    has ${SUBS} sub-issues (epic) - skipping"
+              continue
+            fi
+
+            # Dependencies: the Elaborator writes "Depends on #N" / "depends on
+            # #32 and #33". If any referenced issue is still open, wait.
+            BODY=$(echo "$CANDIDATES" | jq -r --argjson n "$NUM" '.[] | select(.number==$n) | .body')
+            DEPS=$(echo "$BODY" | grep -ioE 'depends on[^.]*' | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
+            BLOCKED=""
+            for D in $DEPS; do
+              STATE=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${D}" --jq '.state' 2>/dev/null || echo "unknown")
+              if [ "$STATE" = "open" ]; then
+                BLOCKED="${BLOCKED} #${D}"
+              fi
+            done
+            if [ -n "$BLOCKED" ]; then
+              echo "    blocked by open dependency:${BLOCKED} - skipping"
+              continue
+            fi
+
+            echo "    ready to build"
+            echo "number=${NUM}" >> "$GITHUB_OUTPUT"
+            exit 0
+          done
+
+          echo "Nothing ready this round (all queued items are assigned, epics, or blocked)."
+          echo "number=" >> "$GITHUB_OUTPUT"
+
+      - name: Assign the Copilot coding agent
+        if: steps.pick.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
+          NUM: ${{ steps.pick.outputs.number }}
+        run: |
+          set -euo pipefail
+          OWNER="${GITHUB_REPOSITORY%/*}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+
+          BOT_ID=$(gh api graphql -f query='
+            query($owner:String!, $repo:String!) {
+              repository(owner:$owner, name:$repo) {
+                suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100) {
+                  nodes { login __typename ... on Bot { id } ... on User { id } }
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" \
+            --jq '.data.repository.suggestedActors.nodes[] | select(.login=="copilot-swe-agent") | .id')
+
+          if [ -z "$BOT_ID" ]; then
+            echo "::error::Copilot coding agent is not assignable on this repository."
+            exit 1
+          fi
+
+          ISSUE_ID=$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $num:Int!) {
+              repository(owner:$owner, name:$repo) { issue(number:$num) { id } }
+            }' -f owner="$OWNER" -f repo="$REPO" -F num="$NUM" \
+            --jq '.data.repository.issue.id')
+
+          gh api graphql -f query='
+            mutation($assignable:ID!, $actor:ID!) {
+              replaceActorsForAssignable(input:{assignableId:$assignable, actorIds:[$actor]}) {
+                assignable { ... on Issue { number } }
+              }
+            }' -f assignable="$ISSUE_ID" -f actor="$BOT_ID"
+
+          echo "Copilot assigned to #${NUM}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         id: issue
         run: echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
 
-      - name: Daily build guard (max 8 per rolling 24h)
+      - name: Daily build guard (max 30 per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
@@ -43,8 +43,8 @@ jobs:
           SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Build runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 8 ]; then
-            echo "Daily limit of 8 builds reached - skipping to protect Copilot credits."
+          if [ "${COUNT}" -gt 30 ]; then
+            echo "Daily limit of 30 builds reached - skipping to protect Copilot credits."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build an issue with Copilot
 
-# Trigger: add the "build" label to an issue, or dispatch manually with an
-# issue number. Assigns the GitHub Copilot coding agent, which branches,
-# writes the code and opens a pull request.
+# Builds ONE issue immediately, on manual dispatch. Use this to jump the queue.
+#
+# The 'build' label does NOT trigger this - it queues the issue for
+# build-queue.yml, which drains the queue a few at a time in dependency order.
+# See docs/pipeline.md for why.
 #
 # Guards:
 #   - refuses epics (an issue with sub-issues, or carrying 'elaborated')
@@ -12,10 +14,8 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to build"
+        description: "Issue number to build now (jumps the queue)"
         required: true
-  issues:
-    types: [labeled]
 
 permissions:
   actions: read
@@ -28,18 +28,12 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'build'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Resolve issue number
         id: issue
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
 
       - name: Daily build guard (max 8 per rolling 24h)
         id: guard

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -5,8 +5,9 @@ name: Elaborate backlog issue
 #   1. Add the "elaborate" label to an issue.
 #   2. Actions tab -> "Elaborate backlog issue" -> Run workflow -> enter issue number.
 #
-# Guard: refuses to start more than 10 elaborator runs in any rolling 24h window,
-# so with the $2/session budget cap the worst case is ~$20/day.
+# Guard: refuses to start more than 20 elaborator runs in any rolling 24h window,
+# so with the $2/session budget cap the worst case is ~$40/day. Raised for the
+# initial build-out of the backlog; drop back to ~10 for ongoing feature work.
 
 on:
   workflow_dispatch:
@@ -32,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Daily run guard (max 10 per rolling 24h)
+      - name: Daily run guard (max 20 per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
@@ -40,8 +41,8 @@ jobs:
           SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/elaborate.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Elaborator runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 10 ]; then
-            echo "Daily limit of 10 elaborator runs reached - skipping. Try again later or raise the limit in elaborate.yml."
+          if [ "${COUNT}" -gt 20 ]; then
+            echo "Daily limit of 20 elaborator runs reached - skipping. Try again later or raise the limit in elaborate.yml."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,7 +10,7 @@ Copilot. You are the gate between them.
 | Role | Engine | Trigger | Output |
 |---|---|---|---|
 | **Elaborator** | Claude Managed Agents | `elaborate` label | Sub-issues with acceptance criteria + an audit comment |
-| **Architect** | Claude Managed Agents | `architect` label | A technical-approach comment on the issue |
+| **Architect** | Claude Managed Agents | `architect` label — applied by the Elaborator where design is genuinely needed | A technical-approach comment on the issue |
 | **Developer** | GitHub Copilot | `build` label | A branch + pull request |
 | **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments — **advisory, does not block the merge** |
 | *(CI)* | GitHub Actions | Automatic on every PR | Pass/fail — **the actual gate** |

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -52,10 +52,25 @@ agent-authored PR (`request-review.yml`).
 issues carrying `role:architect` (#12, #15, #16, #21, #5, #43). CRUD-shaped
 work goes straight from `elaborate` to `build`.
 
-**`role:developer` is not applied any more.** Every sub-issue is developer work
-by default, so the label carried no information. `role:architect` still does:
-it means design this before building it. Older issues still carry
-`role:developer` — harmless, ignore it.
+### Label kinds
+
+Every label in this repo is one of three things. Keeping the distinction sharp
+matters, because two of them cost money and one does not.
+
+| Kind | Labels | Effect |
+|---|---|---|
+| **Trigger** | `elaborate`, `architect`, `build` | Live wire — adding it starts an agent and spends |
+| **Marker** | `elaborated`, `architected` | Applied *by* an agent; records what has been done |
+| **Flag** | `role:architect` | A note to yourself: this one needs design before building |
+
+`role:developer` and `role:tester` were deleted — every sub-issue is developer
+work by default, and the tester runs automatically on every PR, so neither
+label carried information.
+
+`role:architect` is deliberately a flag rather than a trigger: if the
+Elaborator applied `architect` directly it would fire the agent and spend
+money without you deciding. Filter the backlog by it to see exactly what to
+run the architect over.
 
 **Never label an epic `build`.** The workflow refuses and says so, but the
 rule is: build the sub-issues, not the parent.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -48,9 +48,10 @@ Four labels drive everything. You add a label; agents do the rest.
 The tester needs no label: Copilot's review is requested automatically on every
 agent-authored PR (`request-review.yml`).
 
-**When to use `architect`:** only where a genuine technical choice exists —
-issues carrying `role:architect` (#12, #15, #16, #21, #5, #43). CRUD-shaped
-work goes straight from `elaborate` to `build`.
+**`architect` is applied for you** by the Elaborator where a genuine technical
+choice exists. CRUD-shaped work goes straight from `elaborate` to `build`. You
+can still add it by hand to any issue — the older backlog items that predate
+this (#12, #15, #16, #21, #5, #43) need it applied manually.
 
 ### Label kinds
 
@@ -61,16 +62,32 @@ matters, because two of them cost money and one does not.
 |---|---|---|
 | **Trigger** | `elaborate`, `architect`, `build` | Live wire — adding it starts an agent and spends |
 | **Marker** | `elaborated`, `architected` | Applied *by* an agent; records what has been done |
-| **Flag** | `role:architect` | A note to yourself: this one needs design before building |
 
-`role:developer` and `role:tester` were deleted — every sub-issue is developer
-work by default, and the tester runs automatically on every PR, so neither
-label carried information.
+Every label is live. `role:developer` and `role:tester` were deleted (every
+sub-issue is developer work by default, and the tester runs automatically on
+every PR), and `role:architect` was replaced by the Elaborator applying
+`architect` itself.
 
-`role:architect` is deliberately a flag rather than a trigger: if the
-Elaborator applied `architect` directly it would fire the agent and spend
-money without you deciding. Filter the backlog by it to see exactly what to
-run the architect over.
+### Who applies which trigger
+
+| Trigger | Applied by | Spends |
+|---|---|---|
+| `elaborate` | **You** — deciding an item is worth working on | ~$0.35 |
+| `architect` | **The Elaborator**, on sub-issues it judges need design | ~$0.50 each |
+| `build` | **You** — Copilot credits are finite and monthly | ~40–55 credits |
+
+The Elaborator decides the architect question because it has just read the
+codebase and the issue, so it is better placed than you are to know whether a
+design decision remains. Its criteria are in the `SYSTEM_PROMPT` in
+`ops/elaborator/setup_elaborator.py`: new data shapes others build on,
+external services, security/privacy/auth, ongoing per-use cost, or a real
+choice between approaches the existing code does not already settle. CRUD
+following an existing pattern does not qualify. It must say in its comment
+which sub-issues it flagged and why, so the call is reviewable.
+
+`build` stays yours deliberately: Copilot credits are the scarce resource
+(~20–28 per month), so that is the one place worth a human deciding what is
+worth spending them on.
 
 **Never label an epic `build`.** The workflow refuses and says so, but the
 rule is: build the sub-issues, not the parent.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -96,10 +96,21 @@ way:
 The queue skips anything that is an epic, already assigned to Copilot, or has
 an open issue named in a `Depends on #N` line in its body.
 
-**Pace: 4 builds/day** (~200 credits/day, so about 5 days of runway from a full
-1,500 allowance). Change the `cron` in `build-queue.yml` to go faster or
-slower. To jump the queue for one issue: Actions → *Build an issue with
-Copilot* → Run workflow → issue number.
+**Pace: every 30 minutes, up to 3 at a time.** This is deliberately fast — the
+initial build-out of the backlog is a watched, one-off exercise, not steady
+state. Expect it to consume the Copilot allowance quickly; it hard-stops rather
+than billing.
+
+**The dependency check is not a pacing device** and stays whatever the speed:
+it stops Copilot writing against code that does not exist yet.
+
+**When the backlog is built, slow it down.** In `build-queue.yml` set the cron
+to `0 */6 * * *` and `MAX_PER_RUN=1`, and drop the daily guards in
+`elaborate.yml` / `architect.yml` back to ~10. Ongoing feature work does not
+want a firehose.
+
+To jump the queue for one issue: Actions → *Build an issue with Copilot* → Run
+workflow → issue number.
 
 The Elaborator decides the architect question because it has just read the
 codebase and the issue, so it is better placed than you are to know whether a
@@ -122,9 +133,12 @@ rule is: build the sub-issues, not the parent.
 
 | Guard | Limit | Why |
 |---|---|---|
-| Elaborator runs | 10 / rolling 24h | Anthropic spend |
-| Architect runs | 10 / rolling 24h | Anthropic spend |
-| Copilot builds | 4 / day via the queue, 8 / rolling 24h hard cap | Copilot credits are finite and monthly |
+| Elaborator runs | 20 / rolling 24h | Anthropic spend |
+| Architect runs | 20 / rolling 24h | Anthropic spend |
+| Copilot builds | 3 per 30 min via the queue, 30 / rolling 24h hard cap | Copilot credits are finite and monthly |
+
+> Those numbers are raised for the initial build-out. See *The build queue*
+> below for what to set them back to afterwards.
 | Per session | $2.00 hard cap | A runaway session pauses rather than spends |
 | Epic guard | build refuses issues with sub-issues | Prevents unreviewable PRs |
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -4,15 +4,17 @@ Four labels drive everything. You add a label; agents do the rest.
 
 ```
   backlog issue
-       │  add label: elaborate
+       │  YOU add label: elaborate     <- the only click
        ▼
   ELABORATOR (Claude)   → audits the code, writes sub-issues with
        │                   acceptance criteria, links them to the parent
-       │  add label: architect   (only where the design isn't obvious)
+       │  Elaborator adds 'architect' where design is genuinely needed,
+       │  and 'build' on every sub-issue (which queues, does not start)
        ▼
   ARCHITECT (Claude)    → posts "Technical approach" as a comment
        │
-       │  add label: build
+       │  BUILD QUEUE drains 4/day, oldest first,
+       │  skipping epics and anything with an open dependency
        ▼
   DEVELOPER (Copilot)   → branch + pull request
        │
@@ -74,7 +76,30 @@ every PR), and `role:architect` was replaced by the Elaborator applying
 |---|---|---|
 | `elaborate` | **You** — deciding an item is worth working on | ~$0.35 |
 | `architect` | **The Elaborator**, on sub-issues it judges need design | ~$0.50 each |
-| `build` | **You** — Copilot credits are finite and monthly | ~40–55 credits |
+| `build` | **The Elaborator**, on every sub-issue — but it *queues* rather than builds | ~40–55 credits, when the queue reaches it |
+
+### The build queue
+
+`build` means **queued**, not "build now". A scheduled worker
+(`build-queue.yml`, every 6 hours) picks the next queued issue and hands it to
+Copilot — one at a time, oldest first.
+
+Two reasons it is a queue rather than a direct trigger, both learned the hard
+way:
+
+- **Credits are finite and monthly** (~20–28 builds). Labelling four
+  sub-issues at once would blow through a daily cap, and a skipped workflow run
+  never retries — that work would silently never get built.
+- **Sub-issues have dependencies.** Building #34 before #33 lands means Copilot
+  writes against an API that does not exist yet, and invents one.
+
+The queue skips anything that is an epic, already assigned to Copilot, or has
+an open issue named in a `Depends on #N` line in its body.
+
+**Pace: 4 builds/day** (~200 credits/day, so about 5 days of runway from a full
+1,500 allowance). Change the `cron` in `build-queue.yml` to go faster or
+slower. To jump the queue for one issue: Actions → *Build an issue with
+Copilot* → Run workflow → issue number.
 
 The Elaborator decides the architect question because it has just read the
 codebase and the issue, so it is better placed than you are to know whether a
@@ -85,9 +110,10 @@ choice between approaches the existing code does not already settle. CRUD
 following an existing pattern does not qualify. It must say in its comment
 which sub-issues it flagged and why, so the call is reviewable.
 
-`build` stays yours deliberately: Copilot credits are the scarce resource
-(~20–28 per month), so that is the one place worth a human deciding what is
-worth spending them on.
+Nothing needs a click from you after `elaborate`: the Elaborator queues the
+work and decides what needs design, and the queue paces the spend. Your control
+is the pace (the cron), the daily caps, and removing `build` from anything you
+do not want built.
 
 **Never label an epic `build`.** The workflow refuses and says so, but the
 rule is: build the sub-issues, not the parent.
@@ -98,7 +124,7 @@ rule is: build the sub-issues, not the parent.
 |---|---|---|
 | Elaborator runs | 10 / rolling 24h | Anthropic spend |
 | Architect runs | 10 / rolling 24h | Anthropic spend |
-| Copilot builds | 8 / rolling 24h | Copilot credits are finite and monthly |
+| Copilot builds | 4 / day via the queue, 8 / rolling 24h hard cap | Copilot credits are finite and monthly |
 | Per session | $2.00 hard cap | A runaway session pauses rather than spends |
 | Epic guard | build refuses issues with sub-issues | Prevents unreviewable PRs |
 

--- a/ops/elaborator/agent_config.json
+++ b/ops/elaborator/agent_config.json
@@ -2,5 +2,5 @@
   "environment_id": "env_012jJdg3avDkK87pVMTPbGyg",
   "vault_id": "vlt_011CeH1TXwYCKMLhpne9CUeb",
   "agent_id": "agent_01Nmg8LBYVbwdzveoGWf97Gd",
-  "agent_version": 3
+  "agent_version": 4
 }

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -73,13 +73,35 @@ Work in this order:
    real progress bar and hierarchy; a "Part of #N" line in the body alone does
    not.
 
-   LABELLING: apply 'role:architect' ONLY to sub-issues that need a design
-   decision made before coding starts - a new data shape, an external service,
-   a security or privacy choice, anything where a developer would otherwise
-   have to guess. Do NOT apply 'role:developer': every sub-issue is developer
-   work by default, so the label carries no information and only adds noise.
-   Leave a sub-issue unlabelled if it just needs building. If a label does not
-   exist in the repository, skip it rather than failing.
+   LABELLING: leave a sub-issue unlabelled unless it genuinely needs a design
+   decision before coding. Apply the 'architect' label ONLY in that case - and
+   understand that doing so immediately starts the Architect agent and spends
+   money, so it is a judgement call, not a formality. Most sub-issues do not
+   need it.
+
+   Apply 'architect' when the sub-issue involves any of:
+   - a NEW data shape that later features will build on, where getting it
+     wrong means a migration rather than an edit;
+   - an EXTERNAL service, API or browser capability not already used here
+     (speech recognition, push notifications, an LLM call, email);
+   - a SECURITY, PRIVACY or AUTH decision - who can see or do what, what is
+     stored, what leaves the device;
+   - an ONGOING COST per use, so someone should decide whether it is worth it;
+   - a genuine CHOICE BETWEEN APPROACHES where picking wrong is expensive to
+     undo, and the existing codebase does not already answer it.
+
+   Do NOT apply 'architect' when the sub-issue is:
+   - CRUD following a pattern already in hero.js (addTask, deleteTask,
+     requireParent and friends);
+   - UI following the conventions already in index.html;
+   - adding a field, a filter, a sort or a screen section;
+   - anything where reading the existing code answers "how would we do this
+     here?" - if you could answer it yourself while auditing, so can the
+     developer, and you should simply write it into the acceptance criteria.
+
+   When you do apply it, say in your comment on the parent WHICH sub-issues got
+   it and WHY in one line each, so the decision is reviewable. If a label does
+   not exist in the repository, skip it rather than failing.
 
 5. Comment once on the original issue with: the already-built audit summary,
    links to every sub-issue you created, and the open questions. If an

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -100,8 +100,17 @@ Work in this order:
      developer, and you should simply write it into the acceptance criteria.
 
    When you do apply it, say in your comment on the parent WHICH sub-issues got
-   it and WHY in one line each, so the decision is reviewable. If a label does
-   not exist in the repository, skip it rather than failing.
+   it and WHY in one line each, so the decision is reviewable.
+
+   Also apply the 'build' label to EVERY sub-issue you create. This does not
+   start a build immediately - it queues the sub-issue, and a scheduled worker
+   picks queued items up a few a day, in order, skipping any whose stated
+   dependencies are still open. So write dependencies as "Depends on #N" in
+   the body (that exact wording, with the # number) wherever one sub-issue
+   needs another finished first - the queue reads it, and a sub-issue built
+   out of order gets written against code that does not exist yet.
+
+   If a label does not exist in the repository, skip it rather than failing.
 
 5. Comment once on the original issue with: the already-built audit summary,
    links to every sub-issue you created, and the open questions. If an


### PR DESCRIPTION
Four commits that were pushed to #45's branch after it had already been merged. Fresh PR rather than a branch you've closed.

## 1. The Elaborator decides when the Architect is needed

Replaces the `role:architect` flag with the Elaborator applying the `architect` trigger itself — it has just read the codebase and the issue, so it's better placed than a human skimming titles.

Guarded by explicit criteria, because the failure mode is flagging everything and paying $0.50 for a design write-up on CRUD work:

- **Yes:** a new data shape others build on, an external service, security/privacy/auth, ongoing per-use cost, a real choice the existing code doesn't settle
- **No:** CRUD following `hero.js` patterns, UI following `index.html` conventions, adding a field

It must name which sub-issues it flagged and why, so the judgement is reviewable.

## 2. Builds are queued, not fired on the label

The Elaborator now applies `build` to every sub-issue, but that **queues** rather than starts. `build-queue.yml` drains it on a schedule. Two reasons, both real:

- **Credits are finite.** Labelling four sub-issues at once exceeds any daily cap, and a skipped workflow run *never retries* — that work would silently never build.
- **Dependencies.** #34 built before #33 lands means Copilot writes against an API that doesn't exist and invents one. The queue reads `Depends on #N` from the body and waits.

`build.yml` becomes manual-only, for jumping the queue.

## 3. Guards raised for the initial build-out

| | Was | Now |
|---|---|---|
| Build queue | 6-hourly, 1 at a time | every 30 min, 3 at a time |
| Elaborator / Architect | 10/day | 20/day |
| Build hard cap | 8/day | 30/day |

The dependency check is untouched — that's a correctness guard, not a pacing one. `docs/pipeline.md` documents what to set these back to once the backlog is built.

## 4. Label taxonomy documented

Three triggers, two markers, nothing dead. `role:developer` and `role:tester` are gone.

---

**After merging:** re-run *Elaborator — one-time setup* so the agent picks up the new labelling rules (→ v4).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_