### PR TITLE
Fix the queue stalling after one issue, and stop counting runs as work

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -34,6 +34,13 @@ on:
         required: false
   issues:
     types: [labeled]
+  # Backstop. The label event and the self-dispatch below are what normally
+  # move the queue; this catches the cases where neither fires - a failed run,
+  # a dispatch that could not be made, or a label added while a run was already
+  # going. Without it a stall is permanent and silent, which is exactly what
+  # happened when thirteen issues were labelled at once.
+  schedule:
+    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -48,20 +55,41 @@ jobs:
   architect:
     if: >-
       github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule'
       || github.event.label.name == 'architect'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Runaway guard (max 80 runs per rolling 24h)
+      - name: Runaway guard (max 40 issues per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/architect.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
-          echo "Architect runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 80 ]; then
-            echo "::notice::Runaway ceiling of 80 architect runs reached. Labelled issues stay queued and resume once the window clears."
+          # Counts ISSUES WORKED, not workflow runs.
+          #
+          # This used to count runs, and that was wrong twice over. A run that
+          # is cancelled by the concurrency group, skipped by a guard, or that
+          # finds an empty queue costs nothing - but it counted the same as a
+          # real one. With a sweep on the clock the ceiling was reached within
+          # hours and then held forever, stalling the queue permanently. That
+          # is why the sweeps were deleted in #59; counting the right thing is
+          # what lets a backstop schedule exist again.
+          #
+          # What actually costs money is one issue being worked. The
+          # 'architected' label is applied exactly once per issue, so counting
+          # issues that carry it and were touched recently measures spend
+          # directly, and is immune to however often this workflow wakes up.
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%d)
+          COUNT=$(gh api "search/issues?q=repo:${GITHUB_REPOSITORY}+label:architected+updated:%3E%3D${SINCE}" \
+            --jq '.total_count // 0' 2>/dev/null || echo 0)
+
+          # Fail OPEN, never closed. A guard that cannot read its own number
+          # must not be the thing that stops the pipeline - that is the failure
+          # mode this whole change exists to remove.
+          case "$COUNT" in ''|*[!0-9]*) COUNT=0 ;; esac
+          echo "Issues architected in the last 24h: ${COUNT}"
+          if [ "${COUNT:-0}" -gt 40 ]; then
+            echo "::notice::Runaway ceiling of 40 issues reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -147,13 +175,28 @@ jobs:
           fi
 
       - name: Wake the next one straight away
-        # Optional speed-up; needs HEROTASK_GITHUB_TOKEN to carry Actions: Read
-        # and write. Failure here is fine - the 5-minute sweep is the backstop.
-        if: success() && steps.issue.outputs.remaining != '' && steps.issue.outputs.remaining != '0'
+        # Re-reads the queue rather than trusting the count taken at the START
+        # of this run. A run takes several minutes, and anything labelled
+        # during that window was invisible to that earlier count - so a queue
+        # of thirteen looked like a queue of one, this step was skipped, and
+        # the chain stopped dead after a single issue.
+        #
+        # Needs HEROTASK_GITHUB_TOKEN to carry Actions: Read and write - the
+        # built-in token cannot dispatch a workflow. Failure here is survivable
+        # now that the schedule above exists as a backstop.
+        if: success() && steps.issue.outputs.number != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
         run: |
+          LEFT=$(gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=architect&per_page=100" \
+            --jq '[.[] | select(.pull_request == null)] | length' 2>/dev/null || echo 0)
+
+          if [ "${LEFT:-0}" -eq 0 ]; then
+            echo "Queue empty - nothing left to wake."
+            exit 0
+          fi
+
           gh workflow run architect.yml --repo "$GITHUB_REPOSITORY" --ref main \
-            && echo "Dispatched the next drain (${{ steps.issue.outputs.remaining }} left)." \
-            || echo "::notice::Could not self-dispatch; the 5-minute sweep will take the next one."
+            && echo "Dispatched the next drain (${LEFT} left)." \
+            || echo "::notice::Could not self-dispatch; the backstop schedule will take the next one."

--- a/.github/workflows/elaborate.yml
+++ b/.github/workflows/elaborate.yml
@@ -40,6 +40,13 @@ on:
         required: false
   issues:
     types: [labeled]
+  # Backstop. The label event and the self-dispatch below are what normally
+  # move the queue; this catches the cases where neither fires - a failed run,
+  # a dispatch that could not be made, or a label added while a run was already
+  # going. Without it a stall is permanent and silent, which is exactly what
+  # happened when thirteen issues were labelled at once.
+  schedule:
+    - cron: "*/30 * * * *"
 
 permissions:
   actions: read
@@ -54,20 +61,41 @@ jobs:
   elaborate:
     if: >-
       github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule'
       || github.event.label.name == 'elaborate'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Runaway guard (max 80 runs per rolling 24h)
+      - name: Runaway guard (max 40 issues per rolling 24h)
         id: guard
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/elaborate.yml/runs?created=%3E%3D${SINCE}" --jq '.total_count')
-          echo "Elaborator runs in last 24h (including this one): ${COUNT}"
-          if [ "${COUNT}" -gt 80 ]; then
-            echo "::notice::Runaway ceiling of 80 elaborator runs reached. Labelled issues stay queued and resume once the window clears."
+          # Counts ISSUES WORKED, not workflow runs.
+          #
+          # This used to count runs, and that was wrong twice over. A run that
+          # is cancelled by the concurrency group, skipped by a guard, or that
+          # finds an empty queue costs nothing - but it counted the same as a
+          # real one. With a sweep on the clock the ceiling was reached within
+          # hours and then held forever, stalling the queue permanently. That
+          # is why the sweeps were deleted in #59; counting the right thing is
+          # what lets a backstop schedule exist again.
+          #
+          # What actually costs money is one issue being worked. The
+          # 'elaborated' label is applied exactly once per issue, so counting
+          # issues that carry it and were touched recently measures spend
+          # directly, and is immune to however often this workflow wakes up.
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%d)
+          COUNT=$(gh api "search/issues?q=repo:${GITHUB_REPOSITORY}+label:elaborated+updated:%3E%3D${SINCE}" \
+            --jq '.total_count // 0' 2>/dev/null || echo 0)
+
+          # Fail OPEN, never closed. A guard that cannot read its own number
+          # must not be the thing that stops the pipeline - that is the failure
+          # mode this whole change exists to remove.
+          case "$COUNT" in ''|*[!0-9]*) COUNT=0 ;; esac
+          echo "Issues elaborated in the last 24h: ${COUNT}"
+          if [ "${COUNT:-0}" -gt 40 ]; then
+            echo "::notice::Runaway ceiling of 40 issues reached. Labelled issues stay queued and resume once the window clears."
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -148,14 +176,28 @@ jobs:
             || echo "::warning::Could not remove 'elaborate' from #${{ steps.issue.outputs.number }} - it will be picked up again."
 
       - name: Wake the next one straight away
-        # Optional speed-up: without it the next item waits for the 5-minute
-        # sweep. Needs HEROTASK_GITHUB_TOKEN to carry Actions: Read and write -
-        # the built-in token cannot dispatch a workflow. Failure here is fine.
-        if: success() && steps.issue.outputs.remaining != '' && steps.issue.outputs.remaining != '0'
+        # Re-reads the queue rather than trusting the count taken at the START
+        # of this run. A run takes several minutes, and anything labelled
+        # during that window was invisible to that earlier count - so a queue
+        # of thirteen looked like a queue of one, this step was skipped, and
+        # the chain stopped dead after a single issue.
+        #
+        # Needs HEROTASK_GITHUB_TOKEN to carry Actions: Read and write - the
+        # built-in token cannot dispatch a workflow. Failure here is survivable
+        # now that the schedule above exists as a backstop.
+        if: success() && steps.issue.outputs.number != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
         run: |
+          LEFT=$(gh api "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=elaborate&per_page=100" \
+            --jq '[.[] | select(.pull_request == null)] | length' 2>/dev/null || echo 0)
+
+          if [ "${LEFT:-0}" -eq 0 ]; then
+            echo "Queue empty - nothing left to wake."
+            exit 0
+          fi
+
           gh workflow run elaborate.yml --repo "$GITHUB_REPOSITORY" --ref main \
-            && echo "Dispatched the next drain (${{ steps.issue.outputs.remaining }} left)." \
-            || echo "::notice::Could not self-dispatch; the 5-minute sweep will take the next one."
+            && echo "Dispatched the next drain (${LEFT} left)." \
+            || echo "::notice::Could not self-dispatch; the backstop schedule will take the next one."

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -301,6 +301,47 @@ deleted. Work now moves the instant something unblocks it.
 | `auto-merge.yml` (nominally 5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
 | ~~`approve-agent-workflows.yml`~~ | **Deleted.** It never worked — see below |
 
+### Never count workflow runs to measure work
+
+The elaborate/architect queues each had a "runaway guard" that counted workflow
+*runs* in a rolling 24 hours. That is the wrong number, and it caused two
+separate stalls.
+
+A run that is cancelled by the concurrency group, skipped by a guard, or that
+finds an empty queue costs nothing. Counting it the same as a real run means a
+sweep on a timer inflates the count until the ceiling is hit — and then the
+ceiling holds forever, because the sweeps keep counting. That is what happened
+in #59, and it is why every sweep was deleted rather than fixed.
+
+Both guards now count **issues that carry the `elaborated` / `architected`
+label and were updated in the last 24 hours**. That is a direct measure of what
+actually costs money — the label goes on exactly once per issue — and it is
+completely independent of how often the workflow wakes up. Counting the right
+thing is what allowed the backstop schedules to be restored.
+
+Both guards also **fail open**: if the count cannot be read, the run proceeds.
+A guard that cannot read its own number must never be the thing that stops the
+pipeline.
+
+### A count taken at the start of a run is stale by the end of it
+
+Each queue run picked the oldest labelled issue, recorded how many were left,
+and used that number at the end to decide whether to dispatch the next run.
+
+A run takes several minutes. Thirteen issues labelled over ninety seconds all
+arrived *after* the first run had already counted — so it believed the queue
+held one item, skipped the "wake the next one" step, and the chain stopped dead
+after a single issue. The label events for the other twelve were cancelled by
+the concurrency group, as designed, and nothing ever came back for them. The
+comment in the step said the five-minute sweep would catch it; that sweep had
+been deleted in #59, so nothing did.
+
+The wake step now **re-reads the queue at the end of the run** instead of
+trusting the earlier count.
+
+The general rule, which has now cost three separate stalls: **anything measured
+before a long-running step must be measured again after it.**
+
 ### GitHub throttles high-frequency cron, so nothing urgent can hang off it
 
 `auto-merge.yml` is written `*/5 * * * *`. It does not run every five minutes.


### PR DESCRIPTION
Labelling thirteen issues drained exactly one and then stopped silently. Two independent bugs.

## 1. A count taken at the start of a run was used at the end of it

Each run picks the oldest labelled issue, records how many are left, and uses that number to decide whether to dispatch the next run.

A run takes several minutes. The other twelve issues were labelled *during* those minutes, so they were invisible to the count taken beforehand — the run believed the queue held one item, skipped "wake the next one", and the chain died. The label events for the other twelve were cancelled by the concurrency group exactly as designed, and nothing ever came back for them.

**Fix:** the wake step re-reads the queue at the end of the run.

## 2. There was no backstop, and the code said there was

The step's own comment read *"the 5-minute sweep will take the next one"*. That sweep was deleted in #59. A missed dispatch was therefore permanent.

**Fix:** both workflows get a `*/30` schedule back — and the job condition now lets a `schedule` event through. Without that second part the cron would have fired and skipped every single time.

## Why restoring a schedule is safe now: the guard counts the right thing

The runaway guard counted workflow **runs**. That is what made sweeps self-defeating in #59 — a run cancelled by the concurrency group, skipped by a guard, or finding an empty queue costs nothing, but counted the same as a real one. The ceiling was reached in hours and then held forever.

Both guards now count **issues carrying `elaborated`/`architected` updated in the last 24h**. That is a direct measure of what costs money (the label goes on exactly once per issue) and is completely independent of how often the workflow wakes up.

They also **fail open**: if the count can't be read, the run proceeds. A guard that cannot read its own number must not be the thing that stops the pipeline.

## Verification

- All 11 workflow files parse (the CI check).
- Both files inspected post-patch: triggers, job conditions and the full step list are intact and identical across the two.
- `scripts/check-frontend.js`, `scripts/check-design.js` and `api/test-logic.js` all pass.
- The queue has been kicked by hand so work resumes without waiting for this to merge.

## Docs

`docs/pipeline.md` records both bugs and the rule they share: **anything measured before a long-running step must be measured again after it.** Plus the companion rule: never count workflow runs to measure work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_