### PR TITLE
Stop elaboration being an automatic build order

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -301,6 +301,39 @@ deleted. Work now moves the instant something unblocks it.
 | `auto-merge.yml` (nominally 5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
 | ~~`approve-agent-workflows.yml`~~ | **Deleted.** It never worked — see below |
 
+### Elaboration is not a build order
+
+The Elaborator used to end with "apply the 'build' label to EVERY sub-issue you
+create". That made planning and committing the same act: anything it thought of,
+the queue built.
+
+Over one evening that produced calendar views, a schedule-conflict engine with
+alternate-slot suggestions, badge gamification and an audit log — while the live
+app still had no way to switch users. All three of those areas are named in the
+**Non-goals for v1** section of `docs/mvp-scope-v1.md`. Nothing was
+malfunctioning: every agent did what it was told, and what it was told had no
+word for "not yet".
+
+Two labels now, and the Elaborator must pick one per sub-issue:
+
+- **`build`** — core. Something in the MVP scope or core workflows that is not
+  yet built, or a defect stopping the app working. A person cannot do one of the
+  things v1 promises until it exists.
+- **`enhancement`** — everything else. Still created, still linked to its
+  parent, still fully specified. Simply not queued.
+
+The gate is mechanical, not advisory: the build queue only reads `build`. That
+matters, because the same lesson has now been learned three times on this
+project — the design system held only once CI enforced it, the merge gate held
+only once auto-merge checked the check run itself, and scope will hold only
+because the queue cannot see `enhancement`.
+
+The Elaborator is also explicitly allowed to **overrule the issue it was given**.
+A backlog item can itself be out of scope for v1; when it is, it says so and
+labels its sub-issues `enhancement`. It could not do that before, which is the
+root of what went wrong — the issues were queued by a human who had not checked
+them against the non-goals, and no agent had standing to object.
+
 ### Never count workflow runs to measure work
 
 The elaborate/architect queues each had a "runaway guard" that counted workflow

--- a/ops/elaborator/setup_elaborator.py
+++ b/ops/elaborator/setup_elaborator.py
@@ -132,9 +132,39 @@ Work in this order:
    When you do apply it, say in your comment on the parent WHICH sub-issues got
    it and WHY in one line each, so the decision is reviewable.
 
-   Also apply the 'build' label to EVERY sub-issue you create. This does not
-   start a build immediately - it queues the sub-issue, and a scheduled worker
-   picks queued items up a few a day, in order, skipping any whose stated
+   CORE OR ENHANCEMENT - label every sub-issue exactly one of these, and get
+   it right, because 'build' is a build order and 'enhancement' is not.
+
+   Apply 'build' ONLY to work that is CORE: something in the MVP scope list or
+   core workflows of docs/mvp-scope-v1.md that is not yet built, or a defect
+   that stops the app working properly. Core means a person cannot do one of
+   the things v1 promises until this exists.
+
+   Apply 'enhancement' to everything else. An enhancement sub-issue is still
+   created, still linked to its parent, still fully specified - it simply is
+   not queued for building yet. Nothing is lost; it waits.
+
+   Read the "Non-goals for v1" section of docs/mvp-scope-v1.md and treat it as
+   binding. If a sub-issue serves something on that list, it is an enhancement
+   even when the parent issue asks for it directly. YOU MAY OVERRULE THE ISSUE
+   YOU WERE GIVEN. A backlog item can itself be out of scope for v1; when it
+   is, say so plainly in your comment and label its sub-issues 'enhancement'.
+   This has already gone wrong once: a whole evening was spent building
+   calendars, schedule-conflict detection and badge gamification, all three of
+   which that section names as non-goals, because every sub-issue was labelled
+   'build' automatically and nothing could say no.
+
+   Prefer fewer, larger core sub-issues over many small ones. If you find
+   yourself creating a fourth 'build' sub-issue for one parent, stop and ask
+   whether the later ones are really required for v1 to work, or whether they
+   are polish you are describing because you can see it. Polish is an
+   enhancement.
+
+   In your comment on the parent, list which sub-issues you marked core and
+   which enhancement, one line of reasoning each, so the call is reviewable.
+
+   'build' does not start a build immediately - it queues the sub-issue, and a
+   worker picks queued items up in order, skipping any whose stated
    dependencies are still open. So write dependencies as "Depends on #N" in
    the body (that exact wording, with the # number) wherever one sub-issue
    needs another finished first - the queue reads it, and a sub-issue built
@@ -152,6 +182,11 @@ Work in this order:
 
 Be decisive and finish in a single pass. Keep sub-issue count and wording lean:
 quality of acceptance criteria over volume of prose.
+
+The goal of this phase is a FINISHED CORE APP, not a comprehensive one. Work
+that makes the app better but which nobody is blocked without is an
+enhancement, however obvious and however easy it looks. Finishing beats
+covering.
 """
 
 # Filesystem tools: read-only. No bash, write, edit, web_fetch or web_search -


### PR DESCRIPTION
The Elaborator's instructions ended with *"apply the 'build' label to EVERY sub-issue you create"*. That made planning and committing the same act — anything it thought of, the queue built.

Over one evening that produced calendar views, a schedule-conflict engine with alternate-slot suggestions, badge gamification and an audit log — while the live app still had no way to switch users.

All three of those areas are named in the **Non-goals for v1** section of `docs/mvp-scope-v1.md`, which the Elaborator is already instructed to read:

> - Advanced analytics/gamification beyond basic progress
> - Third-party integrations (school systems, **calendars**, smart home platforms)
> - Fully autonomous AI **scheduling or planning**

Nothing malfunctioned. Every agent did what it was told, and what it was told had no word for *"not yet"*.

## The change

Each sub-issue now gets exactly one of:

- **`build`** — core. In the MVP scope or core workflows and not yet built, or a defect stopping the app working properly. A person cannot do one of the things v1 promises until it exists.
- **`enhancement`** — everything else. Still created, still linked to its parent, still fully specified. Simply not queued.

**The gate is mechanical, not advisory** — the build queue only reads `build`. That matters, because this lesson has now been learned three times here: the design system held only once CI enforced it, the merge gate held only once auto-merge checked the check run itself, and scope will hold only because the queue cannot see `enhancement`.

The Elaborator is also now **explicitly allowed to overrule the issue it was given**. A backlog item can itself be out of scope for v1; when it is, it says so and labels the sub-issues `enhancement`. It had no standing to object before — which is the actual root cause, since the backlog was queued without being checked against the non-goals and nothing downstream could refuse.

It must also state, per sub-issue, which call it made and why, so the judgement is reviewable rather than silent.

## Verification

- `setup_elaborator.py` parses.
- Prompt text reviewed for the `f`-string braces it sits inside.

## Docs

`docs/pipeline.md` records the incident and the rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_