### PR TITLE
Keep the approve error instead of swallowing it

### DIFF
--- a/.github/workflows/approve-agent-workflows.yml
+++ b/.github/workflows/approve-agent-workflows.yml
@@ -59,14 +59,17 @@ jobs:
 
           FAILED=0
           for ID in $(echo "$PENDING" | jq -r '.[].id'); do
-            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/approve" >/dev/null 2>&1; then
+            # Keep the error. Swallowing it cost real debugging time: every
+            # approve was failing and the log only said "could not approve",
+            # which read like a token-permission problem when it was not.
+            if ERR=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${ID}/approve" 2>&1); then
               echo "  approved ${ID}"
             else
-              echo "  ::warning::could not approve ${ID}"
+              echo "  ::warning::could not approve ${ID}: ${ERR}"
               FAILED=$((FAILED + 1))
             fi
           done
 
           if [ "$FAILED" -gt 0 ]; then
-            echo "::warning::${FAILED} run(s) could not be approved - check the token has Actions: Read and write."
+            echo "::warning::${FAILED} run(s) could not be approved. The error above is the real reason - note that /actions/runs/{id}/approve is documented for fork pull requests, which Copilot's same-repo branches are not."
           fi


### PR DESCRIPTION
The auto-approve workflow finds the pending runs correctly but **every approve call fails**, and the log only said `could not approve <id>` followed by a hint to check the token's Actions permission. That hint is wrong — the token has Actions: Read and write — and it sent me looking in the wrong place.

Actual log from run 32561704484:

```
Found 5 run(s) awaiting approval:
  32561664976  Build queue  [copilot/add-quiet-hours-setting]
  32561664981  Auto-approve agent workflow runs  [copilot/add-quiet-hours-setting]
  32561267398  CI  [copilot/web-push-notification-infrastructure]
  32561080878  Request Copilot review  [copilot/web-push-notification-infrastructure]
  32561080874  CI  [copilot/web-push-notification-infrastructure]
##[warning]could not approve 32561664976
... all five
```

This prints the real API error instead, and notes the likely cause in the summary message: `POST /actions/runs/{id}/approve` is documented for **fork** pull requests, and Copilot's branches live in this repo rather than a fork — so it may be the wrong endpoint for this gate entirely, not a permissions issue.

## Why this matters beyond the log line

Because these approvals never succeed, **CI has not actually run on any Copilot pull request**. Both CI runs on `copilot/web-push-notification-infrastructure` are sitting blocked, and on #58 CI only ran on `main` *after* the merge. The pipeline docs describe CI as "the actual gate"; in practice it has been reporting after the fact, not gating.

This PR only improves the diagnostics — it does not fix that. The fix depends on what the error turns out to say.

## Testing

`yaml.safe_load` passes (and CI enforces that since #53). The change is confined to error handling in one `run:` block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_