### PR TITLE
Stop avatars printing as "svg:3d-printer Toby"

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1415,6 +1415,22 @@ const SVG_AVATARS = {
 // Returns an HTML string for an avatar value.
 // If value starts with "svg:", renders the matching built-in SVG;
 // otherwise wraps the emoji in a <span>.
+// Text stand-in for an avatar in places that cannot hold markup - <option>
+// labels, prompt() text, plain string concatenation. Without this the raw
+// stored value leaks into the UI as "svg:3d-printer Toby", which is exactly
+// what shipped when only the two render sites named in #88 were converted.
+// Keys match SVG_AVATARS; the glyphs match the Parent HQ picker.
+var SVG_AVATAR_FALLBACK = {
+  'quokka': '\u{1F43E}',
+  '3d-printer': '\u{1F5A8}\uFE0F',
+};
+function avatarText(value) {
+  if (value && value.indexOf('svg:') === 0) {
+    return SVG_AVATAR_FALLBACK[value.slice(4)] || '\u2B50';
+  }
+  return value || '\u2753';
+}
+
 function renderAvatarHtml(value, color) {
   if (value && value.indexOf('svg:') === 0) {
     var key = value.slice(4);
@@ -1958,11 +1974,11 @@ function parentCalendarItemTime(item) {
 function parentCalendarWho(item) {
   if (item.kind === 'chore') {
     var kid = state.people.find(function(person) { return person.id === item.kidId; });
-    return kid ? kid.emoji + ' ' + kid.name : 'Kid';
+    return kid ? avatarText(kid.emoji) + ' ' + kid.name : 'Kid';
   }
   if (item.personId === null || item.personId === undefined) return 'Whole family';
   var person = state.people.find(function(p) { return p.id === item.personId; });
-  return person ? person.emoji + ' ' + person.name : 'Assigned kid';
+  return person ? avatarText(person.emoji) + ' ' + person.name : 'Assigned kid';
 }
 
 function parentCalendarSkeletonHtml() {
@@ -2075,7 +2091,7 @@ function renderParentApprovalsTodayByKid() {
     return '<div class="card parent-card">'
       + '<div class="parent-item-head">'
       + '<div class="parent-copy">'
-      + '<strong>' + kid.emoji + ' ' + esc(kid.name) + '</strong>'
+      + '<strong>' + avatarText(kid.emoji) + ' ' + esc(kid.name) + '</strong>'
       + '<div class="sub">Today’s chores overview</div>'
       + '</div>'
       + '<span class="parent-badge">' + todayItems.length + ' chore' + (todayItems.length === 1 ? '' : 's') + '</span>'
@@ -2107,7 +2123,7 @@ function renderParentCalendarChecklists(item) {
   var adultActions = Array.isArray(item.adultActions) ? item.adultActions : [];
   var prepHtml = prepLists.map(function(list, listIndex) {
     var kid = state.people.find(function(person) { return person.id === list.personId; });
-    var kidLabel = kid ? kid.emoji + ' ' + kid.name : 'Kid prep';
+    var kidLabel = kid ? avatarText(kid.emoji) + ' ' + kid.name : 'Kid prep';
     var items = (list.items || []).map(function(entry, itemIndex) {
       return '<label class="check-row">'
         + '<input type="checkbox" ' + (entry.done ? 'checked' : '')
@@ -2444,7 +2460,7 @@ function renderParent(person) {
       var isExtra = !c.taskId;
       return '<div class="card parent-card">'
         + '<div class="parent-summary-row">'
-        + '<span class="parent-kid-mark">' + kid.emoji + '</span>'
+        + '<span class="parent-kid-mark">' + avatarText(kid.emoji) + '</span>'
         + '<div class="parent-copy">'
         + '<strong>' + esc(kid.name) + '</strong>'
         + '<div>' + esc(c.title) + (isExtra ? ' <span class="tag extra">kid-added</span>' : '') + '</div>'
@@ -2462,7 +2478,7 @@ function renderParent(person) {
   var sel = document.getElementById('p-kid');
   var current = sel.value;
   var kidOptions = kidsOnly().map(function(k) {
-    return '<option value="' + k.id + '">' + k.emoji + ' ' + esc(k.name) + '</option>';
+    return '<option value="' + k.id + '">' + avatarText(k.emoji) + ' ' + esc(k.name) + '</option>';
   }).join('');
   sel.innerHTML = kidOptions;
   if (current) sel.value = current;
@@ -2481,7 +2497,7 @@ function renderParent(person) {
     return '<div class="card parent-card">'
       + '<div class="parent-item-head">'
       + '<div class="parent-copy">'
-      + '<strong>' + k.emoji + ' ' + esc(k.name) + '</strong>'
+      + '<strong>' + avatarText(k.emoji) + ' ' + esc(k.name) + '</strong>'
       + '<div class="sub">' + (stats.balance || 0) + ' balance · ' + (stats.points || 0) + ' lifetime pts</div>'
       + '</div>'
       + '<span class="parent-badge">' + mine.length + ' task' + (mine.length === 1 ? '' : 's') + '</span>'
@@ -2507,7 +2523,7 @@ function renderParent(person) {
         var kid = state.people.find(function(k) { return k.id === r.kidId; }) || { name: '?', emoji: '❓' };
         return '<div class="card parent-card">'
           + '<div class="parent-summary-row">'
-          + '<span class="parent-kid-mark">' + kid.emoji + '</span>'
+          + '<span class="parent-kid-mark">' + avatarText(kid.emoji) + '</span>'
           + '<div class="parent-copy">'
           + '<strong>' + esc(kid.name) + '</strong>'
           + '<div>' + esc(r.title) + '</div>'
@@ -2534,7 +2550,7 @@ function renderParent(person) {
         var decisionClass = c.status === 'approved' ? 'tag approved' : 'tag rejected';
         return '<div class="parent-list-row">'
           + '<div class="parent-copy">'
-          + '<span class="parent-list-title">' + kid.emoji + ' ' + esc(kid.name) + ' — ' + esc(c.title) + '</span>'
+          + '<span class="parent-list-title">' + avatarText(kid.emoji) + ' ' + esc(kid.name) + ' — ' + esc(c.title) + '</span>'
           + '<div class="sub"><span class="' + decisionClass + '">' + decisionLabel + '</span>'
           + (c.status === 'approved' ? ' · ' + (c.points || 0) + ' pts' : '')
           + (c.decidedAt ? ' · ' + formatRewardDate(c.decidedAt) : '')
@@ -2778,7 +2794,7 @@ function currentKidPerson() {
 
 function voiceReminderWhoLabel(kidId) {
   var person = state && state.people && state.people.find(function(entry) { return entry.id === kidId; });
-  if (person) return person.emoji + ' ' + person.name;
+  if (person) return avatarText(person.emoji) + ' ' + person.name;
   return 'You';
 }
 
@@ -3352,7 +3368,7 @@ async function parentEditPlanningItem(itemId) {
     }
   }
   var kidChoices = ['0) Whole family'].concat(kidsOnly().map(function(kid, index) {
-    return (index + 1) + ') ' + kid.emoji + ' ' + kid.name;
+    return (index + 1) + ') ' + avatarText(kid.emoji) + ' ' + kid.name;
   }));
   var defaultChoice = 0;
   if (item.personId) {
@@ -3413,7 +3429,7 @@ async function parentAddPrepItem(itemId) {
   var kids = kidsOnly();
   if (kids.length === 0) { toast('Add a kid first.'); return; }
   var choice = prompt('Which kid prep list?\n' + kids.map(function(kid, index) {
-    return (index + 1) + ') ' + kid.emoji + ' ' + kid.name;
+    return (index + 1) + ') ' + avatarText(kid.emoji) + ' ' + kid.name;
   }).join('\n'), '1');
   if (choice === null) return;
   var choiceIndex = Number(choice.trim()) - 1;
@@ -3511,7 +3527,7 @@ async function parentEditTask(taskId) {
   if (!cycle) { toast('Choose 1, 2, or 3 for how often.'); return; }
   var kids = kidsOnly();
   var kidPrompt = 'Reassign kid\n' + kids.map(function(k, index) {
-    return (index + 1) + ') ' + k.emoji + ' ' + k.name;
+    return (index + 1) + ') ' + avatarText(k.emoji) + ' ' + k.name;
   }).join('  ');
   var kidInput = prompt(kidPrompt, String(kids.findIndex(function(k) { return k.id === task.kidId; }) + 1));
   if (kidInput === null) return;

--- a/scripts/check-frontend.js
+++ b/scripts/check-frontend.js
@@ -146,8 +146,16 @@ bodies.forEach((body, i) => {
 });
 
 function extractFunctionSource(name) {
-  const signature = `async function ${name}(`;
-  const start = html.indexOf(signature);
+  // Handles both `async function f(` and plain `function f(` - avatarText is
+  // synchronous, and only looking for the async form silently returned ''.
+  let start = html.indexOf(`async function ${name}(`);
+  if (start === -1) {
+    const plain = html.indexOf(`function ${name}(`);
+    // Guard against matching the tail of "async function f(" as "function f(".
+    if (plain !== -1 && !/async\s+$/.test(html.slice(Math.max(0, plain - 8), plain))) {
+      start = plain;
+    }
+  }
   if (start === -1) return '';
   const openBrace = html.indexOf('{', start);
   if (openBrace === -1) return '';
@@ -168,6 +176,14 @@ async function runParentEditTaskChecks() {
   check(Boolean(source), 'parentEditTask exists');
   if (!source) return;
 
+  // parentEditTask builds its prompt text through avatarText(), so the real
+  // implementation is lifted out of the page rather than stubbed - otherwise
+  // these checks would pass against behaviour the app does not have.
+  const fallbackSrc = (html.match(/var SVG_AVATAR_FALLBACK = \{[\s\S]*?\};/) || [''])[0];
+  const avatarTextSrc = extractFunctionSource('avatarText');
+  check(Boolean(fallbackSrc), 'SVG_AVATAR_FALLBACK found for the sandbox');
+  check(Boolean(avatarTextSrc), 'avatarText source found for the sandbox');
+
   const factory = new Function(
     'state',
     'session',
@@ -176,7 +192,8 @@ async function runParentEditTaskChecks() {
     'kidsOnly',
     'api',
     'toastApiError',
-    source.replace(/^async function parentEditTask/, 'return async function')
+    `${fallbackSrc}\n${avatarTextSrc}\n` +
+      source.replace(/^async function parentEditTask/, 'return async function')
   );
 
   async function exercise(prompts, options) {
@@ -299,6 +316,64 @@ async function runParentEditTaskChecks() {
     check(run.apiCalls.length === 0, 'missing task aborts before API call');
     check(run.toasts.includes('Task not found.'), 'missing task shows the not-found toast');
   }
+}
+
+// ---------------------------------------------------------------------------
+// Avatars must never reach the screen as their raw stored value.
+//
+// A person's avatar can be an emoji character OR the string "svg:<key>". When
+// #88 introduced the second form it converted only the two render sites its
+// acceptance criteria named, so every other place printed "svg:3d-printer Toby"
+// at the user. Tests passed; the app was wrong. These checks close that gap.
+// ---------------------------------------------------------------------------
+{
+  const svgKeys = [...html.matchAll(/^\s*'([a-z0-9-]+)':\s*function\s*\(color\)/gm)].map((m) => m[1]);
+  const fallbackBlock = (html.match(/var SVG_AVATAR_FALLBACK = \{[\s\S]*?\};/) || [''])[0];
+
+  check(svgKeys.length > 0, `built-in SVG avatars found (${svgKeys.length})`);
+  check(/function avatarText\(value\)/.test(html), 'avatarText() text stand-in exists');
+
+  const missing = svgKeys.filter((k) => !fallbackBlock.includes(`'${k}'`));
+  check(
+    missing.length === 0,
+    `every SVG avatar has a text fallback${missing.length ? ` — missing: ${missing.join(', ')}` : ''}`
+  );
+
+  // A person's .emoji may only be read inside one of the renderers. Anything
+  // else concatenates the raw value into the UI.
+  // True when index `at` sits inside the argument list of a call to one of the
+  // renderers. Walks paren depth, so a nested call in an earlier argument -
+  // setAvatar(document.getElementById('x'), kid.emoji, c) - does not fool it.
+  function insideRendererCall(line, at) {
+    for (const call of line.matchAll(/\b(?:avatarText|renderAvatarHtml|setAvatar)\(/g)) {
+      const open = call.index + call[0].length - 1;
+      if (open > at) continue;
+      let depth = 0;
+      for (let i = open; i < line.length; i += 1) {
+        if (line[i] === '(') depth += 1;
+        else if (line[i] === ')') {
+          depth -= 1;
+          if (depth === 0) { if (at > open && at < i) return true; break; }
+        }
+      }
+      if (depth > 0 && at > open) return true;  // call continues onto the next line
+    }
+    return false;
+  }
+
+  const raw = [];
+  html.split('\n').forEach((line, i) => {
+    if (/^\s*\/\//.test(line)) return;
+    for (const m of line.matchAll(/\b([A-Za-z_$][\w$]*)\.emoji\b/g)) {
+      if (m[1] === 'lvl' || m[1] === 'next') continue;   // level badges, not avatars
+      if (insideRendererCall(line, m.index)) continue;
+      raw.push(`${i + 1}: ${line.trim().slice(0, 70)}`);
+    }
+  });
+  check(
+    raw.length === 0,
+    `no avatar rendered as its raw stored value${raw.length ? `\n       ${raw.join('\n       ')}` : ''}`
+  );
 }
 
 check(/<\/html>\s*$/i.test(html.trim() + '\n') || /<\/html>/i.test(html), 'closing </html> present');


### PR DESCRIPTION
An avatar is either an emoji character or the string `svg:<key>`.

#88 added the second form and converted **the two render sites its acceptance criteria named** — the person-picker tiles and the kid header. **Thirteen other places** concatenate the value straight into text. So once the migration in #101 actually changed Toby and Ollie's data, all thirteen started showing the raw string at the user.

Green tests throughout. The app was visibly wrong.

## The fix

`avatarText()` — a text stand-in for the places that can't hold markup: `<option>` labels, `prompt()` text, plain string concatenation. It uses the same glyphs the Parent HQ picker already shows (🐾 quokka, 🖨️ 3D printer).

All thirteen sites now go through it. The three that render real SVG are untouched.

## Three checks so it can't come back

- **Every key in `SVG_AVATARS` has a matching text fallback** — adding an avatar without one now fails CI instead of shipping.
- **`avatarText()` exists.**
- **No `.emoji` is read outside a renderer call.** The detector walks paren depth rather than matching a prefix, so `setAvatar(getElementById('x'), kid.emoji, c)` is correctly allowed while a bare concatenation is not. `lvl.emoji` / `next.emoji` are excluded — those are level badges, not avatars.

**Confirmed by reverting one site and watching the check fail, then restoring it.** Not assumed.

## One thing found on the way

`extractFunctionSource` only ever looked for `async function`, so asking it for a synchronous function returned `''` and the sandbox silently lacked it — a check that would have reported success against code it never loaded. It now handles both forms, and the `parentEditTask` sandbox is given the **real** `avatarText` rather than a stub, so these checks exercise behaviour the app actually has.

## Verification

`api/test-logic.js`, `scripts/check-frontend.js` (100 checks) and `scripts/check-design.js` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_