### PR TITLE
Stop the app saying "salmon-river-0e879dc00... says"

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -872,6 +872,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 .modal { background: var(--surface); border-radius: var(--radius-lg); padding: var(--space-6); width: 100%; max-width: 320px; text-align: center; box-shadow: var(--shadow-3); display: flex; flex-direction: column; gap: var(--space-3); }
 .modal h3 { margin-bottom: var(--space-3); font-size: var(--text-lg); font-weight: var(--weight-bold); }
 .pin-input { font-size: var(--text-2xl); text-align: center; letter-spacing: 0.4em; width: 100%; padding: var(--space-3); border: 2px solid var(--border); border-radius: var(--radius-md); font-family: inherit; color: var(--ink); background: var(--surface-sunken); }
+.ask-input { font-size: var(--text-base); width: 100%; padding: var(--space-3); border: 2px solid var(--border); border-radius: var(--radius-md); font-family: inherit; color: var(--ink); background: var(--surface-sunken); }
+.ask-input:focus { outline: none; border-color: var(--brand); }
 .pin-err { color: var(--danger); font-size: var(--text-sm); min-height: 1.2em; }
 .voice-modal {
   max-width: 28rem;
@@ -1309,6 +1311,17 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 <!-- ════════════════════════════════════════════════════════════════════ -->
 <!-- PIN MODAL                                                            -->
 <!-- ════════════════════════════════════════════════════════════════════ -->
+<div id="ask-modal" class="modal-bg hidden">
+  <div class="modal">
+    <h3 id="ask-title"></h3>
+    <input class="ask-input hidden" id="ask-input" type="text" autocomplete="off">
+    <div class="modal-actions">
+      <button class="btn" id="ask-ok"></button>
+      <button class="btn ghost" id="ask-cancel">Cancel</button>
+    </div>
+  </div>
+</div>
+
 <div id="pin-modal" class="modal-bg hidden">
   <div class="modal">
     <h3 id="pin-title">Enter PIN</h3>
@@ -2839,8 +2852,78 @@ async function undoTask(completionId) {
   }
 }
 
+// Replaces window.prompt / window.confirm.
+//
+// A native dialog is prefixed by the browser with the page's origin - the app
+// literally announced itself as "salmon-river-0e879dc00.7.azurestaticapps.net
+// says". Nothing in CSS can change that, and it is the single most web-page-ish
+// thing the app did: unstyleable, un-themeable, and it blocks the whole tab.
+// docs/design-system.md exists to stop exactly this.
+//
+// Returns a Promise: the entered string, or null if cancelled - so call sites
+// keep the same shape they had with prompt(), just awaited.
+function askText(question, defaultValue, okLabel) {
+  return new Promise(function(resolve) {
+    var bg = document.getElementById('ask-modal');
+    var input = document.getElementById('ask-input');
+    var ok = document.getElementById('ask-ok');
+    var cancel = document.getElementById('ask-cancel');
+
+    document.getElementById('ask-title').textContent = question;
+    input.classList.remove('hidden');
+    input.value = defaultValue == null ? '' : String(defaultValue);
+    ok.textContent = okLabel || 'OK';
+    bg.classList.remove('hidden');
+    input.focus();
+    input.select();
+
+    function close(value) {
+      bg.classList.add('hidden');
+      ok.onclick = null;
+      cancel.onclick = null;
+      input.onkeydown = null;
+      bg.onclick = null;
+      resolve(value);
+    }
+    ok.onclick = function() { close(input.value); };
+    cancel.onclick = function() { close(null); };
+    input.onkeydown = function(e) {
+      if (e.key === 'Enter') { e.preventDefault(); close(input.value); }
+      if (e.key === 'Escape') { e.preventDefault(); close(null); }
+    };
+    // Tapping the backdrop cancels, matching every other sheet in the app.
+    bg.onclick = function(e) { if (e.target === bg) close(null); };
+  });
+}
+
+function askConfirm(question, okLabel) {
+  return new Promise(function(resolve) {
+    var bg = document.getElementById('ask-modal');
+    var input = document.getElementById('ask-input');
+    var ok = document.getElementById('ask-ok');
+    var cancel = document.getElementById('ask-cancel');
+
+    document.getElementById('ask-title').textContent = question;
+    input.classList.add('hidden');
+    ok.textContent = okLabel || 'Yes';
+    bg.classList.remove('hidden');
+    ok.focus();
+
+    function close(value) {
+      bg.classList.add('hidden');
+      ok.onclick = null;
+      cancel.onclick = null;
+      bg.onclick = null;
+      resolve(value);
+    }
+    ok.onclick = function() { close(true); };
+    cancel.onclick = function() { close(false); };
+    bg.onclick = function(e) { if (e.target === bg) close(false); };
+  });
+}
+
 async function addExtraPrompt() {
-  var title = prompt('What did you do? 🌟');
+  var title = await askText('What did you do? 🌟', '', 'Send it!');
   if (!title || !title.trim()) return;
   toast('Sent to your grown-up! ⏳');
   await api({ action: 'addExtra', kidId: session.personId, personId: session.personId, pin: session.pin, title: title.trim() });
@@ -3215,7 +3298,7 @@ function handleVoiceReminderSecondary() {
 async function redeemKidReward(rewardId, cost) {
   var reward = (state.rewards || []).find(function(r) { return r.id === rewardId; });
   var rewardTitle = reward ? reward.title : 'this reward';
-  if (!confirm('Redeem ' + rewardTitle + ' for ' + cost + ' points?')) return;
+  if (!await askConfirm('Redeem ' + rewardTitle + ' for ' + cost + ' points?', 'Redeem')) return;
 
   var syntheticId = '_opt_' + rewardId + '_' + Date.now();
   var prevRedemptions = (state.redemptions || []).slice();
@@ -3253,7 +3336,7 @@ async function redeemKidReward(rewardId, cost) {
 async function cancelKidRedemption(redemptionId) {
   var redemption = (state.redemptions || []).find(function(r) { return r.id === redemptionId; });
   var rewardTitle = redemption ? redemption.title : 'this reward';
-  if (!confirm('Changed your mind about ' + rewardTitle + '?')) return;
+  if (!await askConfirm('Changed your mind about ' + rewardTitle + '?', 'Cancel it')) return;
 
   var prevRedemptions = (state.redemptions || []).slice();
   var prevStats = JSON.parse(JSON.stringify(state.stats || {}));
@@ -3477,7 +3560,7 @@ async function parentEditPlanningItem(itemId) {
 }
 
 async function parentDeletePlanningItem(itemId) {
-  if (!confirm('Delete this calendar item?')) return;
+  if (!await askConfirm('Delete this calendar item?', 'Delete')) return;
   var result = await api({
     action: 'deletePlanningItem',
     parentId: session.personId,
@@ -3573,7 +3656,7 @@ async function parentReject(completionId) {
 }
 
 async function parentDeleteTask(taskId) {
-  if (!confirm('Remove this task?')) return;
+  if (!await askConfirm('Remove this task?', 'Remove')) return;
   await api({ action: 'deleteTask', parentId: session.personId, parentPin: session.pin, taskId });
 }
 
@@ -3690,7 +3773,7 @@ async function parentEditReward(rewardId) {
 }
 
 async function parentDeleteReward(rewardId) {
-  if (!confirm('Remove this reward?')) return;
+  if (!await askConfirm('Remove this reward?', 'Remove')) return;
   var result = await api({ action: 'deleteReward', parentId: session.personId, parentPin: session.pin, rewardId });
   if (toastApiError(result)) return;
   toast('Reward removed.');

--- a/scripts/check-design.js
+++ b/scripts/check-design.js
@@ -139,7 +139,7 @@ check(Boolean(bodyMatch), '<body> block exists');
 
 if (bodyMatch) {
   const body = bodyMatch[1];
-  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'voice-reminder-modal', 'toast']);
+  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'toast']);
   const seenTopLevelIds = new Set();
   let unexpectedTopLevel = 0;
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -121,3 +121,35 @@ test('the app renders without a JavaScript error', async ({ page }) => {
   await expect(page.locator('#screen-who')).toBeVisible();
   expect(errors).toEqual([]);
 });
+
+// A native prompt() or confirm() is prefixed by the browser with the page's
+// origin - the app announced itself as "salmon-river-0e879dc00.7.azurestatic
+// apps.net says". Unstyleable, and the most web-page-ish thing it did.
+//
+// If a native dialog reappears, Playwright auto-dismisses it and the flow
+// silently does nothing - so assert on the in-app modal being there, and fail
+// loudly if a native one fires.
+test('adding an extra task uses the in-app dialog, not a browser prompt', async ({ page }) => {
+  const native = [];
+  page.on('dialog', async (d) => { native.push(d.message()); await d.dismiss(); });
+
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /something extra/i }).click();
+
+  await expect(page.locator('#ask-modal')).toBeVisible();
+  await expect(page.locator('#ask-title')).toContainText('What did you do?');
+  await page.locator('#ask-input').fill('Tidied the shed');
+  await page.getByRole('button', { name: /send it/i }).click();
+  await expect(page.locator('#ask-modal')).toBeHidden();
+
+  expect(native, 'a native browser dialog fired').toEqual([]);
+});
+
+test('cancelling the in-app dialog does nothing', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /something extra/i }).click();
+  await expect(page.locator('#ask-modal')).toBeVisible();
+  await page.getByRole('button', { name: /^cancel$/i }).click();
+  await expect(page.locator('#ask-modal')).toBeHidden();
+  await expect(page.locator('#screen-kid')).toBeVisible();
+});


### PR DESCRIPTION
Adding an extra task used `window.prompt`, and browsers prefix every native dialog with the page's origin. So the app introduced itself to the kids by reciting its Azure Static Web Apps hostname.

Nothing in CSS can change that. Native dialogs are unstyleable, un-themeable, ignore the design tokens entirely, and block the whole tab while open. `docs/design-system.md` exists to stop precisely this — it was the most web-page-ish thing the app did.

## The change

`askText()` and `askConfirm()`, built on the modal idiom already used by the PIN and voice sheets — same overlay, same tokens, Enter to accept, Escape or a tap on the backdrop to cancel. Both return a Promise resolving to the same shape their native counterpart returned, so call sites keep their structure.

**Converted (6):** add something extra, redeem a reward, cancel a redemption, and the three parent destructive confirmations (delete calendar item / task / reward).

**Not converted (19):** the chained prompts in `parentEditTask`, `parentEditReward` and the calendar item editor — up to *seven sequential dialogs* to edit one task. Those need a real form, not a like-for-like swap, and `check-frontend.js` drives `parentEditTask` with a mocked `prompt()`, so changing both at once would take the test harness down with it. Raised separately.

## Two things that now guard this

**The design check's top-level allow-list gains `ask-modal`.** That list is also a *required* list, so the dialog can't be quietly deleted — verified by renaming it and watching two checks fail.

**A smoke case, and its shape is the point.** Playwright auto-dismisses native dialogs, so if `prompt()` ever comes back the flow silently does nothing and a naive test would still pass. This one asserts the in-app modal appears **and** that no native dialog fired:

```js
page.on('dialog', async (d) => { native.push(d.message()); await d.dismiss(); });
...
expect(native, 'a native browser dialog fired').toEqual([]);
```

Verified by restoring `prompt()` and watching it fail, then restoring.

## Verification

`api/test-logic.js`, `check-frontend.js`, `check-design.js` all pass. Smoke suite 9/9. All six converted call sites are inside functions that were already `async`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_