### PR TITLE
Separate writing infrastructure code from holding Azure credentials

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -69,8 +69,19 @@ integration code between them, and neither engine calls the other.
   unattended. CI is the gate, and it is the only automatic check that can stop
   a change: Copilot's review is advisory. To put a human back in the loop,
   turn on branch protection requiring a review, or disable `auto-merge.yml`.
-- **Claude agents never get Azure credentials.** They read the repo and write
-  GitHub issues; deployment stays outside their reach.
+- **Agents write infrastructure code; they do not hold Azure credentials.**
+  These are different things and conflating them causes confusion. `infra/*.bicep`
+  is code in this repository like anything else — Copilot can write it, CI checks
+  it, it merges normally. What no agent has is a credential that can *apply* it to
+  the subscription, so `az deployment group create` is a human step (see
+  `infra/README.md`). The Claude agents are narrower still: they read the repo and
+  write GitHub issues, nothing more.
+
+  This is unwired, not forbidden. Adding a federated credential and three repo
+  secrets would let `deploy.yml` apply `infra/` too. The reason it has not been
+  done is blast radius, and it is a judgement call rather than a rule: today's
+  Azure secrets can only replace application code, whereas ARM credentials can
+  create, modify and delete resources and read the Key Vault.
 - **Epics are not implementation tasks.** Once elaborated, a parent issue
   should not carry a `role:*` label — the sub-issues do. Assigning an epic to
   Copilot produces sprawling, unreviewable PRs.


### PR DESCRIPTION
The ground rule in `docs/agents.md` read as though agents couldn't work on infrastructure at all:

> **Claude agents never get Azure credentials.** They read the repo and write GitHub issues; deployment stays outside their reach.

That's true of the Claude agents specifically, but it reads as a blanket statement and it misled me during #43 — I described the fix as something agents couldn't do, when in truth it was one boolean not worth a PR cycle. Peter picked it up: Copilot writes IaC, that's the point of IaC.

## The actual distinction

- **Writing infrastructure code** — `infra/*.bicep` is code in this repository like anything else. Copilot can write it, CI checks it, it merges normally.
- **Applying it** — needs a credential that can act on the Azure subscription. No agent has one, so `az deployment group create` is a human step.

The rewritten rule says that, and keeps the narrower point about the Claude agents (which really do only read the repo and write issues).

It also records that **this is unwired, not forbidden**: a federated credential plus three repo secrets would let `deploy.yml` apply `infra/` too. The reason it hasn't been done is blast radius, and that's a judgement call rather than a rule — today's Azure secrets can only replace application code, whereas ARM credentials can create, modify and delete resources and read the Key Vault.

## Testing

Documentation only, no code or workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_