### PR TITLE
Teach the Elaborator that UI work extends the shell, not the page

### DIFF
--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -55,6 +55,33 @@ Work in this order:
      deleteTask). Acceptance criteria that name real code are buildable;
      generic ones are not.
 
+2b. UI WORK EXTENDS THE SHELL, IT DOES NOT APPEND TO THE PAGE.
+
+   The frontend is a single file, frontend/index.html, and the whole backlog
+   edits it. Left unguided, each feature appends another section to the bottom
+   and the app degrades into a long scrolling page - which is exactly what
+   issue #67 exists to fix, and what thirteen subsequent issues would quietly
+   undo.
+
+   So whenever a sub-issue touches the frontend, its acceptance criteria MUST:
+   - place the work inside the existing view and navigation structure - a new
+     screen reached by navigation, or an addition to a screen that already
+     exists. Never "add a section to index.html";
+   - name the real design tokens and conventions you found while auditing (the
+     CSS custom properties for colour, spacing, type and radius; the card and
+     button classes; how a kid's colour and avatar are applied) and require the
+     new work to use them rather than introduce its own values;
+   - keep the register right: playful and generous on kid screens, calm and
+     efficient in Parent HQ;
+   - preserve the app-like behaviour that already exists - the content region
+     scrolls rather than the page, actions give immediate feedback rather than
+     waiting on the API, and decorative motion is skipped under
+     prefers-reduced-motion.
+
+   If the shell and design system do not exist yet in the code you audited, say
+   so plainly in your comment and note that the sub-issue depends on #67, so it
+   is not built against a structure that is about to change underneath it.
+
 3. Produce the elaboration:
    - "Already built" - what exists today, with file references. May be empty.
    - Split the REMAINING work into 2-4 sub-issues, each independently


### PR DESCRIPTION
#67 restructures the frontend into a proper app shell with a design system. Nothing made that stick for the thirteen issues built afterwards.

## The problem

The frontend is one file, `frontend/index.html`, and the whole backlog edits it. Left unguided, each feature appends another section to the bottom — which is exactly what #67 exists to fix, and exactly what the issues after it would quietly undo. By issue five you'd have a scrolling page with a tab bar stuck on top of it.

The audit-first rule means the Elaborator would *see* a design system if one existed, but it was never told to require conformance. "Add a Calendar section to `index.html`" was a perfectly likely spec.

## Fix

A new step in the persona: whenever a sub-issue touches the frontend, its acceptance criteria must

- place the work **inside the existing view and navigation structure** — a new screen reached by navigation, or an addition to one that exists. Never "add a section to index.html"
- **name the real design tokens found during the audit** (the custom properties for colour, spacing, type, radius; card and button classes; how a kid's colour and avatar are applied) and require reuse rather than new one-off values
- keep the register right — playful on kid screens, calm and efficient in Parent HQ
- preserve the app-like behaviours already there: content region scrolls rather than the page, immediate feedback rather than waiting on the API, motion skipped under `prefers-reduced-motion`

## Also fixes the ordering problem

If the shell doesn't exist yet in the code it audited, the Elaborator now says so and notes the dependency on #67 — rather than speccing against a structure that's about to change underneath it. That matters if #67 isn't built first.

## Takes effect after a setup re-run

The live persona is the `SYSTEM_PROMPT` in `ops/elaborator/setup_elaborator.py`; editing the file doesn't change the running agent. Actions → *Elaborator — one-time setup* → Run workflow, which versions the agent in place. **Do that before labelling the backlog**, or the first few issues elaborate under the old persona.

## Testing

`ast.parse` on the modified Python. The persona change itself is only observable in the next elaboration run — what to look for is a frontend sub-issue whose acceptance criteria name real CSS custom properties and place the work in a named view, rather than saying "add a section".

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_