### PR TITLE
Give the build queue a failure backstop, and stop a blip failing the run

### DIFF
--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -19,11 +19,20 @@ name: Build queue
 #   - a pull request closed/merged -> whatever depended on it may be unblocked
 #   - an issue closed              -> same
 #
-# There is no schedule. There used to be, because auto-merge.yml merged via the
-# built-in GITHUB_TOKEN and GitHub raises no workflow events for that token - an
-# auto-merged PR fired no 'pull_request: closed' here, so only a clock could
-# advance the queue. The merge job now uses a real token, the events fire, and
-# the queue moves the moment something unblocks.
+# The half-hourly schedule is a FAILURE BACKSTOP, not polling.
+#
+# Events cover the happy path: the merge job uses a real token now, so a merged
+# pull request raises its events and the queue moves the moment something
+# unblocks. The five-minute sweeps that used to paper over that are gone.
+#
+# But events only fire when something CHANGES. Nothing fires when a run FAILS.
+# That gap is not hypothetical: this workflow failed to assign #73 because the
+# account's API rate limit was exhausted, and with no schedule at all nothing
+# retried - the whole build stalled silently until a human noticed.
+#
+# So: half-hourly, purely so a transient failure heals itself. Rare enough not
+# to be the noise the old sweeps were, frequent enough that nobody has to spot
+# a stall.
 #
 # MAX_PER_RUN caps how many start at once, and it is 1 deliberately.
 #
@@ -40,6 +49,8 @@ on:
     types: [labeled, closed]
   pull_request:
     types: [closed]
+  schedule:
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -164,12 +175,17 @@ jobs:
               }' -f owner="$OWNER" -f repo="$REPO" -F num="$NUM" \
               --jq '.data.repository.issue.id')
 
-            gh api graphql -f query='
+            if ERR=$(gh api graphql -f query='
               mutation($assignable:ID!, $actor:ID!) {
                 replaceActorsForAssignable(input:{assignableId:$assignable, actorIds:[$actor]}) {
                   assignable { ... on Issue { number } }
                 }
-              }' -f assignable="$ISSUE_ID" -f actor="$BOT_ID"
-
-            echo "Copilot assigned to #${NUM}"
+              }' -f assignable="$ISSUE_ID" -f actor="$BOT_ID" 2>&1); then
+              echo "Copilot assigned to #${NUM}"
+            else
+              # Do not fail the run. The issue keeps its 'build' label and stays
+              # unassigned, so the next pass picks it up again - which is what
+              # makes a rate limit or a blip self-healing rather than a stall.
+              echo "::warning::could not assign Copilot to #${NUM}, will retry next pass: ${ERR}"
+            fi
           done


### PR DESCRIPTION
Removing every schedule in #59 was an over-correction, and it bit within the hour.

## What happened

The build queue failed to assign Copilot to #73:

```
gh: API rate limit already exceeded for user ID 52588220
```

(My fault — I burned the account's quota polling for status.)

With no schedule on this workflow, **nothing retried.** The whole app-shell build stalled silently: #73 kept its `build` label, stayed unassigned, and no event was ever going to fire to make anyone look again. It was only spotted by chance.

## The reasoning error

#59 argued that events cover everything once merges use a real token. That's true for the happy path — a merged PR raises its events and the queue moves immediately.

But **events only fire when something CHANGES. Nothing fires when a run FAILS.** A failed run is not an event anyone can subscribe to, so with no clock at all there is no path back to healthy.

## Fix

- **Half-hourly schedule**, purely as a failure backstop. Rare enough not to be the noise the old five-minute sweeps were, frequent enough that nobody has to notice a stall.
- **A failed assignment is now a warning, not a failed run.** The issue keeps its `build` label and stays unassigned, so the next pass picks it up. That's what turns a rate limit or a transient blip into something self-healing rather than a dead stop.

Both matter: the schedule gives it another chance, and not-failing-hard means there's something sensible for that chance to find.

## Testing

`yaml.safe_load` on the workflow, `bash -n` on the modified `run:` block. The behaviour is only observable on a real failure — but the failure mode is now "warns and retries in 30 minutes" rather than "stops forever", which is the direction that matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_