### PR TITLE
Kid Home: count toward real prizes, not eggs and streaks

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -285,8 +285,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   padding: var(--space-5) var(--space-5) calc(var(--space-7) + var(--space-3));
   text-align: center;
 }
-.k-level-text { font-size: var(--text-lg); font-weight: var(--weight-bold); line-height: var(--leading-tight); }
-.k-streak {
+.k-goal-title { font-size: var(--text-lg); font-weight: var(--weight-bold); line-height: var(--leading-tight); }
+.k-goal-balance {
   display: inline-block; margin-top: var(--space-2);
   background: var(--on-brand-faint); border-radius: var(--radius-full);
   padding: var(--space-1) var(--space-3);
@@ -1071,8 +1071,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
     <!-- HOME TAB -->
     <div id="tab-home" class="tab-panel">
       <div class="kid-home-hero" id="k-home-hero">
-        <div class="k-level-text" id="k-level"></div>
-        <span class="k-streak" id="k-streak"></span>
+        <div class="k-goal-title" id="k-goal-title"></div>
+        <span class="k-goal-balance" id="k-goal-balance"></span>
         <div class="progress-wrap">
           <div class="progress-bar"><div class="progress-fill" id="k-progress-fill"></div></div>
           <div class="progress-lbl" id="k-progress-lbl"></div>
@@ -1503,18 +1503,6 @@ function setAvatar(el, value, color) {
   el.textContent = value || '❓';
 }
 
-const LEVELS = [
-  { pts: 0,   title: 'Egg',               emoji: '🥚' },
-  { pts: 25,  title: 'Hatchling',         emoji: '🐣' },
-  { pts: 60,  title: 'Busy Bee',          emoji: '🐝' },
-  { pts: 110, title: 'Ninja in Training', emoji: '🥷' },
-  { pts: 170, title: 'Chore Ninja',       emoji: '⚡' },
-  { pts: 250, title: 'Superstar',         emoji: '🌟' },
-  { pts: 350, title: 'Rocketeer',         emoji: '🚀' },
-  { pts: 480, title: 'Legend',            emoji: '🏆' },
-  { pts: 650, title: 'MEGA LEGEND',       emoji: '👑' },
-];
-
 const CHEERS = [
   'BOOM! 💥', 'You legend! 🙌', 'Chore-tastic! ✨', 'Nailed it! 🔨',
   'Super effort! 🦸', 'High five! ✋', 'Crushing it! 💪', 'Woohoo! 🎉'
@@ -1689,15 +1677,6 @@ function cycleCompletion(task) {
   return live[0] || null;
 }
 
-function levelFor(points) {
-  let lvl = LEVELS[0], next = null;
-  for (let i = 0; i < LEVELS.length; i++) {
-    if (points >= LEVELS[i].pts) lvl = LEVELS[i];
-    else { next = LEVELS[i]; break; }
-  }
-  return { lvl, next };
-}
-
 function buildEmptyState(emoji, line1, line2) {
   return '<div class="empty">'
     + '<span class="empty-emoji">' + emoji + '</span>'
@@ -1808,26 +1787,12 @@ function renderKid(kid) {
   document.getElementById('screen-kid').style.setProperty('--kid-color', kidColorVal);
   syncKidVoiceTrigger();
 
-  var st = state.stats[kid.id] || { points: 0, balance: 0, streak: 0 };
-  var lf = levelFor(st.points);
-  var lvl = lf.lvl, next = lf.next;
+  var st = state.stats[kid.id] || { points: 0, balance: 0 };
   var balance = typeof st.balance === 'number' ? st.balance : st.points;
 
   setAvatar(document.getElementById('k-avatar'), kid.emoji, kidColorVal);
   document.getElementById('k-name').textContent = kid.name;
-  document.getElementById('k-level').textContent = lvl.emoji + ' ' + lvl.title;
   animatePoints(balance);
-  document.getElementById('k-streak').textContent = st.streak > 0 ? '🔥 ' + st.streak + ' day streak' : '🔥 Start a streak today!';
-
-  if (next) {
-    var span = next.pts - lvl.pts;
-    var pct  = Math.min(100, Math.round(((st.points - lvl.pts) / span) * 100));
-    document.getElementById('k-progress-lbl').textContent = (next.pts - st.points) + ' points to become ' + next.emoji + ' ' + next.title + '!';
-    document.getElementById('k-progress-fill').style.width = pct + '%';
-  } else {
-    document.getElementById('k-progress-lbl').textContent = '👑 Maximum level reached. Absolute royalty.';
-    document.getElementById('k-progress-fill').style.width = '100%';
-  }
 
   var mine = state.tasks.filter(function(t) { return t.kidId === kid.id; });
   renderTaskList('k-weekly', mine.filter(function(t) { return t.cycle === 'weekly'; }),
@@ -1840,7 +1805,7 @@ function renderKid(kid) {
   renderTaskList('k-oneoff', oneoffs, '⭐', 'No one-off missions.', '');
 
   renderRewardShop(kid, balance);
-  renderNextGoal(balance);
+  renderRewardProgress(balance);
   renderRedemptions(kid);
   renderRecentActivity(kid);
   renderKidCalendar(kid);
@@ -2612,43 +2577,72 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
   }).join('');
 }
 
-// The nearest goal, shown where kids actually land.
+// The kid Home hero: how close you are to the next real prize.
 //
-// "N more points to go" already existed - but only inside the Rewards tab,
-// which they have to go looking for. On Home it is the thing that makes a chore
-// feel worth doing.
+// This REPLACED the pet ladder (Egg -> Hatchling -> ... -> MEGA LEGEND) and the
+// daily streak badge. Those were invented goals: hatching an egg buys nothing,
+// and a broken streak only ever punishes. The prizes in the Rewards shop are
+// the thing the kids actually want, so the hero now measures distance to one of
+// those instead. Points still accrue exactly as before - only what the screen
+// counts toward has changed.
 //
-// Deliberately the CHEAPEST reward they cannot yet afford, not the dearest:
-// "80 more points" reads as hopeless to a seven-year-old, "5 more points" reads
-// as nearly there. Takes the same balance renderRewardShop() is given, so the
-// two screens can never disagree.
-function renderNextGoal(balance) {
-  var el = document.getElementById('k-next-goal');
-  if (!el) return;
+// The target is deliberately the CHEAPEST reward they cannot yet afford, not
+// the dearest: "80 more points" reads as hopeless to a seven-year-old, "5 more
+// points" reads as nearly there. Takes the same balance renderRewardShop() is
+// given, so the two screens can never disagree.
+function renderRewardProgress(balance) {
+  var titleEl = document.getElementById('k-goal-title');
+  var balanceEl = document.getElementById('k-goal-balance');
+  var fill = document.getElementById('k-progress-fill');
+  var lbl = document.getElementById('k-progress-lbl');
+  var nextEl = document.getElementById('k-next-goal');
+  if (!titleEl || !fill || !lbl) return;
+
+  balanceEl.textContent = '\u2B50 ' + balance + ' point' + (balance === 1 ? '' : 's') + ' to spend';
 
   var rewards = (state.rewards || []).filter(function(r) { return r.active !== false; });
   if (rewards.length === 0) {
-    el.classList.add('hidden');
-    el.innerHTML = '';
+    titleEl.textContent = '\u2B50 Keep earning points!';
+    fill.style.width = '0%';
+    lbl.textContent = 'No prizes in the shop yet \u2014 ask your grown-up to add some.';
+    nextEl.classList.add('hidden');
+    nextEl.innerHTML = '';
     return;
   }
 
-  var affordable = rewards.filter(function(r) { return r.cost <= balance; });
-  if (affordable.length > 0) {
-    el.classList.remove('hidden');
-    el.innerHTML = '<span class="next-goal-title">🎉 You can claim a reward!</span>'
-      + ' <span class="next-goal-gap">Have a look in Rewards.</span>';
+  var sorted = rewards.slice().sort(function(a, b) { return a.cost - b.cost; });
+  var next = sorted.filter(function(r) { return r.cost > balance; })[0];
+
+  if (!next) {
+    // Everything in the shop is already within reach - name the best one.
+    var best = sorted[sorted.length - 1];
+    titleEl.textContent = '\uD83C\uDF89 You can get ' + best.title + '!';
+    fill.style.width = '100%';
+    lbl.textContent = 'Head to Rewards to claim it.';
+    nextEl.classList.add('hidden');
+    nextEl.innerHTML = '';
     return;
   }
-
-  var next = rewards.filter(function(r) { return r.cost > balance; })
-    .sort(function(a, b) { return a.cost - b.cost; })[0];
-  if (!next) { el.classList.add('hidden'); el.innerHTML = ''; return; }
 
   var shortBy = next.cost - balance;
-  el.classList.remove('hidden');
-  el.innerHTML = '<span class="next-goal-title">🎁 ' + esc(next.title) + '</span>'
-    + ' <span class="next-goal-gap">— ' + shortBy + ' more point' + (shortBy === 1 ? '' : 's') + '!</span>';
+  var pct = next.cost > 0 ? Math.min(100, Math.round((balance / next.cost) * 100)) : 0;
+  titleEl.textContent = '\uD83C\uDF81 ' + next.title;
+  fill.style.width = pct + '%';
+  lbl.textContent = shortBy + ' more point' + (shortBy === 1 ? '' : 's') + ' to go!';
+
+  // Anything already affordable is a prize they can claim right now, so say so
+  // rather than letting them save past it without noticing.
+  var affordable = sorted.filter(function(r) { return r.cost <= balance; });
+  if (affordable.length > 0) {
+    var claimable = affordable[affordable.length - 1];
+    nextEl.classList.remove('hidden');
+    nextEl.innerHTML = '<span class="next-goal-title">\uD83C\uDF89 You can already get '
+      + esc(claimable.title) + '</span>'
+      + ' <span class="next-goal-gap">Claim it in Rewards, or keep saving.</span>';
+  } else {
+    nextEl.classList.add('hidden');
+    nextEl.innerHTML = '';
+  }
 }
 
 function renderRewardShop(kid, balance) {
@@ -3533,7 +3527,7 @@ async function redeemKidReward(rewardId, cost) {
   var syntheticId = '_opt_' + rewardId + '_' + Date.now();
   var prevRedemptions = (state.redemptions || []).slice();
   var prevStats = JSON.parse(JSON.stringify(state.stats || {}));
-  var kidStats = prevStats[session.personId] || { points: 0, balance: 0, streak: 0 };
+  var kidStats = prevStats[session.personId] || { points: 0, balance: 0 };
   state.redemptions = prevRedemptions.concat([{
     id: syntheticId, rewardId: rewardId, kidId: session.personId,
     title: rewardTitle, cost: cost, status: reward && !reward.needsApproval ? 'approved' : 'pending',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -941,13 +941,15 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   color: var(--ink-muted);
   margin-top: var(--space-2);
 }
-.voice-when-choices {
+.voice-when-choices,
+.voice-type-choices {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
   margin-top: var(--space-3);
 }
-.voice-when-choices .choice-pill {
+.voice-when-choices .choice-pill,
+.voice-type-choices .choice-pill {
   background: var(--surface);
 }
 
@@ -1374,6 +1376,15 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
       <div id="voice-transcript-help" class="voice-help hidden"></div>
     </div>
     <div id="voice-reminder-fields" class="hidden">
+      <div class="field voice-field" id="voice-type-field">
+        <label>What kind of thing is this?</label>
+        <div id="voice-type-choices" class="voice-type-choices">
+          <button class="choice-pill" id="voice-type-choice-reminder" type="button" onclick="chooseVoiceReminderType('reminder')">Reminder</button>
+          <button class="choice-pill" id="voice-type-choice-task" type="button" onclick="chooseVoiceReminderType('task')">Task</button>
+          <button class="choice-pill" id="voice-type-choice-event" type="button" onclick="chooseVoiceReminderType('event')">Event</button>
+        </div>
+        <div id="voice-type-help" class="voice-help hidden"></div>
+      </div>
       <div class="field voice-field" id="voice-what-field">
         <label for="voice-what-input">What should I remind you about?</label>
         <input id="voice-what-input" type="text" autocomplete="off" oninput="updateVoiceReminderWhat(this.value)">
@@ -1524,6 +1535,11 @@ let kidCalendarItems = [];
 let kidCalendarLoading = false;
 let parentTab = 'approvals';
 const VOICE_REMINDER_CONFIRMATION_THRESHOLD = 0.6;
+const VOICE_REMINDER_TYPE_CHOICES = {
+  reminder: { label: 'Reminder', help: 'A nudge — I\u2019ll remind you about it.' },
+  task: { label: 'Task', help: 'Something to do and tick off.' },
+  event: { label: 'Event', help: 'Something happening at a set time.' },
+};
 const VOICE_REMINDER_WHEN_CHOICES = {
   today: { value: 'Today', label: 'Today' },
   tomorrow: { value: 'Tomorrow', label: 'Tomorrow' },
@@ -3130,7 +3146,8 @@ function newVoiceReminderDraft(overrides) {
     when: '',
     suggestedWhoId: session ? session.personId : null,
     selectedWhenChoice: '',
-    flags: { transcript: false, what: false, when: false, who: false },
+    type: 'reminder',
+    flags: { transcript: false, what: false, when: false, who: false, type: false },
     showWhenChoices: false,
     status: '',
   }, overrides || {});
@@ -3205,6 +3222,8 @@ function renderVoiceReminderModal() {
   var primary = document.getElementById('voice-reminder-primary');
   var secondary = document.getElementById('voice-reminder-secondary');
   var whenChoices = document.getElementById('voice-when-choices');
+  var typeField = document.getElementById('voice-type-field');
+  var typeHelp = document.getElementById('voice-type-help');
   var whatHelp = document.getElementById('voice-what-help');
   var whenHelp = document.getElementById('voice-when-help');
   var whoHelp = document.getElementById('voice-who-help');
@@ -3213,6 +3232,7 @@ function renderVoiceReminderModal() {
   whatField.classList.toggle('attention', !!voiceReminderDraft.flags.what);
   whenField.classList.toggle('attention', !!voiceReminderDraft.flags.when);
   whoField.classList.toggle('attention', !!voiceReminderDraft.flags.who);
+  typeField.classList.toggle('attention', !!voiceReminderDraft.flags.type);
 
   status.textContent = voiceReminderDraft.status || '';
   status.classList.toggle('hidden', !voiceReminderDraft.status);
@@ -3236,6 +3256,15 @@ function renderVoiceReminderModal() {
     var btn = document.getElementById('voice-when-choice-' + key);
     if (btn) btn.classList.toggle('active', voiceReminderDraft.selectedWhenChoice === key);
   });
+
+  Object.keys(VOICE_REMINDER_TYPE_CHOICES).forEach(function(key) {
+    var btn = document.getElementById('voice-type-choice-' + key);
+    if (btn) btn.classList.toggle('active', voiceReminderDraft.type === key);
+  });
+  typeHelp.textContent = voiceReminderDraft.flags.type
+    ? 'I wasn\u2019t sure which one this is \u2014 tap the right one.'
+    : (VOICE_REMINDER_TYPE_CHOICES[voiceReminderDraft.type] || {}).help || '';
+  typeHelp.classList.toggle('hidden', !typeHelp.textContent);
 
   whatHelp.textContent = voiceReminderDraft.flags.what ? 'This bit needs a quick check.' : '';
   whenHelp.textContent = voiceReminderDraft.flags.when
@@ -3369,6 +3398,13 @@ function chooseVoiceReminderWhen(choiceKey) {
   updateVoiceReminderWhen(voiceReminderDraft.when);
 }
 
+function chooseVoiceReminderType(typeKey) {
+  if (!voiceReminderDraft || !VOICE_REMINDER_TYPE_CHOICES[typeKey]) return;
+  voiceReminderDraft.type = typeKey;
+  voiceReminderDraft.flags.type = false;
+  renderVoiceReminderModal();
+}
+
 function applyVoiceReminderValidation(result) {
   var intent = result && result.intent ? result.intent : {};
   var confidence = result && result.confidence ? result.confidence : {};
@@ -3383,8 +3419,11 @@ function applyVoiceReminderValidation(result) {
   voiceReminderDraft.when = String(intent.when || '').trim();
   voiceReminderDraft.suggestedWhoId = suggestedWhoId;
   voiceReminderDraft.selectedWhenChoice = voiceReminderChoiceKey(voiceReminderDraft.when);
+  var suggestedType = String(intent.type || '').trim().toLowerCase();
+  voiceReminderDraft.type = VOICE_REMINDER_TYPE_CHOICES[suggestedType] ? suggestedType : 'reminder';
   voiceReminderDraft.flags = {
     transcript: parseFallback,
+    type: parseFallback || Number(confidence.type) < VOICE_REMINDER_CONFIRMATION_THRESHOLD,
     what: parseFallback || Number(confidence.what) < VOICE_REMINDER_CONFIRMATION_THRESHOLD,
     when: parseFallback || Number(confidence.when) < VOICE_REMINDER_CONFIRMATION_THRESHOLD,
     who: parseFallback || Number(confidence.who) < VOICE_REMINDER_CONFIRMATION_THRESHOLD || suggestedWhoId !== session.personId,
@@ -3446,10 +3485,11 @@ async function handleVoiceReminderPrimary() {
   var result;
   try {
     result = await api({
-      action: 'saveVoiceReminder',
+      action: 'saveVoicePlan',
       personId: session.personId,
       pin: session.pin,
       kidId: session.personId,
+      type: voiceReminderDraft.type,
       title: title,
       when: when || null,
       transcript: voiceReminderDraft.transcript,
@@ -3467,8 +3507,9 @@ async function handleVoiceReminderPrimary() {
     renderVoiceReminderModal();
     return;
   }
+  var savedType = VOICE_REMINDER_TYPE_CHOICES[voiceReminderDraft.type] || VOICE_REMINDER_TYPE_CHOICES.reminder;
   closeVoiceReminder();
-  toast('Voice reminder saved! 🎤');
+  toast(savedType.label + ' saved! 🎤');
 }
 
 function handleVoiceReminderSecondary() {

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Hero Tasks",
   "short_name": "Hero Tasks",
-  "description": "Family chore and task app with points, levels and streaks",
+  "description": "Family chore and task app — earn points, save up for real prizes",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#f7f5ff",

--- a/scripts/check-frontend.js
+++ b/scripts/check-frontend.js
@@ -125,7 +125,10 @@ check(/id="k-voice-reminder-btn"/.test(html), 'kid Home tab includes a voice rem
 check(/id="voice-reminder-modal"/.test(html), 'voice reminder confirmation modal exists');
 check(/window\.SpeechRecognition \|\| window\.webkitSpeechRecognition/.test(html), 'voice reminder flow feature-detects SpeechRecognition support');
 check(/action:\s*'validateVoiceNote'/.test(html), 'voice reminder flow calls validateVoiceNote');
-check(/action:\s*'saveVoiceReminder'/.test(html), 'voice reminder flow calls saveVoiceReminder');
+check(/action:\s*'saveVoicePlan'/.test(html), 'voice capture flow calls saveVoicePlan');
+check(/type:\s*voiceReminderDraft\.type/.test(html), 'voice capture flow sends the chosen item type');
+check(/id="voice-type-choice-reminder"/.test(html) && /id="voice-type-choice-task"/.test(html) && /id="voice-type-choice-event"/.test(html), 'voice capture sheet offers reminder/task/event pills');
+check(/function chooseVoiceReminderType\(typeKey\)/.test(html), 'voice capture sheet lets the kid change the item type');
 check(/This weekend/.test(html) && /No specific time/.test(html), 'voice reminder flow includes low-confidence when choice pills');
 const kidTabButtons = html.match(/id="tabbtn-(home|missions|rewards|leaderboard|calendar)"/g) || [];
 check(kidTabButtons.length === 5, `kid nav exposes 5 tab buttons (${kidTabButtons.length} found)`);

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -199,3 +199,37 @@ test('the old daily-only Missions section is gone from Home', async ({ page }) =
   await page.getByRole('button', { name: /missions/i }).first().click();
   await expect(page.locator('#k-weekly')).toBeVisible();
 });
+
+// #128. The capture sheet used to post `action: 'saveVoiceReminder'`, which is
+// not in hero.js's ROUTES table at all - every save returned "Unknown action".
+// Source-level checks could not see that: the string was present, the route was
+// not. This drives the real sheet against the real route table, so the two have
+// to agree. Headless Chromium has no SpeechRecognition, so the flow opens on
+// its typed fallback - the same path a kid on an unsupported browser takes.
+test('the voice capture sheet lets the kid pick the item type and saves it', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+
+  await page.locator('#k-voice-reminder-btn').click();
+  await expect(page.locator('#voice-reminder-modal')).toBeVisible();
+
+  await page.locator('#voice-transcript-input').fill('soccer training on Saturday');
+  await page.getByRole('button', { name: /check it/i }).click();
+
+  // Type pills only appear once the sheet has something to confirm.
+  await expect(page.locator('#voice-type-choices')).toBeVisible();
+  await expect(page.locator('#voice-type-choice-reminder')).toBeVisible();
+  await expect(page.locator('#voice-type-choice-task')).toBeVisible();
+  await expect(page.locator('#voice-type-choice-event')).toBeVisible();
+
+  // Exactly one is selected at a time, and the kid's choice sticks.
+  await page.locator('#voice-type-choice-event').click();
+  await expect(page.locator('#voice-type-choice-event')).toHaveClass(/active/);
+  await expect(page.locator('#voice-type-choices .choice-pill.active')).toHaveCount(1);
+
+  await page.getByRole('button', { name: /^confirm$/i }).click();
+
+  // The save has to actually land. An unknown action leaves the sheet open with
+  // an error, so a closed sheet is the assertion that matters here.
+  await expect(page.locator('#voice-reminder-modal')).toBeHidden();
+  await expect(page.locator('#toast')).toContainText(/Event saved/i);
+});

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -204,9 +204,20 @@ test('the old daily-only Missions section is gone from Home', async ({ page }) =
 // not in hero.js's ROUTES table at all - every save returned "Unknown action".
 // Source-level checks could not see that: the string was present, the route was
 // not. This drives the real sheet against the real route table, so the two have
-// to agree. Headless Chromium has no SpeechRecognition, so the flow opens on
-// its typed fallback - the same path a kid on an unsupported browser takes.
+// to agree.
+//
+// SpeechRecognition is removed first, deliberately. Whether a headless Chromium
+// exposes it varies by build - where it does, start() waits on a speech service
+// the runner cannot reach and the sheet never opens, so the test would pass or
+// hang depending on the machine. Removing it pins the flow to its typed
+// fallback: the documented path for a browser that cannot record, and the one
+// that exercises everything this test is actually about.
 test('the voice capture sheet lets the kid pick the item type and saves it', async ({ page }) => {
+  await page.addInitScript(() => {
+    delete window.SpeechRecognition;
+    delete window.webkitSpeechRecognition;
+  });
+  await page.reload();
   await pickPerson(page, 'Ollie');
 
   await page.locator('#k-voice-reminder-btn').click();

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -160,11 +160,24 @@ test('cancelling the in-app dialog does nothing', async ({ page }) => {
 test('the kid Home screen names a real reward and how far away it is', async ({ page }) => {
   await pickPerson(page, 'Ollie');
 
-  const goal = page.locator('#k-next-goal');
-  await expect(goal).toBeVisible();
   // Cheapest unaffordable reward first - a nearby goal, not a hopeless one.
-  await expect(goal).toContainText('A player for your soccer game');
-  await expect(goal).toContainText(/\d+ more points?/);
+  await expect(page.locator('#k-goal-title')).toContainText('A player for your soccer game');
+  await expect(page.locator('#k-progress-lbl')).toContainText(/\d+ more points? to go/);
+  await expect(page.locator('#k-goal-balance')).toContainText(/\d+ points? to spend/);
+});
+
+// #9. The hero used to count toward a pet ladder (Egg -> Hatchling -> ... ->
+// MEGA LEGEND) and a daily streak. Neither buys anything, so neither motivated
+// anyone. If any of this reappears, the incentive path has been undone.
+test('the pet ladder and the streak badge are gone from the kid Home screen', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+
+  const home = page.locator('#tab-home');
+  await expect(home).not.toContainText(/Egg|Hatchling|Busy Bee|Chore Ninja|MEGA LEGEND/);
+  await expect(home).not.toContainText(/streak/i);
+  await expect(home).not.toContainText(/points to become/i);
+  await expect(page.locator('#k-streak')).toHaveCount(0);
+  await expect(page.locator('#k-level')).toHaveCount(0);
 });
 
 test('the rewards shop is not empty', async ({ page }) => {


### PR DESCRIPTION
Closes #9.

> Stacked on #175 — it branches off that commit, so this diff shows the voice-type change too until #175 merges. Merge #175 first.

**User story**

> As a kid, when I open Hero Tasks I want to see how close I am to the ice cream — not how close I am to hatching an egg.

## Why

The Home hero counted toward a pet ladder (Egg → Hatchling → Busy Bee → Ninja in Training → Chore Ninja → Superstar → Rocketeer → Legend → MEGA LEGEND) and showed a daily streak badge.

Neither buys anything. Hatching an egg is an invented goal, and a streak only ever punishes the day it breaks. The prizes in the Rewards shop are what the kids actually want, so that is what the hero now measures distance to.

## What the hero shows now

| Before | After |
|---|---|
| 🥚 Egg | 🎁 A player for your soccer game |
| 🔥 Start a streak today! | ⭐ 0 points to spend |
| bar → next level threshold | bar → the prize's cost |
| 25 points to become 🐣 Hatchling! | 15 more points to go! |

The target is the **cheapest** prize they cannot yet afford, not the dearest — "80 more points" reads as hopeless to a seven-year-old, "15 more points" reads as nearly there. When something in the shop is already affordable, a line says so, so they don't save past it without noticing.

**Points still accrue exactly as before.** Only what the screen counts toward has changed. No API change, no data change.

## Removed

- `LEVELS` (the nine-rung pet ladder) and `levelFor()`
- `#k-level` and `#k-streak` and their CSS
- The manifest's `"points, levels and streaks"` description

The API still computes `streak` and `badges` in `stats`. Nothing renders them now — that server-side cleanup is a separate safe change, best done alongside closing #103.

## Files

- `frontend/index.html` — `renderRewardProgress()` replaces `renderNextGoal()`; hero markup and CSS
- `frontend/manifest.json` — description matches what the app now rewards
- `tests/smoke/smoke.spec.js` — assert the new hero, and assert the pet ladder and streak cannot come back

## Testing

- `node api/test-logic.js` — passes
- `node scripts/check-frontend.js` — passes
- `node scripts/check-design.js` — passes
- Smoke suite — **15/15 passed** locally

The new guard case fails if `Egg`, `Hatchling`, `MEGA LEGEND`, `streak` or `points to become` ever reappear on the Home tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_