### PR TITLE
Cap builds in flight, and stop a closed PR queueing an issue forever

### DIFF
--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -85,6 +85,16 @@ jobs:
             --jq '[.[] | select(has("pull_request") | not) | {number, body: (.body // ""), assignees: [.assignees[].login]}]')
 
           MAX_PER_RUN=1
+          # How many builds may be OPEN AT ONCE, across all runs. MAX_PER_RUN
+          # only ever limited a single run: because an assigned issue is
+          # skipped, each subsequent run handed out another one, and six
+          # Copilot branches ended up in flight together. They all edit
+          # frontend/index.html, so every one conflicted with main, and
+          # auto-merge - which cannot resolve a conflict - jammed for hours.
+          # #62 set MAX_PER_RUN=1 intending exactly this, and capped the wrong
+          # thing.
+          MAX_IN_FLIGHT=1
+
           READY=""
           PICKED=0
 
@@ -96,14 +106,45 @@ jobs:
             exit 0
           fi
 
+          # Which issues genuinely have work in progress: an OPEN Copilot pull
+          # request that says it closes them. This is the difference between
+          # "being built" and "was assigned once, and the pull request has since
+          # been closed" - the second used to look identical, and an issue in
+          # that state was skipped forever while still labelled 'build'. That is
+          # how #135 sat queued but unbuildable after its pull request closed,
+          # with every run reporting success.
+          OPEN_PR_BODIES=$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+            --jq '[.[] | select(.user.login == "Copilot" or (.user.login | endswith("[bot]"))) | (.body // "")] | join("\n")' 2>/dev/null || echo "")
+          IN_FLIGHT_ISSUES=$(echo "$OPEN_PR_BODIES" \
+            | grep -ioE '(fixes|closes|resolves)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -u || true)
+          IN_FLIGHT=$(echo "$IN_FLIGHT_ISSUES" | grep -c . || true)
+          IN_FLIGHT=${IN_FLIGHT:-0}
+
+          echo "Builds in flight (open Copilot pull requests): ${IN_FLIGHT}"
+          if [ "$IN_FLIGHT" -ge "$MAX_IN_FLIGHT" ]; then
+            echo "::notice::${IN_FLIGHT} build(s) already in flight (limit ${MAX_IN_FLIGHT}). Waiting - parallel builds conflict in frontend/index.html."
+            echo "numbers=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           for NUM in $(echo "$CANDIDATES" | jq -r '.[].number'); do
             echo "--- considering #${NUM}"
 
-            # Already handed to Copilot? Skip.
             ASSIGNED=$(echo "$CANDIDATES" | jq -r --argjson n "$NUM" '.[] | select(.number==$n) | .assignees | join(",")')
             if echo "$ASSIGNED" | grep -qi 'copilot'; then
-              echo "    already assigned to Copilot - skipping"
-              continue
+              if echo "$IN_FLIGHT_ISSUES" | grep -qx "$NUM"; then
+                echo "    being built now (open Copilot pull request) - skipping"
+                continue
+              fi
+              # Assigned, but nothing open is building it - the pull request was
+              # closed or abandoned. Left alone this is permanent: the issue
+              # keeps its 'build' label, is skipped every run, and the pipeline
+              # reports success while the work never happens.
+              echo "    ::warning::#${NUM} is assigned to Copilot but has no open pull request - stale assignment, re-queueing it"
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${NUM}/assignees" \
+                -f "assignees[]=Copilot" >/dev/null 2>&1 \
+                || echo "    ::warning::could not clear the stale assignee on #${NUM}; it will be retried next run"
             fi
 
             # An epic (has sub-issues) is never built directly.
@@ -137,7 +178,7 @@ jobs:
 
           READY=$(echo "$READY" | xargs || true)
           if [ -z "$READY" ]; then
-            echo "Nothing ready this round (all queued items are assigned, epics, or blocked)."
+            echo "Nothing ready this round (all queued items are being built, epics, or blocked)."
           else
             echo "Building:${READY}"
           fi

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -301,6 +301,37 @@ deleted. Work now moves the instant something unblocks it.
 | `auto-merge.yml` (nominally 5 min) | Copilot never signals "finished" — it opens a draft and later just renames the title from `[WIP] …`. There is no event meaning done |
 | ~~`approve-agent-workflows.yml`~~ | **Deleted.** It never worked — see below |
 
+### Cap what is IN FLIGHT, not what one run hands out
+
+#62 set `MAX_PER_RUN=1` on the build queue, because almost every sub-issue edits
+`frontend/index.html` and parallel Copilot branches conflict. It capped the
+wrong thing.
+
+An issue already assigned to Copilot is skipped, so each *subsequent* run simply
+handed out the next one. Six branches ended up open together, every one of them
+conflicted with `main`, and auto-merge — which cannot resolve a conflict — sat
+warning and retrying for three hours while reporting success.
+
+There is now a `MAX_IN_FLIGHT` cap counted across all runs, from the number of
+**open Copilot pull requests**, not from the assignment.
+
+### "Assigned to Copilot" is not the same as "being built"
+
+The queue treated any Copilot assignment as work in progress. When a pull
+request is closed without merging, the assignment stays — so the issue kept its
+`build` label, was skipped on every run, and never got built. The pipeline
+reported success throughout. #135 sat in exactly that state.
+
+In-flight is now derived from open Copilot pull requests that name the issue
+(`Fixes #N` / `Closes #N` / `Resolves #N`). An issue assigned to Copilot with no
+such pull request is a **stale assignment**: the queue clears the assignee,
+warns, and builds it.
+
+The rule underneath both: **a queue must measure the thing it actually cares
+about.** Counting assignments instead of open work, like counting workflow runs
+instead of issues elaborated, produces a queue that looks healthy while nothing
+moves.
+
 ### Elaboration is not a build order
 
 The Elaborator used to end with "apply the 'build' label to EVERY sub-issue you


### PR DESCRIPTION
Two defects in the build queue. Both bit today.

## 1. `MAX_PER_RUN` capped the wrong thing

#62 set it to `1` because almost every sub-issue edits `frontend/index.html` and parallel Copilot branches conflict. But **an assigned issue is skipped**, so each *subsequent* run simply handed out the next one.

Six branches ended up open together. All six conflicted with `main`. Auto-merge — which cannot resolve a conflict — sat warning and retrying for three hours **while reporting success**.

`MAX_IN_FLIGHT` now caps concurrent builds across all runs, counted from **open Copilot pull requests** rather than from assignment.

## 2. "Assigned to Copilot" was treated as "being built"

When a pull request is closed without merging, the assignment stays. So the issue kept its `build` label, was skipped on every run, and never got built — with every run reporting success.

#135 was in exactly that state and had to be un-assigned by hand.

In-flight is now derived from open Copilot pull requests naming the issue (`Fixes` / `Closes` / `Resolves #N`). An issue assigned to Copilot with **no such pull request** is a stale assignment: the queue clears the assignee, warns, and builds it.

## Verification

YAML parses; the `pick` step's shell parses under `bash -n`. Extraction logic exercised offline against four cases:

| Case | Result |
|---|---|
| No open PRs | `in-flight=0`, nothing skipped |
| One PR `- Fixes #119` | `in-flight=1`, #119 skipped, #135 not |
| Two PRs, `Closes` / `resolves` with odd spacing | both detected |
| Body mentioning `#99` with no closing keyword | correctly **not** counted |

All new commands are guarded against `set -euo pipefail` — `grep -c` on empty input exits 1 and would otherwise abort the step.

## Docs

`docs/pipeline.md` records both, and the rule underneath them: **a queue must measure the thing it actually cares about.** Counting assignments rather than open work — like counting workflow runs rather than issues elaborated — gives a queue that looks healthy while nothing moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_