### PR TITLE
Do not call an assignment stale while Copilot is still starting up

### DIFF
--- a/.github/workflows/build-queue.yml
+++ b/.github/workflows/build-queue.yml
@@ -137,11 +137,33 @@ jobs:
                 echo "    being built now (open Copilot pull request) - skipping"
                 continue
               fi
-              # Assigned, but nothing open is building it - the pull request was
-              # closed or abandoned. Left alone this is permanent: the issue
-              # keeps its 'build' label, is skipped every run, and the pipeline
-              # reports success while the work never happens.
-              echo "    ::warning::#${NUM} is assigned to Copilot but has no open pull request - stale assignment, re-queueing it"
+              # Assigned, but nothing open is building it. Two very different
+              # situations look identical here:
+              #
+              #   1. Copilot was assigned seconds ago and has not opened its
+              #      draft pull request yet - normally a minute or two.
+              #   2. The pull request was closed or abandoned, so nothing will
+              #      ever build this and the issue is stuck forever.
+              #
+              # Treating (1) as (2) un-assigns Copilot mid-startup and assigns
+              # it again, so two sessions work the same issue and produce
+              # conflicting branches. So only call it stale once the assignment
+              # is older than the grace period.
+              STALE_AFTER_MIN=20
+              ASSIGNED_AT=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUM}/events?per_page=100" \
+                --jq '[.[] | select(.event == "assigned")] | last | .created_at' 2>/dev/null || echo "")
+
+              AGE_MIN=99999
+              if [ -n "$ASSIGNED_AT" ] && [ "$ASSIGNED_AT" != "null" ]; then
+                AGE_MIN=$(( ( $(date -u +%s) - $(date -u -d "$ASSIGNED_AT" +%s) ) / 60 ))
+              fi
+
+              if [ "$AGE_MIN" -lt "$STALE_AFTER_MIN" ]; then
+                echo "    assigned ${AGE_MIN}m ago, no pull request yet - Copilot is probably still starting up, leaving it"
+                continue
+              fi
+
+              echo "    ::warning::#${NUM} has been assigned to Copilot for ${AGE_MIN}m with no open pull request - stale, re-queueing it"
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${NUM}/assignees" \
                 -f "assignees[]=Copilot" >/dev/null 2>&1 \
                 || echo "    ::warning::could not clear the stale assignee on #${NUM}; it will be retried next run"

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -382,6 +382,14 @@ In-flight is now derived from open Copilot pull requests that name the issue
 such pull request is a **stale assignment**: the queue clears the assignee,
 warns, and builds it.
 
+**With a grace period, because "assigned" and "building" are not simultaneous.**
+Copilot opens its draft pull request a minute or two after being assigned, and
+in that window an issue is indistinguishable from an abandoned one. Un-assigning
+there would start a second Copilot session on the same issue and produce two
+conflicting branches — the very thing the in-flight cap exists to prevent. An
+assignment only counts as stale after 20 minutes, read from the issue's last
+`assigned` event.
+
 The rule underneath both: **a queue must measure the thing it actually cares
 about.** Counting assignments instead of open work, like counting workflow runs
 instead of issues elaborated, produces a queue that looks healthy while nothing


### PR DESCRIPTION
A race I introduced in #159, caught before it bit.

#159 taught the queue to re-queue an issue assigned to Copilot with **no open pull request**. That's right for an abandoned build and wrong for a brand new one: Copilot opens its draft PR a minute or two *after* being assigned, and in that window the two states are indistinguishable.

Un-assigning there would immediately re-assign — **two Copilot sessions on the same issue, two conflicting branches.** Precisely what the in-flight cap added in that same change exists to prevent.

#135 was assigned at 19:06 and was sitting in exactly that state while this was being written.

## The fix

An assignment only counts as stale after **20 minutes**, measured from the issue's most recent `assigned` event:

```bash
ASSIGNED_AT=$(gh api ".../issues/${NUM}/events?per_page=100" \
  --jq '[.[] | select(.event == "assigned")] | last | .created_at')
```

A missing or unreadable timestamp is treated as *old*, so the abandoned case still self-heals rather than the guard becoming a new way to stall.

## Verification

YAML parses; the `pick` step parses under `bash -n`. Boundary cases exercised offline:

| Assigned | Verdict |
|---|---|
| just now | still starting up |
| 5m ago | still starting up |
| 19m ago | still starting up |
| 21m ago | **stale, re-queue** |
| 3h ago | **stale, re-queue** |
| no `assigned` event | **stale, re-queue** |
| API returned `null` | **stale, re-queue** |

## Docs

`docs/pipeline.md` records why the grace period exists — that "assigned" and "building" are not simultaneous, and a guard that ignores the gap creates the conflict it was meant to prevent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_