### PR TITLE
Give kids a way back to the person picker

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -190,7 +190,31 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   flex-shrink: 0;
   z-index: 10;
 }
-.kid-header-left { display: flex; align-items: center; gap: var(--space-2); flex: 1; min-width: 0; }
+.kid-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  /* A button, but it should read as the kid's name badge rather than as a
+     control - the swap glyph is the only affordance until it is pressed. */
+  background: none;
+  border: 0;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  min-height: 44px;
+  touch-action: manipulation;
+  cursor: pointer;
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+.kid-header-left:active { transform: scale(0.97); }
+.switch-hint {
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+  flex-shrink: 0;
+}
 .kid-avatar-wrap {
   width: 2.5rem; height: 2.5rem;
   min-width: 2.5rem;
@@ -701,10 +725,12 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 <div id="screen-kid" class="screen hidden">
 
   <header class="kid-header" id="kid-header">
-    <div class="kid-header-left">
+    <button class="kid-header-left" onclick="logout()"
+            aria-label="Switch to a different person">
       <div class="kid-avatar-wrap"><span id="k-avatar"></span></div>
       <span class="kid-header-name" id="k-name"></span>
-    </div>
+      <span class="switch-hint" aria-hidden="true">⇄</span>
+    </button>
     <div class="points-chip">
       <span>⭐</span>
       <span id="k-points" style="font-variant-numeric:tabular-nums"></span>


### PR DESCRIPTION
Once a kid was selected there was no way out.

The kid screen has a header (avatar, name, points chip) and a four-tab bar, and neither offered anything but tabs. The session persists in `localStorage`, so the app opened as Ollie every time, permanently.

## Why nothing caught it

`logout()` was never broken — it clears the session, removes the `localStorage` key and re-renders back to the picker. **Nothing called it.** Parent HQ kept its `← Switch user` button through the app-shell rework; the kid screen lost its way back, and no test or check covers "can you get out of this screen".

## The fix

The kid header's avatar and name become the control. Tapping them switches user.

That's the pattern kids already meet in other apps, and it avoids putting an explicit "Switch user" pill into a screen whose register `docs/design-system.md` says should be playful rather than administrative. A small `⇄` glyph is the affordance; the button carries no chrome until pressed, and keeps the 44px tap target and `scale(0.97)` pressed state the design system requires.

Parent HQ is unchanged — its quieter register suits the explicit pill it already has.

## Verification

- `scripts/check-frontend.js` passes (34 checks).
- `scripts/check-design.js` passes.
- `logout()` confirmed to clear `session`, remove `hero-session` from `localStorage`, and re-render to `#screen-who`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_