### PR TITLE
Add the design system, so building the UI is implementation not invention

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,257 @@
+# Design system
+
+The visual language of the app. **These are the actual values to use** — not
+suggestions, not a starting point. Every screen is built from this set.
+
+Why it is written down rather than left to judgement: the frontend is one file
+that the whole backlog edits, and "make it feel premium" is an adjective, not a
+specification. An agent implements a defined thing well and invents a design
+poorly. This turns the work into implementation.
+
+`scripts/check-design.js` enforces the mechanical half of this in CI (see
+[`pipeline.md`](pipeline.md)). It cannot judge taste — that is what the
+component specs below are for.
+
+---
+
+## Principles
+
+1. **Consistency reads as quality.** A confident, repeated set of choices looks
+   more expensive than a novel choice on every screen. When in doubt, reuse.
+2. **Playful for kids, calm for parents.** Same tokens, different register. The
+   kid views are generous and rewarding; Parent HQ is quiet and efficient. A
+   parent screen covered in confetti reads as unserious.
+3. **Reward the moment.** Completing a chore and earning points are the emotional
+   core of the app. They get motion, colour and celebration. Nothing else does.
+4. **Motion is fast or it is annoying.** Nothing decorative runs longer than
+   380ms. All of it is skipped under `prefers-reduced-motion`.
+
+---
+
+## Tokens
+
+All defined once, in a single `:root` block. Nothing below appears as a literal
+value anywhere else in the stylesheet.
+
+### Colour
+
+```css
+/* Surfaces — warm off-white, never pure white. Pure white on a phone at night
+   is harsh, and the warmth is most of what reads as "designed". */
+--bg:             #f7f5ff;
+--surface:        #ffffff;
+--surface-sunken: #efebfa;
+--border:         #e4dff5;
+
+/* Ink — near-black, never #000. Pure black on white is a harsh, cheap contrast. */
+--ink:        #1c1830;
+--ink-muted:  #6b6580;
+--ink-subtle: #9a94ad;
+
+/* Brand */
+--brand:       #6d3bf5;
+--brand-hover: #5c2fe0;
+--brand-wash:  #ede7ff;
+--on-brand:    #ffffff;
+
+/* Status */
+--success:      #12a06a;
+--success-wash: #dff5eb;
+--warning:      #e8890c;
+--warning-wash: #fdf0dc;
+--danger:       #d93a4a;
+--danger-wash:  #fce4e6;
+
+/* Per-kid identity. Each kid keeps their colour on every screen — avatar ring,
+   card accent, progress fill — so the app feels like it knows them. Assign by
+   stable order of the people list, not at random. */
+--kid-1: #0ea5a5;  /* teal */
+--kid-2: #f0873a;  /* amber */
+--kid-3: #d356a8;  /* pink */
+--kid-4: #3b82f6;  /* blue */
+```
+
+### Type
+
+```css
+--font: ui-rounded, "SF Pro Rounded", "Nunito", "Segoe UI Variable Display",
+        system-ui, -apple-system, sans-serif;
+
+--text-xs:   0.75rem;   /* 12px — timestamps, meta only */
+--text-sm:   0.875rem;  /* 14px — secondary text */
+--text-base: 1rem;      /* 16px — body. Never smaller for anything a kid reads */
+--text-lg:   1.125rem;  /* 18px — card titles */
+--text-xl:   1.5rem;    /* 24px — screen titles */
+--text-2xl:  2rem;      /* 32px — section heroes */
+--text-3xl:  2.75rem;   /* 44px — points, the big number */
+
+--weight-normal: 450;
+--weight-medium: 600;
+--weight-bold:   750;
+
+--leading-tight: 1.15;  /* headings and big numbers */
+--leading-base:  1.45;  /* body */
+```
+
+A rounded face is the single biggest lever on "kids app" versus "web form".
+`ui-rounded` gets SF Pro Rounded free on iOS, which is where the kids will use
+it. **No web font downloads** — no build step, and it must work offline.
+
+### Spacing
+
+4px base. Only these values.
+
+```css
+--space-1: 0.25rem;  /*  4px */
+--space-2: 0.5rem;   /*  8px */
+--space-3: 0.75rem;  /* 12px */
+--space-4: 1rem;     /* 16px */
+--space-5: 1.5rem;   /* 24px */
+--space-6: 2rem;     /* 32px */
+--space-7: 3rem;     /* 48px */
+```
+
+Generosity is most of what separates premium from cramped. When unsure, go one
+step larger.
+
+### Radius
+
+```css
+--radius-sm:   0.5rem;   /*  8px — chips, small controls */
+--radius-md:   0.875rem; /* 14px — inputs, small cards */
+--radius-lg:   1.375rem; /* 22px — cards, sheets */
+--radius-full: 999px;    /* buttons, avatars, pills */
+```
+
+Generous radii read friendly. Fully-rounded primary buttons are a deliberate
+choice — it is what separates a kids app from an admin panel.
+
+### Elevation
+
+Layering, not outlines. A card should feel like an object sitting on the
+background, not a rectangle drawn on it.
+
+```css
+--shadow-1: 0 1px 2px rgba(28,24,48,.05), 0 2px 6px rgba(28,24,48,.07);
+--shadow-2: 0 4px 12px rgba(28,24,48,.10);
+--shadow-3: 0 12px 28px rgba(28,24,48,.16);
+```
+
+`--shadow-1` for resting cards, `--shadow-2` for the tab bar and anything
+floating, `--shadow-3` for modals. Never a shadow on a long scrolling list —
+it costs paint time on cheap Android.
+
+### Motion
+
+```css
+--dur-fast: 120ms;  /* press states, tap feedback */
+--dur-base: 220ms;  /* view transitions, card entry */
+--dur-slow: 380ms;  /* celebrations */
+
+--ease-out:    cubic-bezier(0.22, 1, 0.36, 1);      /* almost everything */
+--ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);   /* celebration only — overshoots */
+```
+
+Animate `transform` and `opacity` only. Anything else causes layout work on
+every frame and stutters on a cheap phone.
+
+Every decorative animation sits behind:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+---
+
+## Components
+
+### App shell
+
+- `body { overflow: hidden }`. The page never scrolls — a `<main>` region does,
+  with `overscroll-behavior: contain`.
+- Header: fixed, `--surface`, `--shadow-1` only once content scrolls beneath it.
+  Respects `env(safe-area-inset-top)`.
+- Tab bar: fixed bottom, `--surface`, `--shadow-2`, height `4rem` plus
+  `env(safe-area-inset-bottom)`. Icon above a `--text-xs` label. Active tab in
+  `--brand`, inactive in `--ink-subtle`.
+- View transition: the outgoing view fades to 0 and the incoming fades in with
+  `translateY(8px) → 0`, `--dur-base`, `--ease-out`.
+
+### Cards
+
+`--surface`, `--radius-lg`, `--shadow-1`, padding `--space-4`, gap `--space-3`
+between cards. A kid's card carries a 4px left accent bar or an avatar ring in
+their `--kid-*` colour.
+
+### Buttons
+
+- Primary: `--brand` fill, `--on-brand` text, `--radius-full`, min-height
+  `3.25rem`, `--weight-medium`, `--text-base`.
+- Secondary: `--brand-wash` fill, `--brand` text, same geometry.
+- Destructive: `--danger-wash` fill, `--danger` text.
+- Every button: `touch-action: manipulation` (kills the 300ms tap delay) and a
+  pressed state of `transform: scale(0.97)` over `--dur-fast`. **Every tap gets
+  a response before the network does.**
+- Minimum target 44px in every direction, including icon-only buttons.
+
+### The points number
+
+`--text-3xl`, `--weight-bold`, `font-variant-numeric: tabular-nums` so it does
+not jitter while counting. When points change it **counts up** over `--dur-slow`
+rather than snapping. This is the single most rewarding moment in the app for a
+kid — it is worth the code.
+
+### Progress
+
+Rings or bars filled in the kid's colour, with the number inside or beside it.
+Never a bare number where progress toward something is the point. Kids respond
+to a visibly filling shape far more than to a figure.
+
+### Completing a chore
+
+The moment that has to feel good:
+
+1. Instant press feedback (`scale(0.97)`).
+2. **Optimistic update** — the card moves to its done state immediately, before
+   the API responds, and reverts with a message if the call fails. Waiting on a
+   round trip is the single biggest "this is a website" tell.
+3. The card animates out: `translateX(12px)` and fade, `--dur-base`.
+4. Points count up.
+5. `navigator.vibrate(12)` where supported, unless the household is in quiet
+   hours or has muted feedback.
+
+### Empty states
+
+Never a blank area or a bare sentence. A large emoji or inline SVG, a
+`--text-lg` line in `--ink`, a `--text-sm` line in `--ink-muted` saying what to
+do next. "No chores today 🎉" should read as good news, because it is.
+
+### Loading
+
+Skeleton blocks in `--surface-sunken` at the final layout's dimensions. Never a
+spinner on a full screen, and never a blank flash followed by content jumping in.
+
+---
+
+## Parent HQ
+
+Same tokens, different register:
+
+- `--text-base` and `--text-lg` rather than `--text-2xl` and above
+- `--radius-md` rather than `--radius-lg`
+- `--shadow-1` only
+- Density over generosity — a parent scanning approvals wants to see more at once
+- **No celebration animations.** Approving is administration, not achievement.
+
+---
+
+## What this does not cover
+
+Dark mode, theming, and any per-household customisation. Deliberately out of
+scope until someone asks for it; adding a second palette before the first is
+proven doubles the work of every screen.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -250,6 +250,81 @@ Same tokens, different register:
 
 ---
 
+## Reference patterns
+
+Taken from published kids/lifestyle app design that reads as premium. These are
+**layout and interaction patterns to reuse**, not palettes to copy.
+
+### The curved hero sheet
+
+The strongest "app, not web page" device available, and the one worth taking
+first. A coloured or illustrated hero band across the top, with the white
+content surface curving up over it — a large `border-radius` on the top corners
+of the content sheet, pulled up so it overlaps the hero by `--space-5` or so. An
+avatar or icon badge straddles the join, centred.
+
+Use it on the kid home screen (their avatar, their colour as the hero) and on a
+single reward's detail. Not in Parent HQ.
+
+### A persistent points chip
+
+Points balance lives as a pill in the header on every kid screen — icon plus
+`tabular-nums` figure, `--radius-full`, on `--brand-wash`. Always visible means
+always motivating, and it gives the count-up animation somewhere fixed to happen.
+
+### Tile grid, not a list
+
+For a kid's top-level choices, a two-column grid of large square-ish tiles —
+big emoji or inline SVG, a `--text-lg` label, a `--text-sm` sub-label, each on
+`--surface` with `--radius-lg` and `--shadow-1`. Lists read as admin; tiles read
+as an app and are far easier to hit.
+
+Parent HQ stays list-based — density matters more there.
+
+### Goal progress with the numbers
+
+Reward progress as a full-width bar, `--radius-full`, filled in the kid's colour
+(a subtle gradient toward `--brand` is fine), with `earned / target` stated
+underneath in `--text-sm`. Seeing "$3,856 / $5,000" alongside the bar is what
+makes it feel like progress rather than decoration. Same for points toward a
+reward.
+
+### Choice pills
+
+Where a kid picks between a few options, use a row of pills with one active —
+`--radius-full`, inactive on `--surface-sunken` with `--ink-muted`, active on
+the kid's colour with white text. Better than a dropdown for a child, and better
+than radio buttons for a thumb.
+
+### Soft gradients on primary surfaces
+
+The hero band and the primary action can carry a gentle gradient between two
+adjacent hues rather than a flat fill. Restraint is the whole trick: two stops,
+low contrast between them. A gradient on every card looks cheap; one on the hero
+looks considered.
+
+### What we cannot take from these references
+
+**They are carried by custom illustration** — hand-drawn scenes, 3D character
+renders, bespoke iconography. We have no build step, no asset pipeline and no
+illustrator, so promising that would specify something unbuildable.
+
+Substitute deliberately, and it still works:
+
+- **Large emoji as hero art.** At `--text-3xl` and above, on a gradient band, an
+  emoji reads as intentional rather than lazy — and it is free, instant, offline
+  and accessible.
+- **Inline SVG for shapes** — progress rings, badges, simple decorative blobs.
+  Small, themeable with `currentColor`, no request.
+- **Colour and gradient do the work** illustration would otherwise do.
+- **The kid's own avatar and colour** carry identity in place of a character.
+
+Judged against these references the result will be plainer. It should not be
+less consistent, less generous with space, or less rewarding to use — and those
+are the parts that actually read as premium.
+
+---
+
 ## What this does not cover
 
 Dark mode, theming, and any per-household customisation. Deliberately out of

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -250,6 +250,44 @@ Same tokens, different register:
 
 ---
 
+## The one thing that separates an app from a web page
+
+**Everything is an object.**
+
+A web page is text with links and thin borders. An app is a set of chunky,
+obviously-tappable shapes. Look at any kids app that feels right and the pattern
+is the same: no bare text links, no 1px rules, no dense paragraphs, nothing small
+enough to doubt whether you can press it.
+
+Concretely, in this app:
+
+- **No text-only actions.** Anything tappable is a filled pill, a card, or a
+  round icon button. If it does something, it looks like it does something.
+- **No thin borders as the main definition of a shape.** Use surface colour,
+  radius and `--shadow-1`. A border is for a subtle divider, not for drawing a
+  control.
+- **Coloured chrome, light content.** A brand-coloured header band and a
+  bottom tab bar, with the scrolling content on `--bg` between them. That
+  sandwich is most of the effect on its own, before any other polish.
+- **Nothing important below `--text-base`.** `--text-xs` is for timestamps and
+  meta, never for something a kid needs to read or act on.
+- **Round icon buttons in the tab bar**, at least 44px, well spaced. Icons alone
+  are fine there; everywhere else an icon needs a label.
+
+### Calibrating the age
+
+Much published kids design is aimed at pre-schoolers — heavy cartoon characters,
+very saturated primaries, everything bouncing. Toby and Ollie are past that, and
+Peter uses the same app.
+
+Take the **object-ness** from that style — the chunk, the generous hit areas,
+the confident colour, the visible reward. Leave the toddler cues: no mascot, no
+comic outlines, no rainbow of unrelated hues on one screen. The palette above is
+deliberately one confident brand colour plus per-kid accents, not six primaries.
+
+The test: it should look like something a ten-year-old would be happy to open in
+front of a friend.
+
 ## Reference patterns
 
 Taken from published kids/lifestyle app design that reads as premium. These are

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -309,6 +309,21 @@ Until both exist the deploy jobs **skip with a notice** rather than failing —
 merges are never blocked by missing credentials, the live app just doesn't
 change.
 
+## Design
+
+[`design-system.md`](design-system.md) holds the visual language — the actual
+colour, type, spacing, radius, elevation and motion values, plus component specs
+for the shell, cards, buttons, the points number, celebrations, empty states and
+Parent HQ.
+
+It exists because "make it feel premium" is an adjective, not a specification.
+An agent implements a defined thing well and invents a design poorly, so the
+values are written down and the work becomes implementation. The Elaborator
+reads it on every run and must ground frontend acceptance criteria in it.
+
+`scripts/check-design.js` enforces the mechanical half in CI. It cannot judge
+taste — that is what the written component specs are for.
+
 ## Setting up the agents (one-time)
 
 1. *Elaborator — one-time setup* (Actions tab) — creates the environment,

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -37,7 +37,9 @@ never close issues.
 Work in this order:
 
 1. Read the issue and its comments using the GitHub tools. Also read
-   docs/mvp-scope-v1.md in the mounted repository for product rules.
+   docs/mvp-scope-v1.md in the mounted repository for product rules, and
+   docs/design-system.md for the visual language - its tokens and component
+   specs are the actual values to build from, not suggestions.
 
 2. AUDIT THE CODE FIRST. The repository is mounted read-only in your sandbox.
    Backlog items are written at a point in time and the app moves on, so an
@@ -67,10 +69,11 @@ Work in this order:
    - place the work inside the existing view and navigation structure - a new
      screen reached by navigation, or an addition to a screen that already
      exists. Never "add a section to index.html";
-   - name the real design tokens and conventions you found while auditing (the
-     CSS custom properties for colour, spacing, type and radius; the card and
-     button classes; how a kid's colour and avatar are applied) and require the
-     new work to use them rather than introduce its own values;
+   - name the real design tokens and conventions from docs/design-system.md and
+     from what you found while auditing (the CSS custom properties for colour,
+     spacing, type and radius; the card and button classes; how a kid's colour
+     and avatar are applied) and require the new work to use them rather than
+     introduce its own values;
    - keep the register right: playful and generous on kid screens, calm and
      efficient in Parent HQ;
    - preserve the app-like behaviour that already exists - the content region


### PR DESCRIPTION
#67 asked an agent to "make it feel premium". That's an adjective, not a specification — and it would have produced something competent and generic no matter what reviewed it afterwards. Copilot implements a defined thing well and invents a design poorly.

So the design is now specified.

## `docs/design-system.md`

The actual values, not a starting point:

- **Colour** — warm off-white surfaces (never pure white, which is harsh on a phone at night and is most of what reads as *not designed*), near-black ink (never `#000`), a violet brand, status colours with washes, and four per-kid identity colours so Toby and Ollie keep their colour on every screen.
- **Type** — a rounded system stack (`ui-rounded` gets SF Pro Rounded free on iOS, which is where the kids will use it), a seven-step scale, three weights. No web font downloads: no build step, must work offline.
- **Spacing** — 4px base, seven steps. Generosity is most of what separates premium from cramped.
- **Radius** — up to 22px on cards, fully-rounded primary buttons. That choice is what separates a kids app from an admin panel.
- **Elevation** — a three-step shadow ramp, so cards feel like objects rather than rectangles drawn on the background. Explicitly none on long scrolling lists, because it costs paint time on cheap Android.
- **Motion** — three durations, two curves (one that overshoots, for celebrations only), `transform`/`opacity` only, all of it behind `prefers-reduced-motion`.

Then component specs for the shell, cards, buttons, the points number, **what completing a chore should feel like** step by step, progress, empty states and loading.

## Two things worth calling out

**Parent HQ gets its own register.** Same tokens, but denser, quieter, smaller radii, and no celebration animations — approving a chore is administration, not achievement. A parent screen covered in confetti reads as unserious, and Peter is the one using it.

**The document is honest about what it can't do.** `check-design.js` enforces the mechanical half in CI. Taste isn't checkable — that's what the written component specs are for, and why they're specific ("points count up over `--dur-slow` rather than snapping") rather than aspirational.

## Reaching every issue, not just #67

The Elaborator now reads `docs/design-system.md` alongside `docs/mvp-scope-v1.md` on every run, and must ground frontend acceptance criteria in it. That's the mechanism that stops the values living in one issue body and dying there.

**Needs the Elaborator setup workflow re-run after merge** — the live persona is the `SYSTEM_PROMPT`, so editing the file doesn't change the running agent.

## Testing

`ast.parse` on the modified Python. The document is prose and CSS values; the real test is the first elaboration that cites it, and then whether the built result looks like the spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_