### PR TITLE
Stop the pipeline silently dropping work: deploy sweep + label-as-queue triggers

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -1,19 +1,29 @@
 name: Architect an issue
 
-# Trigger: add the "architect" label to an issue, or dispatch manually with an
-# issue number. Posts a technical approach as a comment; writes no code.
+# The "architect" label IS the queue - same design as elaborate.yml, and for the
+# same reason: the Elaborator can label several sub-issues in one pass, and
+# GitHub's concurrency queue only holds one pending run, so reacting to the
+# label event directly would silently drop all but the last.
 #
-# Guard: at most 20 architect runs per rolling 24h. Raised for the initial
-# build-out; drop back to ~10 for ongoing feature work.
+# Drains one issue at a time, oldest first, posting a technical approach as a
+# comment. Writes no code. On success it swaps 'architect' for 'architected'.
+#
+# Wakes on: a label being added, every 5 minutes, and manual dispatch. Dispatch
+# with an issue number to jump the queue; leave it blank to just drain.
+#
+# Guard: at most 20 runs per rolling 24h. Raised for the initial build-out; drop
+# back to ~10 for ongoing feature work.
 
 on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to design"
-        required: true
+        description: "Issue number to jump the queue with (blank = drain the queue)"
+        required: false
   issues:
     types: [labeled]
+  schedule:
+    - cron: "*/5 * * * *"
 
 permissions:
   actions: read
@@ -26,7 +36,10 @@ concurrency:
 
 jobs:
   architect:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'architect'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule'
+      || github.event.label.name == 'architect'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -39,37 +52,88 @@ jobs:
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/architect.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Architect runs in last 24h (including this one): ${COUNT}"
           if [ "${COUNT}" -gt 20 ]; then
-            echo "Daily limit of 20 architect runs reached - skipping."
+            echo "::notice::Daily limit of 20 architect runs reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve issue number
+      - name: Take the next issue off the queue
         if: steps.guard.outputs.ok == 'true'
         id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          set -uo pipefail
+
+          MANUAL="${{ github.event.inputs.issue_number }}"
+          if [ -n "$MANUAL" ]; then
+            echo "Jumping the queue with #${MANUAL}."
+            echo "number=${MANUAL}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          QUEUE=$(gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=architect&sort=created&direction=asc&per_page=100" \
+            --jq '[.[] | select(.pull_request == null) | {number, title}]' 2>/dev/null || echo '[]')
+
+          DEPTH=$(echo "$QUEUE" | jq 'length')
+          if [ "$DEPTH" -eq 0 ]; then
+            echo "Queue empty - nothing labelled 'architect'."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Queue depth ${DEPTH}:"
+          echo "$QUEUE" | jq -r '.[] | "  #\(.number)  \(.title)"'
+
+          NEXT=$(echo "$QUEUE" | jq -r '.[0].number')
+          echo "Taking #${NEXT}."
+          echo "number=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "remaining=$((DEPTH - 1))" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
 
       - uses: actions/setup-python@v5
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         with:
           python-version: "3.12"
 
       - name: Install Anthropic SDK
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         run: pip install anthropic
 
       - name: Run the Architect
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.HEROTASK_ANTHROPIC_KEY }}
           HEROTASK_GITHUB_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
         run: python ops/architect/run_architect.py "${{ steps.issue.outputs.number }}"
+
+      - name: Take it off the queue
+        if: success() && steps.issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUM: ${{ steps.issue.outputs.number }}
+        run: |
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${NUM}/labels/architect" >/dev/null 2>&1 \
+            && echo "Removed 'architect' from #${NUM}." \
+            || echo "::warning::Could not remove 'architect' from #${NUM} - it will be picked up again."
+
+          # 'architected' is optional - if the label does not exist, skip it.
+          if gh api "repos/${GITHUB_REPOSITORY}/labels/architected" >/dev/null 2>&1; then
+            gh issue edit "$NUM" --repo "$GITHUB_REPOSITORY" --add-label architected >/dev/null 2>&1 \
+              && echo "Marked #${NUM} architected."
+          fi
+
+      - name: Wake the next one straight away
+        # Optional speed-up; needs HEROTASK_GITHUB_TOKEN to carry Actions: Read
+        # and write. Failure here is fine - the 5-minute sweep is the backstop.
+        if: success() && steps.issue.outputs.remaining != '' && steps.issue.outputs.remaining != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
+        run: |
+          gh workflow run architect.yml --repo "$GITHUB_REPOSITORY" --ref main \
+            && echo "Dispatched the next drain (${{ steps.issue.outputs.remaining }} left)." \
+            || echo "::notice::Could not self-dispatch; the 5-minute sweep will take the next one."

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -18,7 +18,12 @@ name: Build queue
 #   - a 'build' label added        -> that issue may be ready right now
 #   - a pull request closed/merged -> whatever depended on it may be unblocked
 #   - an issue closed              -> same
-# The hourly schedule is only a safety net for events that get missed.
+#
+# The schedule is NOT just a safety net. When auto-merge.yml merges a PR it acts
+# as github-actions[bot] via GITHUB_TOKEN, and GitHub raises no workflow events
+# for that token - so an auto-merged PR fires no 'pull_request: closed' here at
+# all. On an unattended pipeline the sweep is what actually advances the queue,
+# which is why it is every 10 minutes rather than hourly.
 #
 # MAX_PER_RUN caps how many start at once. For the initial build-out it is 6;
 # drop it to 1 for ongoing feature work.
@@ -29,7 +34,7 @@ on:
   pull_request:
     types: [closed]
   schedule:
-    - cron: "0 * * * *"
+    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,9 +76,14 @@ jobs:
               BASE=$(git rev-parse HEAD^)
             fi
           elif [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "::notice::No 'deployed' tag yet - nothing to sweep. The next push or manual run creates it."
-            echo "api=false" >> "$GITHUB_OUTPUT"
-            echo "frontend=false" >> "$GITHUB_OUTPUT"
+            # First sweep after this workflow lands: there is no tag yet, so
+            # there is no way to know what is live. Deploy both and create the
+            # tag - a full deploy is idempotent and takes ~80s, and skipping
+            # here would leave the tag uncreated indefinitely, which is exactly
+            # the hole this workflow exists to close.
+            echo "::notice::No 'deployed' tag yet - deploying both once to establish it."
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
             exit 0
           else
             BASE=$(git rev-parse HEAD^)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,23 @@
 name: Deploy to Azure
 
-# Deploys whichever part of the app changed, on every push to main. Replaces
-# the manual Cloud Shell steps in docs/deploy-app.md (those still work as a
-# fallback).
+# Deploys whichever part of the app changed. Replaces the manual Cloud Shell
+# steps in docs/deploy-app.md (those still work as a fallback).
+#
+# Why this also runs on a schedule:
+#   When auto-merge.yml merges a Copilot pull request it acts as
+#   github-actions[bot], using the built-in GITHUB_TOKEN. GitHub deliberately
+#   does NOT raise workflow events for anything that token does - otherwise a
+#   workflow could trigger itself forever. So an auto-merged pull request lands
+#   on main and no 'push' run ever fires, and the change sits undeployed.
+#   (That is exactly what happened to the Rewards UI in #48/#49.)
+#
+#   Rather than hand a write-scoped personal token to the merge job, this
+#   workflow keeps its own record of what is live - the 'deployed' tag - and
+#   sweeps every 5 minutes for anything on main that is newer than it.
+#
+# The 'deployed' tag is the source of truth for what is on Azure, so a run
+# deploys everything changed since the last SUCCESSFUL deploy. A failed deploy
+# leaves the tag where it is and the next run retries it.
 #
 # Required repository secrets:
 #   AZURE_STATIC_WEB_APPS_API_TOKEN  - Static Web App deployment token
@@ -18,10 +33,12 @@ name: Deploy to Azure
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: deploy-main
@@ -36,18 +53,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
-      - name: Detect what changed
+          ref: main
+          fetch-depth: 0
+      - name: Detect what changed since the last successful deploy
         id: filter
         run: |
+          set -uo pipefail
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "api=true" >> "$GITHUB_OUTPUT"
             echo "frontend=true" >> "$GITHUB_OUTPUT"
             echo "Manual run - deploying both."
             exit 0
           fi
-          CHANGED=$(git diff --name-only HEAD^ HEAD || echo "")
-          echo "Changed files:"; echo "$CHANGED"
+
+          # Compare against the 'deployed' tag: what is actually live. Falls
+          # back to the previous commit only until the tag first exists.
+          if git rev-parse -q --verify refs/tags/deployed >/dev/null; then
+            BASE=$(git rev-parse refs/tags/deployed^{commit})
+            if ! git merge-base --is-ancestor "$BASE" HEAD; then
+              echo "::warning::'deployed' tag is not an ancestor of main - falling back to HEAD^."
+              BASE=$(git rev-parse HEAD^)
+            fi
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "::notice::No 'deployed' tag yet - nothing to sweep. The next push or manual run creates it."
+            echo "api=false" >> "$GITHUB_OUTPUT"
+            echo "frontend=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            BASE=$(git rev-parse HEAD^)
+          fi
+
+          echo "Deployed: $BASE"
+          echo "main:     $(git rev-parse HEAD)"
+
+          CHANGED=$(git diff --name-only "$BASE" HEAD || echo "")
+          if [ -z "$CHANGED" ]; then
+            echo "Nothing changed since the last deploy."
+          else
+            echo "Changed files:"; echo "$CHANGED"
+          fi
           echo "api=$(echo "$CHANGED" | grep -q '^api/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "frontend=$(echo "$CHANGED" | grep -q '^frontend/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
@@ -114,3 +159,23 @@ jobs:
           app_location: frontend
           skip_app_build: true
           skip_api_build: true
+
+  record:
+    # Moves the 'deployed' tag to what was just shipped, so the next run knows
+    # where to start. Only runs when nothing failed - a failed deploy leaves
+    # the tag behind and gets retried on the next sweep.
+    needs: [changes, deploy-api, deploy-frontend]
+    if: >-
+      always() && needs.changes.result == 'success'
+      && (needs.changes.outputs.api == 'true' || needs.changes.outputs.frontend == 'true')
+      && needs.deploy-api.result != 'failure' && needs.deploy-frontend.result != 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Mark this commit as deployed
+        run: |
+          git tag -f deployed
+          git push -f origin refs/tags/deployed
+          echo "deployed -> $(git rev-parse HEAD)"

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -1,22 +1,36 @@
 name: Elaborate backlog issue
 
-# Two ways to trigger, both deliberate (one issue per run, per Peter's
-# confirmation-per-item rule):
-#   1. Add the "elaborate" label to an issue.
-#   2. Actions tab -> "Elaborate backlog issue" -> Run workflow -> enter issue number.
+# The "elaborate" label IS the queue. Label as many issues as you like, whenever
+# you like; this drains them one at a time, oldest first, and removes the label
+# from each one it finishes.
 #
-# Guard: refuses to start more than 20 elaborator runs in any rolling 24h window,
-# so with the $2/session budget cap the worst case is ~$40/day. Raised for the
-# initial build-out of the backlog; drop back to ~10 for ongoing feature work.
+# Why a queue rather than "run the issue that was just labelled":
+#   GitHub's concurrency queue holds exactly ONE pending run. Label three issues
+#   in quick succession and the middle run is CANCELLED, silently - runs #4, #5
+#   and #6 of this workflow were lost exactly that way. A guarded run is lost the
+#   same way: #11 was labelled, hit the old 4-per-day cap, and nothing ever
+#   picked it up again.
+#   Reading the queue from the labels instead means a cancelled or guarded run
+#   costs nothing - the work is still sitting there labelled, and the next wake
+#   finds it.
+#
+# Wakes on: a label being added, every 5 minutes, and manual dispatch. Dispatch
+# with an issue number to jump the queue; leave it blank to just drain.
+#
+# Guard: at most 20 runs per rolling 24h, so with the $2/session cap the worst
+# case is ~$40/day. Raised for the initial build-out; drop back to ~10 for
+# ongoing feature work.
 
 on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to elaborate"
-        required: true
+        description: "Issue number to jump the queue with (blank = drain the queue)"
+        required: false
   issues:
     types: [labeled]
+  schedule:
+    - cron: "*/5 * * * *"
 
 permissions:
   actions: read
@@ -29,7 +43,10 @@ concurrency:
 
 jobs:
   elaborate:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'elaborate'
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule'
+      || github.event.label.name == 'elaborate'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -42,37 +59,84 @@ jobs:
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/elaborate.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Elaborator runs in last 24h (including this one): ${COUNT}"
           if [ "${COUNT}" -gt 20 ]; then
-            echo "Daily limit of 20 elaborator runs reached - skipping. Try again later or raise the limit in elaborate.yml."
+            echo "::notice::Daily limit of 20 elaborator runs reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve issue number
+      - name: Take the next issue off the queue
         if: steps.guard.outputs.ok == 'true'
         id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          set -uo pipefail
+
+          MANUAL="${{ github.event.inputs.issue_number }}"
+          if [ -n "$MANUAL" ]; then
+            echo "Jumping the queue with #${MANUAL}."
+            echo "number=${MANUAL}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          QUEUE=$(gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=elaborate&sort=created&direction=asc&per_page=100" \
+            --jq '[.[] | select(.pull_request == null) | {number, title}]' 2>/dev/null || echo '[]')
+
+          DEPTH=$(echo "$QUEUE" | jq 'length')
+          if [ "$DEPTH" -eq 0 ]; then
+            echo "Queue empty - nothing labelled 'elaborate'."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Queue depth ${DEPTH}:"
+          echo "$QUEUE" | jq -r '.[] | "  #\(.number)  \(.title)"'
+
+          NEXT=$(echo "$QUEUE" | jq -r '.[0].number')
+          echo "Taking #${NEXT}."
+          echo "number=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "remaining=$((DEPTH - 1))" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
 
       - uses: actions/setup-python@v5
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         with:
           python-version: "3.12"
 
       - name: Install Anthropic SDK
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         run: pip install anthropic
 
       - name: Run the Elaborator
-        if: steps.guard.outputs.ok == 'true'
+        if: steps.issue.outputs.number != ''
         env:
           ANTHROPIC_API_KEY: ${{ secrets.HEROTASK_ANTHROPIC_KEY }}
           HEROTASK_GITHUB_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
         run: python ops/elaborator/run_elaborator.py "${{ steps.issue.outputs.number }}"
+
+      - name: Take it off the queue
+        if: success() && steps.issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${{ steps.issue.outputs.number }}/labels/elaborate" \
+            >/dev/null 2>&1 \
+            && echo "Removed 'elaborate' from #${{ steps.issue.outputs.number }}." \
+            || echo "::warning::Could not remove 'elaborate' from #${{ steps.issue.outputs.number }} - it will be picked up again."
+
+      - name: Wake the next one straight away
+        # Optional speed-up: without it the next item waits for the 5-minute
+        # sweep. Needs HEROTASK_GITHUB_TOKEN to carry Actions: Read and write -
+        # the built-in token cannot dispatch a workflow. Failure here is fine.
+        if: success() && steps.issue.outputs.remaining != '' && steps.issue.outputs.remaining != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
+        run: |
+          gh workflow run elaborate.yml --repo "$GITHUB_REPOSITORY" --ref main \
+            && echo "Dispatched the next drain (${{ steps.issue.outputs.remaining }} left)." \
+            || echo "::notice::Could not self-dispatch; the 5-minute sweep will take the next one."

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -176,8 +176,38 @@ disabled, so it hard-stops rather than billing you.
 - **Copilot's review** (`request-review.yml`) is advisory. It does not block
   anything — read it after the fact, or turn on branch protection if you want
   it to gate.
-- **Deployment** (`deploy.yml`) runs on push to `main` and deploys only what
-  changed — API to `herotasks-func-dev`, frontend to `herotasks-swa-dev`.
+- **Deployment** (`deploy.yml`) deploys only what changed — API to
+  `herotasks-func-dev`, frontend to `herotasks-swa-dev`. It runs on push to
+  `main`, **and sweeps every 5 minutes** for anything merged that the push
+  event missed. See below for why that sweep is not optional.
+
+### Why deployment needs a sweep as well as a push trigger
+
+When `auto-merge.yml` merges a Copilot PR it acts as `github-actions[bot]`,
+using the built-in `GITHUB_TOKEN`. GitHub deliberately raises **no workflow
+events** for anything that token does — otherwise a workflow could trigger
+itself in a loop. So an auto-merged PR lands on `main` and **no deploy run
+fires at all**.
+
+This bit us for real: #48 and #49 (the Rewards UI) merged cleanly, sat on
+`main`, and never reached Azure. The dashboard looked correct on GitHub and the
+live app had no Rewards section.
+
+So `deploy.yml` keeps its own record of what is live — a git tag called
+**`deployed`** — and each run deploys everything changed *since that tag*,
+moving it forward only after a successful deploy. That means:
+
+- a failed deploy leaves the tag behind and the next sweep retries it;
+- a merge that fired no push event is picked up within 5 minutes;
+- the diff is against what is actually on Azure, not against `HEAD^`, so
+  nothing gets skipped when several commits land together.
+
+Worst-case lag between an auto-merge and the live app is about 10 minutes
+(5 for the merge poll, 5 for the deploy sweep). If you ever want it instant,
+give `HEROTASK_GITHUB_TOKEN` **Contents: Read and write** and **Pull requests:
+Read and write** and use it in `auto-merge.yml` — merges by a real token do
+raise events. The sweep exists so that is a nice-to-have rather than a
+requirement.
 
 ### Deployment secrets (add these once)
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -78,11 +78,32 @@ every PR), and `role:architect` was replaced by the Elaborator applying
 | `architect` | **The Elaborator**, on sub-issues it judges need design | ~$0.50 each |
 | `build` | **The Elaborator**, on every sub-issue — but it *queues* rather than builds | ~40–55 credits, when the queue reaches it |
 
+**All three are queues.** Adding any of them means *queued*, not *now*. Label
+the whole backlog `elaborate` in one go and walk away — they drain one at a
+time, oldest first, and the label is removed as each is finished. So the labels
+on the board are always the work still outstanding.
+
+### Why every trigger has to be a queue
+
+Two GitHub behaviours quietly destroy work, and both bit this repo:
+
+- **The concurrency queue holds exactly one pending run.** Label three issues in
+  quick succession and the middle run is **cancelled**, with no error anywhere.
+  Runs #4, #5 and #6 of `elaborate.yml` were lost exactly that way.
+- **A skipped or guarded run never retries.** #11 was labelled `elaborate`, hit
+  the old 4-per-day cap, and simply never ran again — the label sat there
+  looking queued while nothing was going to happen.
+
+Reading the queue from the labels rather than from the event fixes both: a
+cancelled or guarded run costs nothing, because the work is still sitting there
+labelled and the next wake finds it. The event is just a hint to look; the
+labels are the truth.
+
 ### The build queue
 
-`build` means **queued**, not "build now". A scheduled worker
-(`build-queue.yml`, every 6 hours) picks the next queued issue and hands it to
-Copilot — one at a time, oldest first.
+`build` means **queued**, not "build now". `build-queue.yml` picks the next
+queued issues and hands them to Copilot, oldest first, sweeping every 10
+minutes and on any event that could change what is buildable.
 
 Two reasons it is a queue rather than a direct trigger, both learned the hard
 way:
@@ -104,11 +125,17 @@ have changed what is buildable:
 | A `build` label is added | That issue may be ready to start immediately |
 | A pull request is merged or closed | Whatever depended on it may now be unblocked |
 | An issue is closed | Same |
-| Hourly schedule | Safety net only, for events that get missed |
+| 10-minute sweep | **Load-bearing, not a safety net** — see below |
 
-So a chain like #33 → #34 → #35 flows straight through: #33's PR merges, #33
-closes, the queue wakes within seconds and starts #34 and #35 — no waiting for
-a timer.
+The sweep is not optional. When `auto-merge.yml` merges a PR it acts as
+`github-actions[bot]` via `GITHUB_TOKEN`, and GitHub raises **no workflow
+events** for that token — so an auto-merged PR fires no `pull_request: closed`
+here at all. On an unattended pipeline the sweep is what actually advances the
+queue.
+
+So a chain like #33 → #34 → #35 flows straight through, but on the sweep's
+cadence: #33's PR auto-merges, #33 closes, and #34 and #35 start within about
+10 minutes.
 
 **Up to 6 start at once** (`MAX_PER_RUN` in the workflow), with no daily cap.
 Deliberate for the initial build-out: the Copilot credit budget is the real


### PR DESCRIPTION
Two separate bugs, same root cause: **the pipeline was relying on events and runs that GitHub never guarantees.** Both had already destroyed work.

## 1. Auto-merged PRs never deployed

The Rewards section was missing from the live app even though #48 and #49 had merged. The code was on `main` the whole time — it just never reached Azure.

When `auto-merge.yml` merges a Copilot PR it acts as `github-actions[bot]` using the built-in `GITHUB_TOKEN`. **GitHub deliberately raises no workflow events for anything that token does** (otherwise a workflow could trigger itself in a loop). So the merge lands on `main` and no `push` run fires.

Evidence: no deploy run exists with `head_sha` `a2ad281` (#48) or `0f8a6f6` (#49). Runs #7–#10 all completed in 7–9 seconds — the `changes` job finding nothing, because a merge commit's `HEAD^` is the previous `main` tip and hides everything that landed underneath.

Ironically, auto-merge working properly for the first time is what broke the deploy.

**Fix:** `deploy.yml` keeps its own record of what is live — a git tag called `deployed` — and diffs against that instead of `HEAD^`:

- sweeps every 5 minutes as well as running on push, so a merge that fired no event is caught within 5 minutes
- diffs `deployed..HEAD`, so several commits landing together can't hide each other
- moves the tag only after a successful deploy, so failures retry instead of being skipped silently
- falls back to `HEAD^` until the tag first exists

## 2. Labelling several issues at once lost most of them

Two GitHub behaviours, both already fired here:

- **The concurrency queue holds exactly one pending run.** Label three issues in quick succession and the middle run is *cancelled*, with no error anywhere. Runs #4, #5 and #6 of `elaborate.yml` were lost exactly that way.
- **A skipped or guarded run never retries.** #11 was labelled `elaborate`, hit the old 4-per-day cap, and never ran again — the label sat there looking queued while nothing was going to happen. (It's still sitting there now.)

That matters a lot right now, because the plan is to label the remaining backlog in one go and walk away — which under the old design would have silently dropped most of it.

**Fix:** `elaborate.yml` and `architect.yml` now read their queue from the **labels** instead of the triggering event — take the oldest labelled issue, run it, remove the label. A cancelled or guarded run then costs nothing, because the work is still sitting there labelled and the next wake finds it. Both sweep every 5 minutes and self-dispatch the next item when more remain. Dispatching with an issue number still jumps the queue.

Side effect worth having: the labels on the board are now always exactly the work still outstanding.

## 3. Build queue cadence

`build-queue.yml` already read its queue from labels, so it was never at risk — but its hourly schedule was documented as "a safety net for events that get missed". It isn't: an auto-merged PR raises no `pull_request: closed` event either, so on an unattended pipeline **the sweep is the only thing that advances the queue**. Moved to every 10 minutes and documented as load-bearing.

## Already done outside this PR

Dispatched a deploy manually (run #11, 80s, both jobs green) — Rewards is confirmed live. This PR stops it recurring.

## Testing

All workflow files validated with `yaml.safe_load`. The behaviour is only observable once merged: the first deploy sweep should create the `deployed` tag and then go quiet, and the first elaborate sweep should pick up #11, which has been stranded since 04:18.