### PR TITLE
Actually change Toby and Ollie's avatars, not just the seed

### DIFF
--- a/api/src/lib/seed.js
+++ b/api/src/lib/seed.js
@@ -11,6 +11,21 @@ const SEED_PEOPLE = [
   { id: 'ollie', name: 'Ollie', emoji: 'svg:quokka', pin: '1234', role: 'kid' },
 ];
 
+// One-time corrections to people who were seeded BEFORE a default changed.
+//
+// SEED_PEOPLE only applies when the household does not yet exist, so editing it
+// does nothing for a household already in the database - which is every real
+// one. #88 changed Toby and Ollie to custom SVG avatars and shipped green, but
+// the live app kept showing the old emoji because only the seed had moved.
+//
+// Each entry is applied only when the person still holds the exact value they
+// were originally seeded with. If a parent has since chosen something else,
+// `from` will not match and their choice is left alone.
+const AVATAR_MIGRATIONS = [
+  { id: 'toby', from: '\u{1F996}', to: 'svg:3d-printer' },
+  { id: 'ollie', from: '\u{1F98A}', to: 'svg:quokka' },
+];
+
 let seeded = false;
 
 // Runs once per warm Function instance (the `seeded` flag), and is itself idempotent
@@ -24,15 +39,39 @@ async function ensureSeeded() {
     .read()
     .catch(() => ({ resource: null }));
 
+  const people = container('people');
+
   if (!household) {
     await households.items.create({ id: HOUSEHOLD_ID, name: 'Our Household' });
-    const people = container('people');
     for (const p of SEED_PEOPLE) {
       await people.items.create({ ...p, householdId: HOUSEHOLD_ID });
     }
+  } else {
+    await applyAvatarMigrations(people);
   }
 
   seeded = true;
+}
+
+
+// Only touches a person whose avatar is still the value they were seeded with,
+// so a parent's own choice is never overwritten. Best-effort: a failure here
+// must not stop the app serving, so each one is caught individually.
+async function applyAvatarMigrations(people) {
+  for (const m of AVATAR_MIGRATIONS) {
+    try {
+      const { resource: person } = await people
+        .item(m.id, HOUSEHOLD_ID)
+        .read()
+        .catch(() => ({ resource: null }));
+
+      if (person && person.emoji === m.from) {
+        await people.item(m.id, HOUSEHOLD_ID).replace({ ...person, emoji: m.to });
+      }
+    } catch {
+      // Leave the old avatar in place rather than failing the request.
+    }
+  }
 }
 
 module.exports = { ensureSeeded, HOUSEHOLD_ID };


### PR DESCRIPTION
#88 shipped green and changed nothing visible.

It edited `SEED_PEOPLE`, but `ensureSeeded` only creates people when the household does not yet exist — and every real household already does. Toby and Ollie kept the 🦖 and 🦊 they were created with, so the live app looked untouched despite CI passing and the deploy succeeding.

## The fix

A one-time migration runs when the household is already present:

```js
const AVATAR_MIGRATIONS = [
  { id: 'toby',  from: '🦖', to: 'svg:3d-printer' },
  { id: 'ollie', from: '🦊', to: 'svg:quokka' },
];
```

Each entry applies **only if the person still holds the exact value they were seeded with**. If a parent has since chosen their own avatar, `from` will not match and their choice is left alone.

It is best-effort and per-person: a failure leaves the old avatar in place rather than failing the request. Seeding a brand-new household is unchanged.

## Verification

- `api/test-logic.js` passes (full suite).
- `scripts/check-frontend.js` and `scripts/check-design.js` pass.
- `from` values checked against the pre-#88 seed to confirm they are the exact characters those two people were created with.

## The lesson worth keeping

Changing a default only affects records created **after** it. Anything already in the database needs migrating — and a green test suite cannot tell you the difference. #88's acceptance criteria said "Ollie's tile shows a quokka", which was never true, and nothing in the pipeline could catch that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_