### PR TITLE
Point Copilot's repo instructions at the design system

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,8 +35,29 @@ Raw speech-to-text is not sufficient. Any voice-capture feature must:
    rather than silently saving a guess
 
 ## Kid-friendly UX
-Simple, large, readable UI. Minimal taps to do anything. Both platforms
-(Android and iOS) via installable PWA, not native apps.
+**Read `docs/design-system.md` before writing any frontend code.** It holds the
+actual colour, type, spacing, radius, elevation and motion values, plus
+component specs. They are the values to use, not suggestions — do not introduce
+your own.
+
+The rules that matter most, in short:
+
+- **Everything is an object.** No text-only actions, no thin borders defining a
+  control. Filled pills, cards and round icon buttons. If it does something, it
+  looks like it does something.
+- **Extend the app shell; never append a section to the page.** New work belongs
+  in a view reached by navigation, not stacked at the bottom of `index.html`.
+- **Use the tokens.** Every colour, size, radius, shadow and duration comes from
+  the `:root` block. `scripts/check-design.js` fails the build on raw values.
+- **Respond before the network does.** Every tap gets an immediate pressed state,
+  and actions update the UI optimistically rather than waiting on the API.
+- **Kid views are playful, Parent HQ is calm.** Same tokens, different register.
+  No celebration animations on parent screens.
+- **No external requests** for fonts, icons or images. Inline SVG or emoji.
+- **Skip decorative motion** under `prefers-reduced-motion`.
+
+Minimal taps to do anything. Both platforms (Android and iOS) via installable
+PWA, not native apps.
 
 ## Agent workflow
 See `docs/agents.md` for the five-agent model. In practice:

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -12,6 +12,19 @@ poorly. This turns the work into implementation.
 [`pipeline.md`](pipeline.md)). It cannot judge taste — that is what the
 component specs below are for.
 
+**How this reaches work that has not been written yet.** Three routes, so it
+survives issues added long after this was written:
+
+1. The **Elaborator** reads this file on every run and must ground frontend
+   acceptance criteria in it, so specs cite real tokens rather than adjectives.
+2. **`.github/copilot-instructions.md`** points here, and Copilot reads that on
+   every task in this repository — including issues that skip elaboration
+   entirely.
+3. **`check-design.js`** fails the build on raw values, external asset requests
+   and content added outside the view structure, whatever route the code took.
+
+The first two guide; only the third can stop a merge.
+
 ---
 
 ## Principles


### PR DESCRIPTION
Closes the last gap in making the design guidance stick for work that doesn't exist yet.

## The gap

`.github/copilot-instructions.md` is what Copilot reads on **every task in this repository**, whatever route the issue took. Its UX section said:

> Simple, large, readable UI. Minimal taps to do anything.

Which is exactly the kind of adjective `docs/design-system.md` exists to replace. So the one file Copilot always reads was the weakest guidance in the repo — and it's the only guidance reaching an issue labelled `build` directly, without elaboration.

## Fix

It now points at the design system and carries the rules that matter most in short form:

- Everything is an object — no text-only actions, no thin borders defining controls
- Extend the app shell; never append a section to the page
- Use the tokens; `check-design.js` fails the build on raw values
- Respond before the network does — pressed states and optimistic updates
- Kid views playful, Parent HQ calm, no celebrations on parent screens
- No external requests for fonts, icons or images
- Skip decorative motion under `prefers-reduced-motion`

## Three routes, and which one actually holds

Also recorded in `design-system.md`, because it's worth being clear-eyed about:

1. **The Elaborator** reads it every run and must ground frontend criteria in it — covers anything elaborated, including issues added months from now
2. **Copilot's repo instructions** — covers every Copilot task, including ones that skip elaboration
3. **`check-design.js`** — fails the build on raw values, external requests and content outside the view structure, whatever route the code took

The first two guide. Only the third can stop a merge. Stated that way in the doc so nobody mistakes guidance for enforcement.

## Testing

Markdown only, no code or workflow changes. The real test is the first Copilot task after #67 lands — whether the code it writes uses the tokens without being told to in the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_