### PR TITLE
Wake auto-merge on CI completing, not on a cron GitHub throttles

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,15 +4,27 @@ name: Auto-merge agent PRs
 # auto-merge, so they merge themselves once CI is green. Human-authored pull
 # requests are untouched - you merge those yourself.
 #
-# Why this polls rather than reacting to an event:
+# What wakes this up:
 #   Copilot opens its pull request as a DRAFT and then works for several
-#   minutes. It never fires 'ready_for_review' - it just renames the title from
-#   "[WIP] ..." to the final title and stops. So there is no event meaning
-#   "finished", and acting on 'opened' would mark half-written work ready and
-#   merge it.
+#   minutes. It never fires 'ready_for_review' by itself - it just renames the
+#   title from "[WIP] ..." to the final title and stops. So there is no event
+#   meaning "finished", and acting on 'opened' would mark half-written work
+#   ready and merge it.
 #
-# The finished signal used here: authored by Copilot, still a draft, and the
-# title no longer starts with "[WIP]".
+#   The finished signal used here: authored by Copilot and the title no longer
+#   starts with "[WIP]".
+#
+#   The primary trigger is CI completing (workflow_run below). That is the
+#   moment the merge gate could newly pass, and by then Copilot has finished
+#   working and renamed the title - it renames when it stops, while CI is still
+#   running on its last push. Reacting to it takes the decision from tens of
+#   minutes to seconds.
+#
+#   The cron is now only a backstop, and it is worth being honest about what it
+#   actually does. It is written "*/5" but GitHub does not honour that: the
+#   observed gaps between scheduled runs on this repository were 22, 23, 26,
+#   31, 32, 36, 41, 44 and 48 minutes. High-frequency crons are throttled.
+#   Anything that has to happen promptly cannot be hung off it.
 #
 # This does NOT use GitHub's --auto. That merges as soon as the *required*
 # checks pass, and this repository has no branch protection, so nothing is
@@ -28,6 +40,14 @@ name: Auto-merge agent PRs
 # To stop one merging, put it back to draft.
 
 on:
+  # The real trigger: CI has just concluded on some commit, so a pull request
+  # that was waiting on it may now be mergeable. Fires for CI runs on main too,
+  # which is harmless - the job re-reads the whole candidate list every time and
+  # does nothing when there is nothing waiting.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  # Backstop only. See the note above about how rarely this actually fires.
   schedule:
     - cron: "*/5 * * * *"
   # Fires when you mark something ready by hand, and on events raised by your
@@ -64,18 +84,24 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Open pull requests authored by Copilot that look finished: still a
-          # draft, and no longer titled "[WIP] ...".
+          # Open pull requests authored by Copilot that look finished: no longer
+          # titled "[WIP] ...".
+          #
+          # Draft state is deliberately NOT part of this filter. It used to
+          # require draft == true, which meant a pull request that had been
+          # marked ready - by hand, or by an earlier pass of this workflow that
+          # then found CI still running - dropped out of the candidate set for
+          # good and needed a human to merge it. Whether it is a draft says
+          # nothing about whether Copilot has finished; the title does.
           CANDIDATES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
             --jq '[.[]
                    | select(.user.login == "Copilot" or (.user.login | endswith("[bot]")))
-                   | select(.draft == true)
                    | select(.title | startswith("[WIP]") | not)
                    | {number, title}]' 2>/dev/null || echo '[]')
 
           COUNT=$(echo "$CANDIDATES" | jq 'length')
           if [ "$COUNT" -eq 0 ]; then
-            echo "No finished Copilot drafts waiting."
+            echo "No finished Copilot pull requests waiting."
           else
             echo "Found ${COUNT}:"
             echo "$CANDIDATES" | jq -r '.[] | "  #\(.number)  \(.title)"'

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -229,9 +229,21 @@ disabled, so it hard-stops rather than billing you.
 - **Copilot opens its PRs as drafts** and works for several minutes, then just
   renames the title from `[WIP] …` and stops. It never fires a
   `ready_for_review` event, so there is no "finished" signal to react to.
-  `auto-merge.yml` therefore polls every 5 minutes for Copilot drafts whose
-  title has lost its `[WIP]` prefix, marks those ready and enables auto-merge.
   Acting on `opened` instead would mark half-written work ready and merge it.
+  `auto-merge.yml` looks for Copilot PRs whose title has lost its `[WIP]`
+  prefix, marks them ready and merges them once CI is green.
+
+  It is woken by **CI completing** (`workflow_run`), which is the moment the
+  merge gate could newly pass — and by then Copilot has finished and renamed
+  the title, because it renames when it stops working while CI is still running
+  on its last push. A cron still runs as a backstop, but nothing depends on it;
+  see the throttling note below.
+
+  Draft state is **not** part of the filter. It used to require `draft == true`,
+  which meant any PR already marked ready — by hand, or by an earlier pass that
+  found CI still running — fell out of the candidate set permanently and needed
+  a human. Whether it is a draft says nothing about whether Copilot has
+  finished; the title does.
 - **CI** (`ci.yml`) runs `node api/test-logic.js`, a frontend parse check and a
   workflow-YAML check on every PR. **This is the only automatic check that can
   stop a change reaching the app** — and making that actually true took two
@@ -282,12 +294,30 @@ write), so its merges raise events like anyone else's, and every sweep on
 `deploy.yml`, `build-queue.yml`, `elaborate.yml` and `architect.yml` was
 deleted. Work now moves the instant something unblocks it.
 
-**One timer remains, and it is irreducible:**
+**One timer remains, and it is now only a backstop:**
 
 | Workflow | Why it cannot be an event |
 |---|---|
-| `auto-merge.yml` (5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
+| `auto-merge.yml` (nominally 5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
 | ~~`approve-agent-workflows.yml`~~ | **Deleted.** It never worked — see below |
+
+### GitHub throttles high-frequency cron, so nothing urgent can hang off it
+
+`auto-merge.yml` is written `*/5 * * * *`. It does not run every five minutes.
+Measured gaps between consecutive scheduled runs on this repository, over one
+morning: **22, 23, 26, 31, 32, 36, 41, 44 and 48 minutes.** Not once did it fire
+on time.
+
+That was the whole reason auto-merge looked broken. It was not — it merged #82
+correctly — but on the cron path a finished PR could sit for the better part of
+an hour, which is long enough that a human watching the repo always merged it
+first. The pipeline looked manual because the automation was too slow to get a
+turn, not because it was failing.
+
+The lesson generalises: **GitHub's cron is a backstop, never a mechanism.**
+Anything that has to happen promptly must hang off an event. For auto-merge that
+event is `workflow_run` on CI completing. This is the same unreliability the
+fermenter project hit and worked around with an external scheduler.
 
 `deploy.yml` still keeps its own record of what is live — a git tag called
 **`deployed`** — and deploys everything changed *since that tag* rather than


### PR DESCRIPTION
Auto-merge was not broken — it merged #82 correctly. It was too slow to ever get a turn, so every merge looked manual.

## The measurement

The cron says `*/5`. GitHub does not honour it. Gaps between consecutive scheduled runs of `auto-merge.yml`, one morning:

**22, 23, 26, 31, 32, 36, 41, 44 and 48 minutes.** Not once on time.

A finished Copilot PR could therefore sit for the better part of an hour, which is long enough that a human watching the repo always merged it first. The pipeline looked manual because the automation could not get a turn, not because it was failing.

## The change

**Primary trigger is now `workflow_run` on CI completing.** That is the exact moment the merge gate could newly pass — and by then Copilot has finished and renamed the title, because it renames when it stops working while CI is still running on its last push. Tens of minutes becomes seconds. The cron stays as a backstop with nothing depending on it.

**Drops `draft == true` from the candidate filter.** A pull request already marked ready — by hand, or by an earlier pass of this workflow that found CI still running — fell out of the candidate set permanently and needed a human to merge it. Whether it is a draft says nothing about whether Copilot has finished; the title does.

## Verification

- Candidate `jq` filter exercised against representative PR shapes: picks up a finished draft and a finished non-draft, skips `[WIP]` and human-authored PRs.
- `.github/workflows/*.yml` all parse (the CI check).
- `scripts/check-frontend.js` and `scripts/check-design.js` both pass.

## Docs

`docs/pipeline.md` records the throttling measurement and the general rule it implies: **GitHub's cron is a backstop, never a mechanism.** Anything that has to happen promptly must hang off an event. This is the same unreliability the fermenter project hit and worked around with an external scheduler.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_