### PR TITLE
Lift the build caps for the initial build-out

### DIFF
--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -20,7 +20,7 @@ name: Build queue
 #   - an issue closed              -> same
 # The hourly schedule is only a safety net for events that get missed.
 #
-# MAX_PER_RUN caps how many start at once. For the initial build-out it is 3;
+# MAX_PER_RUN caps how many start at once. For the initial build-out it is 6;
 # drop it to 1 for ongoing feature work.
 
 on:
@@ -63,7 +63,7 @@ jobs:
           CANDIDATES=$(gh api "repos/${GITHUB_REPOSITORY}/issues?labels=build&state=open&sort=created&direction=asc&per_page=100" \
             --jq '[.[] | select(has("pull_request") | not) | {number, body: (.body // ""), assignees: [.assignees[].login]}]')
 
-          MAX_PER_RUN=3
+          MAX_PER_RUN=6
           READY=""
           PICKED=0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,13 @@ jobs:
         id: issue
         run: echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
 
-      - name: Daily build guard (max 30 per rolling 24h)
+      # No daily cap during the initial build-out: the Copilot credit budget is
+      # the real limit and it fails safe on its own, so a second ceiling
+      # underneath it only stalls the run. Restore a cap here (~8/day) once the
+      # backlog is built and work becomes iterative.
+      - name: Daily build guard (disabled for the build-out)
         id: guard
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/build.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
-          echo "Build runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 30 ]; then
-            echo "Daily limit of 30 builds reached - skipping to protect Copilot credits."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ok=true" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Refuse epics
         if: steps.guard.outputs.ok == 'true'

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -110,9 +110,13 @@ So a chain like #33 → #34 → #35 flows straight through: #33's PR merges, #33
 closes, the queue wakes within seconds and starts #34 and #35 — no waiting for
 a timer.
 
-**Up to 3 start at once** (`MAX_PER_RUN` in the workflow). That is set for the
-initial build-out; drop it to 1 for ongoing feature work, along with the daily
-guards in `elaborate.yml` / `architect.yml` back to ~10.
+**Up to 6 start at once** (`MAX_PER_RUN` in the workflow), with no daily cap.
+Deliberate for the initial build-out: the Copilot credit budget is the real
+limit, it fails safe, and a second ceiling underneath it only stalls the run.
+
+**Afterwards, restore the guards:** `MAX_PER_RUN=1`, the daily guard in
+`build.yml` back to ~8, the guards in `elaborate.yml` / `architect.yml` back to
+~10, and disable the auto-approve workflow.
 
 **The dependency check is not a pacing device** and stays whatever the speed:
 it stops Copilot writing against code that does not exist yet.
@@ -143,7 +147,7 @@ rule is: build the sub-issues, not the parent.
 |---|---|---|
 | Elaborator runs | 20 / rolling 24h | Anthropic spend |
 | Architect runs | 20 / rolling 24h | Anthropic spend |
-| Copilot builds | 3 at a time via the queue, 30 / rolling 24h hard cap | Copilot credits are finite and monthly |
+| Copilot builds | 6 at a time via the queue; **no daily cap during the build-out** | The Copilot credit budget is the real limit and fails safe on its own |
 
 > Those numbers are raised for the initial build-out. See *The build queue*
 > below for what to set them back to afterwards.


### PR DESCRIPTION
The Copilot credit budget is the real spending limit and it fails safe on its own — a daily cap underneath it doesn't protect anything, it just stalls the run halfway through the backlog.

- **`build.yml`**: daily guard removed (was 30/24h)
- **`build-queue.yml`**: `MAX_PER_RUN` 3 → 6

`docs/pipeline.md` records exactly what to restore afterwards: `MAX_PER_RUN=1`, the daily guard back to ~8, the `elaborate`/`architect` guards back to ~10, and the auto-approve workflow disabled.

**Still in place, deliberately:**
- The **$2 per-session cap** on Anthropic agents — that's a runaway guard, not a pacing one
- The **dependency check** in the queue — correctness, not pacing
- The **epic guard** — stops an epic producing an unreviewable PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_