### PR TITLE
Stop duplicating the design system, and drop a point-in-time count

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,26 +35,17 @@ Raw speech-to-text is not sufficient. Any voice-capture feature must:
    rather than silently saving a guess
 
 ## Kid-friendly UX
-**Read `docs/design-system.md` before writing any frontend code.** It holds the
-actual colour, type, spacing, radius, elevation and motion values, plus
-component specs. They are the values to use, not suggestions — do not introduce
-your own.
+**`docs/design-system.md` is the specification for anything visual. Read it
+before writing frontend code, and take its values as given rather than
+inventing your own.** Deliberately not restated here — one source of truth, so
+this file cannot drift out of step with it.
 
-The rules that matter most, in short:
+Two things that must hold even if nothing else is read:
 
-- **Everything is an object.** No text-only actions, no thin borders defining a
-  control. Filled pills, cards and round icon buttons. If it does something, it
-  looks like it does something.
 - **Extend the app shell; never append a section to the page.** New work belongs
   in a view reached by navigation, not stacked at the bottom of `index.html`.
-- **Use the tokens.** Every colour, size, radius, shadow and duration comes from
-  the `:root` block. `scripts/check-design.js` fails the build on raw values.
-- **Respond before the network does.** Every tap gets an immediate pressed state,
-  and actions update the UI optimistically rather than waiting on the API.
-- **Kid views are playful, Parent HQ is calm.** Same tokens, different register.
-  No celebration animations on parent screens.
-- **No external requests** for fonts, icons or images. Inline SVG or emoji.
-- **Skip decorative motion** under `prefers-reduced-motion`.
+- **Use the tokens.** `scripts/check-design.js` fails the build on raw colours
+  and sizes, so inventing values does not merge anyway.
 
 Minimal taps to do anything. Both platforms (Android and iOS) via installable
 PWA, not native apps.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -19,7 +19,8 @@ survives issues added long after this was written:
    acceptance criteria in it, so specs cite real tokens rather than adjectives.
 2. **`.github/copilot-instructions.md`** points here, and Copilot reads that on
    every task in this repository — including issues that skip elaboration
-   entirely.
+   entirely. It points rather than restates, deliberately: a summary kept in two
+   places drifts, and this file is the one that should win.
 3. **`check-design.js`** fails the build on raw values, external asset requests
    and content added outside the view structure, whatever route the code took.
 

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -62,8 +62,8 @@ Work in this order:
    The frontend is a single file, frontend/index.html, and the whole backlog
    edits it. Left unguided, each feature appends another section to the bottom
    and the app degrades into a long scrolling page - which is exactly what
-   issue #67 exists to fix, and what thirteen subsequent issues would quietly
-   undo.
+   issue #67 exists to fix, and what every feature built afterwards would
+   otherwise erode.
 
    So whenever a sub-issue touches the frontend, its acceptance criteria MUST:
    - place the work inside the existing view and navigation structure - a new


### PR DESCRIPTION
Two things Peter caught, both about documents aging badly.

## 1. A backlog count in the Elaborator persona

The rule I added in #68 said "thirteen subsequent issues would quietly undo". True this morning, wrong next week. A persona is read on every future run, so a snapshot of the backlog in it reads as stale the moment the backlog moves — the same problem the audit rule had before it was reworded earlier.

Now "every feature built afterwards", which says the same thing and stays true. #67's body had the same issue and has been reworded too.

## 2. `copilot-instructions.md` restated the design system

I'd copied seven design rules into it rather than pointing at `docs/design-system.md`. That guarantees drift the first time the design system changes — and the instructions file is read on every task, so the stale copy would be the one that wins.

Now it points, and keeps only the two rules that must hold even if the linked file is never opened:

- extend the shell; never append a section to the page
- use the tokens — which CI enforces regardless, so inventing values doesn't merge anyway

## The three artefacts, and why all three exist

Worth stating since the overlap prompted the question:

| | Job |
|---|---|
| `docs/design-system.md` | The **specification** — one source of truth for anything visual |
| #67 | The **task** — build it once, then it closes |
| `.github/copilot-instructions.md` | The **standing rule** — read on every task forever, so later work doesn't drift |

Build the house to the plan, and everyone who works on it afterwards follows the same plan. Only the duplicated *content* was redundant, not the third artefact.

## Testing

`ast.parse` on the modified Python. Documentation and persona text otherwise. **Needs the Elaborator setup workflow re-run after merge** for the persona change to reach the live agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_