### PR TITLE
Put real rewards in the shop, and show the next one on the kid Home screen

### DIFF
--- a/api/src/lib/seed.js
+++ b/api/src/lib/seed.js
@@ -26,6 +26,24 @@ const AVATAR_MIGRATIONS = [
   { id: 'ollie', from: '\u{1F98A}', to: 'svg:quokka' },
 ];
 
+// The reward shop shipped with no rewards at all, so renderRewardShop() always
+// took its empty branch and every kid saw "Ask your grown-up to add some!"
+// permanently - including the "N more points to go" progress text, which has
+// therefore never been seen by anyone.
+//
+// Costs are pitched against 5 points per chore and roughly track what each one
+// costs a parent. The soccer player is deliberately the CHEAPEST: it is an ~80c
+// in-game purchase and the one that actually motivates Ollie, so it is the
+// first-win reward - the thing that proves the system pays out before a kid
+// loses interest. Do not make it aspirational. "Pick dinner" is dearest despite
+// costing nothing, because it has real social value and no natural price.
+const SEED_REWARDS = [
+  { title: 'A player for your soccer game', cost: 15 },
+  { title: "Ice cream from McDonald's", cost: 25 },
+  { title: 'Ice cream from the Italian place', cost: 50 },
+  { title: 'Pick dinner one night this week — from 3 options Mum and Dad give you', cost: 80 },
+];
+
 let seeded = false;
 
 // Runs once per warm Function instance (the `seeded` flag), and is itself idempotent
@@ -50,6 +68,11 @@ async function ensureSeeded() {
     await applyAvatarMigrations(people);
   }
 
+  // Runs for BOTH branches on purpose. Adding to a seed list only affects
+  // households created afterwards, and every real one already exists - that is
+  // exactly how #88's avatars shipped green and changed nothing.
+  await topUpRewards();
+
   seeded = true;
 }
 
@@ -71,6 +94,43 @@ async function applyAvatarMigrations(people) {
     } catch {
       // Leave the old avatar in place rather than failing the request.
     }
+  }
+}
+
+
+// Adds any seeded reward that is not already there, matched on title. Existing
+// rewards are never touched, so a cost a parent has edited stays edited; and a
+// reward they deliberately deleted is NOT resurrected, because delete is a soft
+// delete (active: false) and the title still matches.
+//
+// Best-effort: the app must still serve if this fails.
+async function topUpRewards() {
+  try {
+    const rewards = container('rewards');
+    const { resources: existing } = await rewards.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.householdId = @h',
+        parameters: [{ name: '@h', value: HOUSEHOLD_ID }],
+      })
+      .fetchAll();
+
+    const seen = new Set((existing || []).map((r) => r.title));
+
+    for (const r of SEED_REWARDS) {
+      if (seen.has(r.title)) continue;
+      await rewards.items.create({
+        id: `seed-reward-${r.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)}`,
+        householdId: HOUSEHOLD_ID,
+        type: 'reward',
+        title: r.title,
+        cost: r.cost,
+        needsApproval: true,
+        active: true,
+        createdAt: new Date().toISOString(),
+      });
+    }
+  } catch {
+    // Leave the shop as it is rather than failing the request.
   }
 }
 

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -842,12 +842,28 @@ async function main() {
 
   state = await getState();
   assert.ok(Array.isArray(state.rewards), 'getState should include rewards array');
-  assert.strictEqual(state.rewards.length, 1, 'one active reward should appear');
-  assert.strictEqual(state.rewards[0].id, 'reward1');
-  assert.strictEqual(state.rewards[0].title, 'Screen time');
-  assert.strictEqual(state.rewards[0].cost, 20);
-  assert.strictEqual(state.rewards[0].needsApproval, false);
+  // The shop is seeded now, so assert on THIS reward rather than a total. A
+  // count would have to be edited every time the seed list changes, which makes
+  // it a maintenance tax that tests nothing.
+  const added = state.rewards.find((r) => r.id === 'reward1');
+  assert.ok(added, 'the added reward should appear in getState().rewards');
+  assert.strictEqual(added.title, 'Screen time');
+  assert.strictEqual(added.cost, 20);
+  assert.strictEqual(added.needsApproval, false);
   console.log('✓ addReward appears in getState().rewards');
+
+  // The seeded shop itself, and that seeding is idempotent.
+  const seededTitles = state.rewards.map((r) => r.title);
+  assert.ok(seededTitles.includes('A player for your soccer game'), 'seeded rewards should be present');
+  assert.strictEqual(
+    seededTitles.filter((t) => t === 'A player for your soccer game').length,
+    1,
+    'a seeded reward should not be duplicated'
+  );
+  const soccer = state.rewards.find((r) => r.title === 'A player for your soccer game');
+  assert.strictEqual(soccer.cost, 15, 'the cheapest reward is the first-win one');
+  assert.strictEqual(soccer.needsApproval, true, 'seeded rewards need parent approval');
+  console.log('✓ rewards are seeded into an existing household, without duplicates');
 
   // Soft-delete reward — set active: false
   const rewardDoc = (await rewardsContainer.items.query({}).fetchAll()).resources.find((r) => r.id === 'reward1');
@@ -855,7 +871,12 @@ async function main() {
   await rewardsContainer.item('reward1').replace(rewardDoc);
 
   state = await getState();
-  assert.strictEqual(state.rewards.length, 0, 'soft-deleted reward should not appear in getState().rewards');
+  // Same reasoning as above: assert this reward is gone, not that the shop is
+  // empty. The seeded rewards are legitimately still there.
+  assert.ok(
+    !state.rewards.some((r) => r.id === 'reward1'),
+    'soft-deleted reward should not appear in getState().rewards'
+  );
   console.log('✓ soft-deleted reward disappears from getState().rewards');
 
   // stats now include spent and balance

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -872,6 +872,15 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 .modal { background: var(--surface); border-radius: var(--radius-lg); padding: var(--space-6); width: 100%; max-width: 320px; text-align: center; box-shadow: var(--shadow-3); display: flex; flex-direction: column; gap: var(--space-3); }
 .modal h3 { margin-bottom: var(--space-3); font-size: var(--text-lg); font-weight: var(--weight-bold); }
 .pin-input { font-size: var(--text-2xl); text-align: center; letter-spacing: 0.4em; width: 100%; padding: var(--space-3); border: 2px solid var(--border); border-radius: var(--radius-md); font-family: inherit; color: var(--ink); background: var(--surface-sunken); }
+.next-goal {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--on-brand-faint);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+}
+.next-goal-title { font-weight: var(--weight-bold); }
+.next-goal-gap { color: var(--on-brand-strong); }
 .ask-input { font-size: var(--text-base); width: 100%; padding: var(--space-3); border: 2px solid var(--border); border-radius: var(--radius-md); font-family: inherit; color: var(--ink); background: var(--surface-sunken); }
 .ask-input:focus { outline: none; border-color: var(--brand); }
 .pin-err { color: var(--danger); font-size: var(--text-sm); min-height: 1.2em; }
@@ -1049,6 +1058,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
           <div class="progress-bar"><div class="progress-fill" id="k-progress-fill"></div></div>
           <div class="progress-lbl" id="k-progress-lbl"></div>
         </div>
+        <div class="next-goal hidden" id="k-next-goal"></div>
       </div>
       <div class="home-content-sheet">
         <h2 class="section-title">📅 Today's Missions</h2>
@@ -1797,6 +1807,7 @@ function renderKid(kid) {
   renderTaskList('k-oneoff', oneoffs, '⭐', 'No one-off missions.', '');
 
   renderRewardShop(kid, balance);
+  renderNextGoal(balance);
   renderRedemptions(kid);
   renderRecentActivity(kid);
   renderKidCalendar(kid);
@@ -2444,6 +2455,45 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
       + '<span class="pts-badge">+' + t.points + '</span>'
       + '</div>';
   }).join('');
+}
+
+// The nearest goal, shown where kids actually land.
+//
+// "N more points to go" already existed - but only inside the Rewards tab,
+// which they have to go looking for. On Home it is the thing that makes a chore
+// feel worth doing.
+//
+// Deliberately the CHEAPEST reward they cannot yet afford, not the dearest:
+// "80 more points" reads as hopeless to a seven-year-old, "5 more points" reads
+// as nearly there. Takes the same balance renderRewardShop() is given, so the
+// two screens can never disagree.
+function renderNextGoal(balance) {
+  var el = document.getElementById('k-next-goal');
+  if (!el) return;
+
+  var rewards = (state.rewards || []).filter(function(r) { return r.active !== false; });
+  if (rewards.length === 0) {
+    el.classList.add('hidden');
+    el.innerHTML = '';
+    return;
+  }
+
+  var affordable = rewards.filter(function(r) { return r.cost <= balance; });
+  if (affordable.length > 0) {
+    el.classList.remove('hidden');
+    el.innerHTML = '<span class="next-goal-title">🎉 You can claim a reward!</span>'
+      + ' <span class="next-goal-gap">Have a look in Rewards.</span>';
+    return;
+  }
+
+  var next = rewards.filter(function(r) { return r.cost > balance; })
+    .sort(function(a, b) { return a.cost - b.cost; })[0];
+  if (!next) { el.classList.add('hidden'); el.innerHTML = ''; return; }
+
+  var shortBy = next.cost - balance;
+  el.classList.remove('hidden');
+  el.innerHTML = '<span class="next-goal-title">🎁 ' + esc(next.title) + '</span>'
+    + ' <span class="next-goal-gap">— ' + shortBy + ' more point' + (shortBy === 1 ? '' : 's') + '!</span>';
 }
 
 function renderRewardShop(kid, balance) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -153,3 +153,23 @@ test('cancelling the in-app dialog does nothing', async ({ page }) => {
   await expect(page.locator('#ask-modal')).toBeHidden();
   await expect(page.locator('#screen-kid')).toBeVisible();
 });
+
+// The rewards shop shipped with no rewards in it, so the "N more points to go"
+// text that was already written had never once been seen. That is the shape
+// this whole suite exists for: coded correctly, invisible in the running app.
+test('the kid Home screen names a real reward and how far away it is', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+
+  const goal = page.locator('#k-next-goal');
+  await expect(goal).toBeVisible();
+  // Cheapest unaffordable reward first - a nearby goal, not a hopeless one.
+  await expect(goal).toContainText('A player for your soccer game');
+  await expect(goal).toContainText(/\d+ more points?/);
+});
+
+test('the rewards shop is not empty', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /rewards/i }).first().click();
+  await expect(page.locator('#k-rewards')).not.toContainText('No rewards in the shop yet');
+  await expect(page.locator('#k-rewards')).toContainText("Ice cream from McDonald's");
+});


### PR DESCRIPTION
Closes #161. Built here rather than by Copilot — zero premium requests.

The rewards feature **shipped with no rewards**. `seed.js` seeded a household and four people and nothing else, so `renderRewardShop()` always took its empty branch and every kid saw *"Ask your grown-up to add some!"* permanently. The "N more points to go" text under each unaffordable reward was already written — and had therefore never once been seen.

## The four rewards

| Points | Reward | Real cost |
|---|---|---|
| **15** | A player for your soccer game | ~80c in-game |
| 25 | Ice cream from McDonald's | ~$1 |
| 50 | Ice cream from the Italian place | ~$6 |
| 80 | Pick dinner, from 3 options | — |

The soccer player is **deliberately the cheapest**. It's the one that actually motivates Ollie, so it's the first-win reward — the thing that proves the system pays out before a kid loses interest. Making the most motivating reward the hardest to reach is how the mechanic dies in week one. "Pick dinner" is dearest despite costing nothing, because it has real social value and no natural price.

## Seeding alone would have changed nothing — the #88 trap

`ensureSeeded()` only creates things when the household does **not** yet exist, and every real one already does. That's exactly how #88's avatars shipped green and left the live app untouched.

So `topUpRewards()` runs on **both** branches, adding only rewards whose title isn't already present. Idempotent, and a reward that's been edited or soft-deleted is neither overwritten nor resurrected.

**Verified against a household that already exists:** 4 rewards after the first run, 4 after the second.

## The Home screen

`renderNextGoal()` shows the **cheapest** reward not yet affordable, not the dearest — *"80 more points"* reads as hopeless to a seven-year-old, *"5 more points"* reads as nearly there. It takes the same balance `renderRewardShop()` is given, so Home and the Rewards tab can't disagree. Affordable → says so and points at the tab. Empty shop → renders nothing, not dead space.

## Two tests changed, and why

Two existing tests asserted reward **counts** (one active, then zero after a soft delete). Both now assert on the specific reward instead. A count needs editing every time the seed list changes — a maintenance tax that tests nothing.

## Verification

`api/test-logic.js`, `check-frontend.js`, `check-design.js` all pass. Smoke suite **11/11**, including two new cases: the Home screen names the soccer player with a shortfall, and the shop is not empty.

The design check caught a raw `rgba()` I'd written for the divider — replaced with the existing `--on-brand-faint` token, which already existed for exactly this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_