### PR TITLE
Build one issue at a time — parallel builds conflict with each other

### DIFF
--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -25,8 +25,15 @@ name: Build queue
 # advance the queue. The merge job now uses a real token, the events fire, and
 # the queue moves the moment something unblocks.
 #
-# MAX_PER_RUN caps how many start at once. For the initial build-out it is 6;
-# drop it to 1 for ongoing feature work.
+# MAX_PER_RUN caps how many start at once, and it is 1 deliberately.
+#
+# Running builds in parallel looks faster and is not. Almost every sub-issue
+# edits api/src/functions/hero.js or frontend/index.html, so concurrent Copilot
+# branches conflict with each other: the first merges, the rest need a human to
+# resolve, and auto-merge cannot. #57 and #58 hit this within minutes of each
+# other. One at a time means each build branches off code that already contains
+# the one before it, so conflicts mostly cannot arise - which is what actually
+# keeps the pipeline unattended.
 
 on:
   issues:
@@ -66,7 +73,7 @@ jobs:
           CANDIDATES=$(gh api "repos/${GITHUB_REPOSITORY}/issues?labels=build&state=open&sort=created&direction=asc&per_page=100" \
             --jq '[.[] | select(has("pull_request") | not) | {number, body: (.body // ""), assignees: [.assignees[].login]}]')
 
-          MAX_PER_RUN=6
+          MAX_PER_RUN=1
           READY=""
           PICKED=0
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -142,11 +142,20 @@ merges made by a real token the events fire, so a chain like #33 → #34 → #35
 flows straight through: #33's PR auto-merges, #33 closes, and the queue wakes
 within seconds to start #34 and #35.
 
-**Up to 6 start at once** (`MAX_PER_RUN` in the workflow), with no daily cap.
-Deliberate for the initial build-out: the Copilot credit budget is the real
-limit, it fails safe, and a second ceiling underneath it only stalls the run.
+**One build at a time** (`MAX_PER_RUN=1`), with no daily cap.
 
-**Afterwards, restore the guards:** `MAX_PER_RUN=1`, the daily guard in
+Parallel builds look faster and are not. Almost every sub-issue edits
+`api/src/functions/hero.js` or `frontend/index.html`, so concurrent Copilot
+branches conflict: the first merges, the rest need a human to resolve, and
+**auto-merge cannot resolve a conflict** — those pull requests just sit there.
+#57 and #58 hit this within minutes of each other and needed a hand-resolved
+merge.
+
+Serialising means each build branches off code that already contains the one
+before it, so the conflict mostly cannot arise. That is what actually keeps the
+pipeline unattended; six at once does not.
+
+**Afterwards, restore the guards:** the daily guard in
 `build.yml` back to ~8, and delete `approve-agent-workflows.yml` (which also
 removes one of the two remaining timers). Leave the
 `elaborate.yml` / `architect.yml` ceilings alone — they are runaway protection,


### PR DESCRIPTION
`MAX_PER_RUN` 6 → 1, before the rest of the backlog is labelled.

## Why

Almost every sub-issue edits `api/src/functions/hero.js` or `frontend/index.html`. Run six Copilot builds concurrently and they all branch off the same base, so the first to merge wins and the rest conflict — and **auto-merge cannot resolve a conflict**, so those PRs just sit waiting for a human.

This isn't hypothetical: #57 and #58 were started together, both touched `hero.js` and `api/test-logic.js`, #58 merged first, and #57 needed a hand-resolved merge commit before it could go anywhere. With ~30 sub-issues coming, that becomes the normal case rather than the exception.

Serialising means each build branches off code that already contains the one before it, so the conflict mostly cannot arise.

## The trade

Slower per issue — builds queue behind each other instead of running six abreast. But six-at-once isn't actually faster when half of them stall on a conflict that needs manual intervention. One at a time is the difference between a pipeline that runs unattended and one that stops every second PR.

Copilot credits are unchanged either way — same number of builds, just not simultaneous.

## Testing

`yaml.safe_load` passes (enforced by CI since #53). `docs/pipeline.md` updated with the reasoning, and the stale "restore `MAX_PER_RUN=1` afterwards" note removed since that's now the default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_