### PR TITLE
Make CI check that every workflow file parses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,22 @@ jobs:
 
       - name: Check the frontend still parses
         run: node scripts/check-frontend.js
+
+      - name: Check every workflow file parses
+        # The pipeline is unattended, so a malformed workflow would merge and
+        # quietly stop something running. Two have been broken by hand already:
+        # an inline `node -e` containing a colon, and a `---` at column 0 inside
+        # a run block starting a second YAML document.
+        run: |
+          python3 - <<'EOF'
+          import glob, sys, yaml
+          bad = []
+          for f in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  yaml.safe_load(open(f))
+                  print(f"ok     {f}")
+              except yaml.YAMLError as e:
+                  bad.append(f)
+                  print(f"BROKEN {f}\n{e}")
+          sys.exit(1 if bad else 0)
+          EOF


### PR DESCRIPTION
CI now fails if any file in `.github/workflows/` doesn't parse as YAML.

The pipeline runs unattended, so a malformed workflow would merge and quietly stop something running, with no error anywhere obvious — the run just never appears. Two have been broken by hand already during this build-out: an inline `node -e` containing a colon, and a `---` at column 0 inside a `run:` block, which starts a second YAML document.

Uses PyYAML, which is preinstalled on `ubuntu-latest`. All eleven current workflow files pass.

## Testing

Ran the same check locally against all eleven workflow files — all parse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_