### PR TITLE
Merge with a real token and delete every polling sweep

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -8,7 +8,7 @@ name: Architect an issue
 # Drains one issue at a time, oldest first, posting a technical approach as a
 # comment. Writes no code. On success it swaps 'architect' for 'architected'.
 #
-# Wakes on: a label being added, every 30 minutes, and manual dispatch. Dispatch
+# Wakes on: a label being added, and manual dispatch. Dispatch
 # with an issue number to jump the queue; leave it blank to just drain.
 #
 # What bounds the spend:
@@ -20,12 +20,11 @@ name: Architect an issue
 #      loop is a failed label removal, and that closes it.
 #   4. A runaway ceiling of 80 runs per rolling 24h, below.
 #
-# The ceiling counts RUNS, and a sweep is a run. At */5 that is 288 a day, so a
-# ceiling of 20 was crossed within two hours - after which nothing would ever
-# run again, the exact silent stall this workflow exists to prevent. Hence a
-# 30-minute sweep (48/day, well under 80). The sweep is only a backstop anyway:
-# adding the label fires this immediately, and each finished run dispatches the
-# next itself.
+# The ceiling counts RUNS, so keep it well clear of however often this fires.
+# A ceiling of 20 against a 5-minute sweep was crossed within two hours and then
+# held forever, after which nothing would ever run again - a guard that becomes
+# the outage. There is no sweep now: the label event starts this, and each
+# finished run dispatches the next itself.
 
 on:
   workflow_dispatch:
@@ -35,8 +34,6 @@ on:
         required: false
   issues:
     types: [labeled]
-  schedule:
-    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -51,7 +48,6 @@ jobs:
   architect:
     if: >-
       github.event_name == 'workflow_dispatch'
-      || github.event_name == 'schedule'
       || github.event.label.name == 'architect'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -8,11 +8,24 @@ name: Architect an issue
 # Drains one issue at a time, oldest first, posting a technical approach as a
 # comment. Writes no code. On success it swaps 'architect' for 'architected'.
 #
-# Wakes on: a label being added, every 5 minutes, and manual dispatch. Dispatch
+# Wakes on: a label being added, every 30 minutes, and manual dispatch. Dispatch
 # with an issue number to jump the queue; leave it blank to just drain.
 #
-# Guard: at most 20 runs per rolling 24h. Raised for the initial build-out; drop
-# back to ~10 for ongoing feature work.
+# What bounds the spend:
+#   1. The queue itself. Only labelled issues run, each runs once, and the
+#      label comes off afterwards - so the ceiling is (issues labelled) x
+#      ~$0.50.
+#   2. A $2 hard cap per session, set in the runner.
+#   3. Skipping anything already marked 'architected' - the one way this could
+#      loop is a failed label removal, and that closes it.
+#   4. A runaway ceiling of 80 runs per rolling 24h, below.
+#
+# The ceiling counts RUNS, and a sweep is a run. At */5 that is 288 a day, so a
+# ceiling of 20 was crossed within two hours - after which nothing would ever
+# run again, the exact silent stall this workflow exists to prevent. Hence a
+# 30-minute sweep (48/day, well under 80). The sweep is only a backstop anyway:
+# adding the label fires this immediately, and each finished run dispatches the
+# next itself.
 
 on:
   workflow_dispatch:
@@ -23,7 +36,7 @@ on:
   issues:
     types: [labeled]
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -43,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Daily run guard (max 20 per rolling 24h)
+      - name: Runaway guard (max 80 runs per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
@@ -51,8 +64,8 @@ jobs:
           SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/architect.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Architect runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 20 ]; then
-            echo "::notice::Daily limit of 20 architect runs reached. Labelled issues stay queued and resume once the window clears."
+          if [ "${COUNT}" -gt 80 ]; then
+            echo "::notice::Runaway ceiling of 80 architect runs reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -87,6 +100,17 @@ jobs:
           echo "$QUEUE" | jq -r '.[] | "  #\(.number)  \(.title)"'
 
           NEXT=$(echo "$QUEUE" | jq -r '.[0].number')
+
+          # Already done? Then 'architect' was left behind by a failed label
+          # removal. Clear it rather than paying to redo the work - this is the
+          # only way the queue could loop.
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${NEXT}/labels" --jq '.[].name' 2>/dev/null | grep -qx 'architected'; then
+            echo "#${NEXT} is already architected - clearing the stale label instead of rerunning."
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${NEXT}/labels/architect" >/dev/null 2>&1 || true
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Taking #${NEXT}."
           echo "number=${NEXT}" >> "$GITHUB_OUTPUT"
           echo "remaining=$((DEPTH - 1))" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -44,7 +44,14 @@ jobs:
     steps:
       - name: Ready and auto-merge finished Copilot pull requests
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Deliberately the personal token, not the built-in GITHUB_TOKEN.
+          # GitHub raises no workflow events for anything GITHUB_TOKEN does, so
+          # a merge made with it fires no 'push' (deploy never runs), no
+          # 'pull_request: closed' and no issue auto-close (the build queue
+          # never wakes). That is what left the Rewards UI merged but
+          # undeployed. A merge made with a real token raises events normally,
+          # which is what lets every polling sweep in this pipeline be deleted.
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
         run: |
           set -uo pipefail
 

--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -19,11 +19,11 @@ name: Build queue
 #   - a pull request closed/merged -> whatever depended on it may be unblocked
 #   - an issue closed              -> same
 #
-# The schedule is NOT just a safety net. When auto-merge.yml merges a PR it acts
-# as github-actions[bot] via GITHUB_TOKEN, and GitHub raises no workflow events
-# for that token - so an auto-merged PR fires no 'pull_request: closed' here at
-# all. On an unattended pipeline the sweep is what actually advances the queue,
-# which is why it is every 10 minutes rather than hourly.
+# There is no schedule. There used to be, because auto-merge.yml merged via the
+# built-in GITHUB_TOKEN and GitHub raises no workflow events for that token - an
+# auto-merged PR fired no 'pull_request: closed' here, so only a clock could
+# advance the queue. The merge job now uses a real token, the events fire, and
+# the queue moves the moment something unblocks.
 #
 # MAX_PER_RUN caps how many start at once. For the initial build-out it is 6;
 # drop it to 1 for ongoing feature work.
@@ -33,8 +33,6 @@ on:
     types: [labeled, closed]
   pull_request:
     types: [closed]
-  schedule:
-    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,21 +3,16 @@ name: Deploy to Azure
 # Deploys whichever part of the app changed. Replaces the manual Cloud Shell
 # steps in docs/deploy-app.md (those still work as a fallback).
 #
-# Why this also runs on a schedule:
-#   When auto-merge.yml merges a Copilot pull request it acts as
-#   github-actions[bot], using the built-in GITHUB_TOKEN. GitHub deliberately
-#   does NOT raise workflow events for anything that token does - otherwise a
-#   workflow could trigger itself forever. So an auto-merged pull request lands
-#   on main and no 'push' run ever fires, and the change sits undeployed.
-#   (That is exactly what happened to the Rewards UI in #48/#49.)
-#
-#   Rather than hand a write-scoped personal token to the merge job, this
-#   workflow keeps its own record of what is live - the 'deployed' tag - and
-#   sweeps every 5 minutes for anything on main that is newer than it.
+# Runs on push to main. That is enough because auto-merge.yml merges with a
+# real personal token: GitHub raises no workflow events for the built-in
+# GITHUB_TOKEN, so while the merge job used it an auto-merged pull request
+# fired no push here at all and the change sat undeployed. That is what
+# happened to the Rewards UI in #48/#49.
 #
 # The 'deployed' tag is the source of truth for what is on Azure, so a run
-# deploys everything changed since the last SUCCESSFUL deploy. A failed deploy
-# leaves the tag where it is and the next run retries it.
+# deploys everything changed since the last SUCCESSFUL deploy rather than just
+# HEAD^. A failed deploy leaves the tag where it is and the next push retries
+# it, and several commits landing together cannot hide each other.
 #
 # Required repository secrets:
 #   AZURE_STATIC_WEB_APPS_API_TOKEN  - Static Web App deployment token
@@ -33,8 +28,6 @@ name: Deploy to Azure
 on:
   push:
     branches: [main]
-  schedule:
-    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -75,17 +68,9 @@ jobs:
               echo "::warning::'deployed' tag is not an ancestor of main - falling back to HEAD^."
               BASE=$(git rev-parse HEAD^)
             fi
-          elif [ "${{ github.event_name }}" = "schedule" ]; then
-            # First sweep after this workflow lands: there is no tag yet, so
-            # there is no way to know what is live. Deploy both and create the
-            # tag - a full deploy is idempotent and takes ~80s, and skipping
-            # here would leave the tag uncreated indefinitely, which is exactly
-            # the hole this workflow exists to close.
-            echo "::notice::No 'deployed' tag yet - deploying both once to establish it."
-            echo "api=true" >> "$GITHUB_OUTPUT"
-            echo "frontend=true" >> "$GITHUB_OUTPUT"
-            exit 0
           else
+            # No tag yet - fall back to the previous commit. The record job
+            # creates the tag after the first deploy that ships something.
             BASE=$(git rev-parse HEAD^)
           fi
 

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -14,12 +14,24 @@ name: Elaborate backlog issue
 #   costs nothing - the work is still sitting there labelled, and the next wake
 #   finds it.
 #
-# Wakes on: a label being added, every 5 minutes, and manual dispatch. Dispatch
+# Wakes on: a label being added, every 30 minutes, and manual dispatch. Dispatch
 # with an issue number to jump the queue; leave it blank to just drain.
 #
-# Guard: at most 20 runs per rolling 24h, so with the $2/session cap the worst
-# case is ~$40/day. Raised for the initial build-out; drop back to ~10 for
-# ongoing feature work.
+# What bounds the spend:
+#   1. The queue itself. Only labelled issues run, each runs once, and the
+#      label comes off afterwards - so the ceiling is (issues you label) x
+#      ~$0.35. Labelling is the budget.
+#   2. A $2 hard cap per session, set in the runner.
+#   3. Skipping anything already marked 'elaborated' - the one way this could loop is
+#      a failed label removal, and that closes it.
+#   4. A runaway ceiling of 80 runs per rolling 24h, below.
+#
+# The ceiling counts RUNS, and a sweep is a run. At */5 that is 288 a day, so a
+# ceiling of 20 was crossed within two hours - after which nothing would ever
+# run again, the exact silent stall this workflow exists to prevent. Hence a
+# 30-minute sweep (48/day, well under 80). The sweep is only a backstop anyway:
+# adding the label fires this immediately, and each finished run dispatches the
+# next itself.
 
 on:
   workflow_dispatch:
@@ -30,7 +42,7 @@ on:
   issues:
     types: [labeled]
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -50,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Daily run guard (max 20 per rolling 24h)
+      - name: Runaway guard (max 80 runs per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
@@ -58,8 +70,8 @@ jobs:
           SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/elaborate.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
           echo "Elaborator runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 20 ]; then
-            echo "::notice::Daily limit of 20 elaborator runs reached. Labelled issues stay queued and resume once the window clears."
+          if [ "${COUNT}" -gt 80 ]; then
+            echo "::notice::Runaway ceiling of 80 elaborator runs reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -94,6 +106,17 @@ jobs:
           echo "$QUEUE" | jq -r '.[] | "  #\(.number)  \(.title)"'
 
           NEXT=$(echo "$QUEUE" | jq -r '.[0].number')
+
+          # Already done? Then 'elaborate' was left behind by a failed label
+          # removal. Clear it rather than paying to redo the work - this is the
+          # only way the queue could loop.
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${NEXT}/labels" --jq '.[].name' 2>/dev/null | grep -qx 'elaborated'; then
+            echo "#${NEXT} is already elaborated - clearing the stale label instead of rerunning."
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${NEXT}/labels/elaborate" >/dev/null 2>&1 || true
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Taking #${NEXT}."
           echo "number=${NEXT}" >> "$GITHUB_OUTPUT"
           echo "remaining=$((DEPTH - 1))" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -14,7 +14,7 @@ name: Elaborate backlog issue
 #   costs nothing - the work is still sitting there labelled, and the next wake
 #   finds it.
 #
-# Wakes on: a label being added, every 30 minutes, and manual dispatch. Dispatch
+# Wakes on: a label being added, and manual dispatch. Dispatch
 # with an issue number to jump the queue; leave it blank to just drain.
 #
 # What bounds the spend:
@@ -26,12 +26,11 @@ name: Elaborate backlog issue
 #      a failed label removal, and that closes it.
 #   4. A runaway ceiling of 80 runs per rolling 24h, below.
 #
-# The ceiling counts RUNS, and a sweep is a run. At */5 that is 288 a day, so a
-# ceiling of 20 was crossed within two hours - after which nothing would ever
-# run again, the exact silent stall this workflow exists to prevent. Hence a
-# 30-minute sweep (48/day, well under 80). The sweep is only a backstop anyway:
-# adding the label fires this immediately, and each finished run dispatches the
-# next itself.
+# The ceiling counts RUNS, so keep it well clear of however often this fires.
+# A ceiling of 20 against a 5-minute sweep was crossed within two hours and then
+# held forever, after which nothing would ever run again - a guard that becomes
+# the outage. There is no sweep now: the label event starts this, and each
+# finished run dispatches the next itself.
 
 on:
   workflow_dispatch:
@@ -41,8 +40,6 @@ on:
         required: false
   issues:
     types: [labeled]
-  schedule:
-    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -57,7 +54,6 @@ jobs:
   elaborate:
     if: >-
       github.event_name == 'workflow_dispatch'
-      || github.event_name == 'schedule'
       || github.event.label.name == 'elaborate'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -83,6 +83,17 @@ the whole backlog `elaborate` in one go and walk away — they drain one at a
 time, oldest first, and the label is removed as each is finished. So the labels
 on the board are always the work still outstanding.
 
+### What actually bounds the Anthropic spend
+
+Not the run ceiling — **the labels**. An issue runs once and loses its label, so
+the total is (issues you label) × ~$0.35, with a $2 hard cap per session on top.
+Labelling is the budget.
+
+The 80-runs ceiling is only there to stop a loop, and it counts *runs* — a sweep
+is a run. That is a trap: at a 5-minute sweep the old ceiling of 20 was crossed
+within two hours, after which nothing would ever run again. Keep any ceiling
+comfortably above the sweep rate, or the guard becomes the outage.
+
 ### Why every trigger has to be a queue
 
 Two GitHub behaviours quietly destroy work, and both bit this repo:
@@ -142,8 +153,10 @@ Deliberate for the initial build-out: the Copilot credit budget is the real
 limit, it fails safe, and a second ceiling underneath it only stalls the run.
 
 **Afterwards, restore the guards:** `MAX_PER_RUN=1`, the daily guard in
-`build.yml` back to ~8, the guards in `elaborate.yml` / `architect.yml` back to
-~10, and disable the auto-approve workflow.
+`build.yml` back to ~8, and disable the auto-approve workflow. Leave the
+`elaborate.yml` / `architect.yml` ceilings alone — they are runaway protection,
+not a budget, and lowering them below the sweep rate stalls the queue for good
+(see below).
 
 **The dependency check is not a pacing device** and stays whatever the speed:
 it stops Copilot writing against code that does not exist yet.
@@ -172,8 +185,8 @@ rule is: build the sub-issues, not the parent.
 
 | Guard | Limit | Why |
 |---|---|---|
-| Elaborator runs | 20 / rolling 24h | Anthropic spend |
-| Architect runs | 20 / rolling 24h | Anthropic spend |
+| Elaborator runs | 80 / rolling 24h | Runaway protection, **not** a budget |
+| Architect runs | 80 / rolling 24h | Runaway protection, **not** a budget |
 | Copilot builds | 6 at a time via the queue; **no daily cap during the build-out** | The Copilot credit budget is the real limit and fails safe on its own |
 
 > Those numbers are raised for the initial build-out. See *The build queue*

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -89,10 +89,10 @@ Not the run ceiling — **the labels**. An issue runs once and loses its label, 
 the total is (issues you label) × ~$0.35, with a $2 hard cap per session on top.
 Labelling is the budget.
 
-The 80-runs ceiling is only there to stop a loop, and it counts *runs* — a sweep
-is a run. That is a trap: at a 5-minute sweep the old ceiling of 20 was crossed
-within two hours, after which nothing would ever run again. Keep any ceiling
-comfortably above the sweep rate, or the guard becomes the outage.
+The 80-runs ceiling is only there to stop a loop, and it counts *runs*. Keep any
+ceiling comfortably clear of however often the workflow fires: a ceiling of 20
+against a 5-minute sweep was crossed within two hours and then held forever,
+turning the guard itself into the outage.
 
 ### Why every trigger has to be a queue
 
@@ -113,8 +113,8 @@ labels are the truth.
 ### The build queue
 
 `build` means **queued**, not "build now". `build-queue.yml` picks the next
-queued issues and hands them to Copilot, oldest first, sweeping every 10
-minutes and on any event that could change what is buildable.
+queued issues and hands them to Copilot, oldest first, waking on any event that
+could change what is buildable.
 
 Two reasons it is a queue rather than a direct trigger, both learned the hard
 way:
@@ -136,24 +136,19 @@ have changed what is buildable:
 | A `build` label is added | That issue may be ready to start immediately |
 | A pull request is merged or closed | Whatever depended on it may now be unblocked |
 | An issue is closed | Same |
-| 10-minute sweep | **Load-bearing, not a safety net** — see below |
 
-The sweep is not optional. When `auto-merge.yml` merges a PR it acts as
-`github-actions[bot]` via `GITHUB_TOKEN`, and GitHub raises **no workflow
-events** for that token — so an auto-merged PR fires no `pull_request: closed`
-here at all. On an unattended pipeline the sweep is what actually advances the
-queue.
-
-So a chain like #33 → #34 → #35 flows straight through, but on the sweep's
-cadence: #33's PR auto-merges, #33 closes, and #34 and #35 start within about
-10 minutes.
+There is no schedule here any more — see **the bot-token trap** above. With
+merges made by a real token the events fire, so a chain like #33 → #34 → #35
+flows straight through: #33's PR auto-merges, #33 closes, and the queue wakes
+within seconds to start #34 and #35.
 
 **Up to 6 start at once** (`MAX_PER_RUN` in the workflow), with no daily cap.
 Deliberate for the initial build-out: the Copilot credit budget is the real
 limit, it fails safe, and a second ceiling underneath it only stalls the run.
 
 **Afterwards, restore the guards:** `MAX_PER_RUN=1`, the daily guard in
-`build.yml` back to ~8, and disable the auto-approve workflow. Leave the
+`build.yml` back to ~8, and delete `approve-agent-workflows.yml` (which also
+removes one of the two remaining timers). Leave the
 `elaborate.yml` / `architect.yml` ceilings alone — they are runaway protection,
 not a budget, and lowering them below the sweep rate stalls the queue for good
 (see below).
@@ -217,37 +212,46 @@ disabled, so it hard-stops rather than billing you.
   anything — read it after the fact, or turn on branch protection if you want
   it to gate.
 - **Deployment** (`deploy.yml`) deploys only what changed — API to
-  `herotasks-func-dev`, frontend to `herotasks-swa-dev`. It runs on push to
-  `main`, **and sweeps every 5 minutes** for anything merged that the push
-  event missed. See below for why that sweep is not optional.
+  `herotasks-func-dev`, frontend to `herotasks-swa-dev` — on push to `main`.
 
-### Why deployment needs a sweep as well as a push trigger
+### The bot-token trap, and why the pipeline has almost no polling
 
-When `auto-merge.yml` merges a Copilot PR it acts as `github-actions[bot]`,
-using the built-in `GITHUB_TOKEN`. GitHub deliberately raises **no workflow
-events** for anything that token does — otherwise a workflow could trigger
-itself in a loop. So an auto-merged PR lands on `main` and **no deploy run
-fires at all**.
+Worth understanding, because it caused the worst bug in this project so far and
+it dictates the shape of everything else.
 
-This bit us for real: #48 and #49 (the Rewards UI) merged cleanly, sat on
-`main`, and never reached Azure. The dashboard looked correct on GitHub and the
-live app had no Rewards section.
+**GitHub raises no workflow events for anything the built-in `GITHUB_TOKEN`
+does.** It has to work that way, or a workflow could trigger itself in a loop.
 
-So `deploy.yml` keeps its own record of what is live — a git tag called
-**`deployed`** — and each run deploys everything changed *since that tag*,
-moving it forward only after a successful deploy. That means:
+While `auto-merge.yml` merged with that token, an auto-merged PR therefore fired
+*nothing*: no `push` (so no deploy), no `pull_request: closed` (so the build
+queue never woke), no issue auto-close. #48 and #49 — the Rewards UI — merged
+cleanly, sat on `main`, and never reached Azure. GitHub looked perfectly
+healthy; the live app just had no Rewards section.
 
-- a failed deploy leaves the tag behind and the next sweep retries it;
-- a merge that fired no push event is picked up within 5 minutes;
-- the diff is against what is actually on Azure, not against `HEAD^`, so
-  nothing gets skipped when several commits land together.
+The first fix was polling: every workflow swept on a timer to catch what the
+events missed. That worked, but it put GitHub's cron scheduler on the critical
+path of everything — the same scheduler the fermenter project deliberately
+avoids as unreliable — and it introduced a second bug, where a run-counting
+guard counted its own sweeps and stalled the queue permanently.
 
-Worst-case lag between an auto-merge and the live app is about 10 minutes
-(5 for the merge poll, 5 for the deploy sweep). If you ever want it instant,
-give `HEROTASK_GITHUB_TOKEN` **Contents: Read and write** and **Pull requests:
-Read and write** and use it in `auto-merge.yml` — merges by a real token do
-raise events. The sweep exists so that is a nice-to-have rather than a
-requirement.
+**The real fix is to merge with a real token.** `auto-merge.yml` uses
+`HEROTASK_GITHUB_TOKEN` (Contents: Read and write, Pull requests: Read and
+write), so its merges raise events like anyone else's, and every sweep on
+`deploy.yml`, `build-queue.yml`, `elaborate.yml` and `architect.yml` was
+deleted. Work now moves the instant something unblocks it.
+
+**Two timers remain, both irreducible:**
+
+| Workflow | Why it cannot be an event |
+|---|---|
+| `auto-merge.yml` (5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
+| `approve-agent-workflows.yml` (5 min) | Temporary build-out only; there is no event for "a run is waiting for approval". Delete it when the backlog is built |
+
+`deploy.yml` still keeps its own record of what is live — a git tag called
+**`deployed`** — and deploys everything changed *since that tag* rather than
+since `HEAD^`, moving it only after a successful deploy. So a failed deploy
+retries on the next push, and several commits landing together cannot hide each
+other.
 
 ### Deployment secrets (add these once)
 


### PR DESCRIPTION
Removes the polling this pipeline was leaning on, by fixing the reason it was needed.

## The root cause

**GitHub raises no workflow events for anything the built-in `GITHUB_TOKEN` does.** It has to work that way, or a workflow could trigger itself in a loop.

While `auto-merge.yml` merged with that token, an auto-merged PR fired *nothing*: no `push` (so no deploy), no `pull_request: closed` (so the build queue never woke), no issue auto-close. #48 and #49 — the Rewards UI — merged cleanly, sat on `main`, and never reached Azure. GitHub looked healthy; the live app just had no Rewards section.

#52 papered over it with sweeps. That worked, but put GitHub's cron scheduler on the critical path of everything — the same scheduler the fermenter project deliberately avoids as unreliable — and introduced a second bug (below).

## Fix

`auto-merge.yml` now merges with `HEROTASK_GITHUB_TOKEN`, so its merges raise events like any other user's. That makes the sweeps unnecessary, and they're gone:

- `deploy.yml` — schedule removed (keeps the `deployed` tag, which is still worth having: it retries a failed deploy and stops several commits hiding each other)
- `build-queue.yml` — schedule removed
- `elaborate.yml`, `architect.yml` — schedule removed, dead `schedule` branch dropped from the job condition

**Two timers remain, and neither can be an event:**

| Workflow | Why |
|---|---|
| `auto-merge.yml` (5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. No event means done |
| `approve-agent-workflows.yml` (5 min) | Temporary build-out only; no event exists for "a run is waiting for approval" |

Requires the token to carry **Contents: Read and write** and **Pull requests: Read and write** — both granted.

## Also fixes a bug #52 introduced

The daily guard counts **workflow runs** and refused above 20 per rolling 24 hours. The `*/5` sweep was itself a run — 288 a day — so the ceiling would have been crossed within two hours and then held above the line permanently, after which the Elaborator would never have run again. Precisely the silent stall #52 existed to prevent.

- ceiling raised to 80/24h and renamed: it's runaway protection, not a budget
- issues already marked `elaborated` / `architected` are skipped and their stale trigger label cleared, closing the one path where the queue could loop and pay twice

**What actually bounds the Anthropic spend is the labels**, not the ceiling: an issue runs once and loses its label, so the total is (issues labelled) × ~$0.35, with a $2 hard cap per session. The repo is public, so Actions minutes are free either way.

## Testing

All workflow files validated with `yaml.safe_load` (and CI now enforces that, per #53). The queue logic is confirmed working end-to-end: run #17, dispatched with no issue number, picked #11 off the queue on its own and ran the Elaborator against it.

Not yet exercised: an auto-merge performed with the new token. That's the first thing to watch after this merges.