### PR TITLE
Send red CI back to Copilot instead of leaving the PR sitting

### DIFF
--- a/.github/workflows/fix-red-ci.yml
+++ b/.github/workflows/fix-red-ci.yml
@@ -1,0 +1,96 @@
+name: Send red CI back to Copilot
+
+# When CI fails on a Copilot pull request, hand the failure back to Copilot to
+# fix rather than leaving the pull request sitting for a human.
+#
+# Copilot's coding agent starts a new session when someone with write access
+# mentions it on a pull request it authored, so this posts the failing log as a
+# comment addressed to @copilot. It uses the personal token deliberately: a
+# comment from github-actions[bot] would not reach Copilot.
+#
+# ATTEMPT CAP: three. If Copilot cannot fix it in three goes it is not going to,
+# and each attempt costs Copilot credits and can make the diff worse. After
+# that the pull request is left alone and labelled 'needs-human' if that label
+# exists, so it is easy to find.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: fix-red-ci-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  hand-back:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && startsWith(github.event.workflow_run.head_branch, 'copilot/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Ask Copilot to fix its own failing build
+        env:
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -uo pipefail
+
+          NUM=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY%%/*}:${BRANCH}" \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+          if [ -z "$NUM" ]; then
+            echo "No open pull request for ${BRANCH} - nothing to hand back."
+            exit 0
+          fi
+          echo "Pull request #${NUM} on ${BRANCH}"
+
+          MARKER="<!-- ci-handback -->"
+          ATTEMPTS=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUM}/comments?per_page=100" \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\"))] | length" 2>/dev/null || echo 0)
+          echo "Previous hand-backs on this pull request: ${ATTEMPTS}"
+
+          if [ "${ATTEMPTS:-0}" -ge 3 ]; then
+            echo "::warning::#${NUM} has already been handed back 3 times and CI is still red. Leaving it for a human."
+            if gh api "repos/${GITHUB_REPOSITORY}/labels/needs-human" >/dev/null 2>&1; then
+              gh issue edit "$NUM" --repo "$GITHUB_REPOSITORY" --add-label needs-human >/dev/null 2>&1 \
+                && echo "Labelled #${NUM} needs-human."
+            fi
+            exit 0
+          fi
+
+          # Last 60 lines of whatever actually failed - enough for a stack trace
+          # or a failed assertion without pasting the whole build.
+          LOG=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed 2>/dev/null | tail -60 || echo "")
+          if [ -z "$LOG" ]; then
+            LOG="(could not read the failing log - see the run link below)"
+          fi
+
+          BODY=$(cat <<EOF
+          ${MARKER}
+          @copilot CI is failing on this pull request. Please fix it and push to this branch.
+
+          Attempt $((ATTEMPTS + 1)) of 3. Full run: ${RUN_URL}
+
+          The tests are \`node api/test-logic.js\`, a frontend parse check (\`node scripts/check-frontend.js\`) and a workflow YAML check. Run them locally before pushing.
+
+          Tail of the failing job:
+
+          \`\`\`
+          ${LOG}
+          \`\`\`
+          EOF
+          )
+
+          # Strip the leading indentation the heredoc carries inside the YAML block.
+          echo "$BODY" | sed 's/^          //' > /tmp/body.md
+          gh pr comment "$NUM" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.md \
+            && echo "Handed #${NUM} back to Copilot (attempt $((ATTEMPTS + 1)))." \
+            || echo "::warning::could not comment on #${NUM}"

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,7 +13,7 @@ Copilot. You are the gate between them.
 | **Architect** | Claude Managed Agents | `architect` label — applied by the Elaborator where design is genuinely needed | A technical-approach comment on the issue |
 | **Developer** | GitHub Copilot | `build` label | A branch + pull request |
 | **Tester** | GitHub Copilot | Automatic on every agent PR | Review comments — **advisory, does not block the merge** |
-| *(CI)* | GitHub Actions | Automatic on every PR | Pass/fail — **the actual gate** |
+| *(CI)* | GitHub Actions | Automatic on every PR | Pass/fail — **the actual gate**; a failure is handed back to Copilot to fix, up to three times |
 
 The project-manager role was dropped — with one person and a labelled backlog
 there is nothing for it to sequence.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -128,6 +128,18 @@ way:
 The queue skips anything that is an epic, already assigned to Copilot, or has
 an open issue named in a `Depends on #N` line in its body.
 
+**Red CI goes back to Copilot, not to you.** `fix-red-ci.yml` watches for a
+failed CI run on a `copilot/` branch and comments on the pull request tagging
+`@copilot` with the tail of the failing log. Copilot's agent starts a new
+session when someone with write access mentions it on a pull request it wrote,
+so it fixes and pushes by itself. The comment comes from the personal token
+deliberately — one from `github-actions[bot]` would not reach it.
+
+**Capped at three attempts.** If Copilot cannot fix it in three goes it is not
+going to, and each attempt spends credits and can make the diff worse. After
+that the pull request is left alone and labelled `needs-human`, which is the
+one thing genuinely worth looking at when you come back.
+
 **Staying merge-able.** Before merging, `auto-merge.yml` checks whether the
 branch is behind `main` and, if so, updates it and waits for CI to re-run
 against the merged result. Between that and building one at a time, a conflict


### PR DESCRIPTION
Closes the last thing that could strand work unattended.

## The gap

#63 made the merge gate real — a red pull request now stays open instead of merging broken. Correct, but incomplete: nothing then *fixed* it, so the PR would sit until a human looked at it. Good failure direction, still a stop.

## Fix

Copilot's coding agent starts a new session when someone with write access mentions it on a pull request it authored. So `fix-red-ci.yml` watches for a failed CI run on a `copilot/` branch and comments on the PR tagging `@copilot` with:

- the tail of the failing job log (last 60 lines — enough for a stack trace or failed assertion, not the whole build)
- what the tests actually are, so it can run them locally
- which attempt this is, and a link to the run

The comment posts with `HEROTASK_GITHUB_TOKEN` deliberately — a comment from `github-actions[bot]` would not reach Copilot.

## Capped at three

Counted from a `<!-- ci-handback -->` marker in the comment body. If Copilot can't fix it in three goes it isn't going to, and each attempt spends credits and can make the diff worse. After that the PR is left alone and labelled `needs-human` — which becomes the one thing genuinely worth looking at after an unattended run.

## Testing

`yaml.safe_load` on all workflow files, `bash -n` on the run block, and I rendered the comment body with a fake log to confirm the heredoc indentation strips correctly and the fenced code block survives:

```
<!-- ci-handback -->
@copilot CI is failing on this pull request. Please fix it and push to this branch.

Attempt 1 of 3. Full run: https://example/run
...
```

Only genuinely testable on a real red build. If the trigger is wrong it does nothing — the PR just sits, which is exactly today's behaviour, so it can't make anything worse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_