### PR TITLE
Deploy: tag the commit that was actually deployed, not whatever main is now

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,14 @@ name: Deploy to Azure
 # HEAD^. A failed deploy leaves the tag where it is and the next push retries
 # it, and several commits landing together cannot hide each other.
 #
+# Every job checks out ${{ github.sha }} - this run's own commit - and never
+# 'main'. When #175 and #176 merged 45 seconds apart, the deploy job correctly
+# uploaded #175's commit, but the record job checked out 'main' (already moved
+# on to #176) and tagged THAT as deployed. #176's own run then compared main
+# against the tag, found them identical, logged "Nothing changed since the last
+# deploy" and skipped every job - green, having shipped nothing. The commit sat
+# undeployed while the pipeline reported success.
+#
 # Required repository secrets:
 #   AZURE_STATIC_WEB_APPS_API_TOKEN  - Static Web App deployment token
 #                                      (Portal -> herotasks-swa-dev -> Manage
@@ -46,7 +54,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          # This run's own commit, NOT 'main'. A later merge can move main
+          # while this run is still queued, and then the run reports on a
+          # commit it is not deploying. That is exactly how #176 was skipped.
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - name: Detect what changed since the last successful deploy
         id: filter
@@ -163,9 +174,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          # Same reason as the 'changes' job: tag the commit this run actually
+          # deployed. Checking out 'main' tagged whatever had merged in the
+          # meantime, marking an undeployed commit as live and causing the very
+          # next run to skip everything as "nothing changed".
+          ref: ${{ github.sha }}
+          fetch-depth: 0
       - name: Mark this commit as deployed
         run: |
-          git tag -f deployed
+          set -euo pipefail
+
+          # Runs are serialised by the concurrency group, but a retry or a
+          # re-run of an older run can still arrive late. Never move the tag
+          # backwards - that would re-deploy old code over new.
+          if git rev-parse -q --verify refs/tags/deployed >/dev/null 2>&1; then
+            PREV=$(git rev-parse refs/tags/deployed^{commit})
+            if [ "$PREV" = "${{ github.sha }}" ]; then
+              echo "Already tagged - nothing to do."
+              exit 0
+            fi
+            if ! git merge-base --is-ancestor "$PREV" "${{ github.sha }}"; then
+              echo "::warning::deployed ($PREV) is not an ancestor of ${{ github.sha }} - leaving the tag alone."
+              exit 0
+            fi
+          fi
+
+          git tag -f deployed "${{ github.sha }}"
           git push -f origin refs/tags/deployed
-          echo "deployed -> $(git rev-parse HEAD)"
+          echo "deployed -> ${{ github.sha }}"


### PR DESCRIPTION
**User story**

> As the owner, when the pipeline says a change deployed, I want it to actually be on the site — not sitting on main marked as live.

## The bug

#175 and #176 merged 45 seconds apart. From the run logs:

| Time (UTC) | What happened |
|---|---|
| 00:26:53 | #175's `deploy-frontend` checks out its own commit `2b2080f` and uploads it. **Correct.** |
| 00:27:28 | #176 merges. `main` moves to `952506c`. |
| 00:28:02 | #175's `record` job checks out `ref: main` — now `952506c` — and tags `deployed = 952506c`. **It tagged a commit that was never uploaded.** |
| 00:28:11 | #176's run compares main against the tag, they match, logs `Nothing changed since the last deploy`, skips every job. Run is green. |

Net effect: `952506c` (the kid Home rewrite) was on main, marked deployed, and had never reached Azure. The live site still served the previous build, and the pipeline reported success throughout.

This is silent by construction — a skipped job does not fail a run, so the workflow list showed nothing but green ticks.

## The fix

`changes` and `record` now check out `${{ github.sha }}` — this run's own commit — instead of `ref: main`. A run can no longer report on, or tag, a commit it is not deploying.

`record` additionally refuses to move the tag backwards: if the current `deployed` tag is not an ancestor of this run's commit, it warns and leaves it alone. Runs are serialised by the concurrency group, but a re-run of an older run could otherwise re-deploy old code over new.

The `deploy-api` and `deploy-frontend` jobs already used bare `actions/checkout@v4`, which defaults to the run's own commit — that is why the upload was correct and only the bookkeeping was wrong.

## Files

- `.github/workflows/deploy.yml` — pin `changes` and `record` to `github.sha`; forward-only tag move; header comment records the failure mode

## After merging

The `deployed` tag currently points at `952506c`, which was never uploaded, so a normal push would still skip the frontend. A `workflow_dispatch` run is needed once to force a full deploy — it sets `api=true` and `frontend=true` unconditionally, bypassing the tag, and the corrected `record` job then leaves the tag pointing at what genuinely shipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_