### PR TITLE
My List: a kid's own notes, plans and reminders

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -1083,6 +1083,138 @@ async function sendDueReminders(now = new Date()) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// My List - a kid's own notes, plans and reminders.
+//
+// These sit in the same planningItems container as the parent calendar, but on
+// their own routes gated by requireSelf rather than requireParent. Separate
+// routes rather than loosening the parent ones: validatePlanningPayload demands
+// an ISO startAt and only allows event|reminder, and a note jotted down with no
+// date fits neither. Widening it to admit undated notes would weaken the
+// validation the parent calendar depends on.
+//
+// This is also why My List exists at all. calendar() skips any item whose
+// startAt will not parse, so an undated personal item - including a voice item
+// whose "when" could not be read - is invisible everywhere in the app today.
+const MY_ITEM_TYPES = ['note', 'reminder', 'plan'];
+const MY_ITEM_CATEGORIES = ['school', 'home', 'sport', 'fun', 'other'];
+
+function isMyItem(doc, kidId) {
+  return doc
+    && doc.active !== false
+    && doc.personId === kidId
+    && MY_ITEM_TYPES.includes(doc.type);
+}
+
+async function readMyItems(kidId) {
+  const items = await queryHousehold('planningItems');
+  return items
+    .filter((doc) => isMyItem(doc, kidId))
+    .sort((a, b) => {
+      const byOrder = (a.order ?? 0) - (b.order ?? 0);
+      if (byOrder !== 0) return byOrder;
+      return String(a.createdAt || '').localeCompare(String(b.createdAt || ''));
+    });
+}
+
+async function myItems(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+  return { ok: true, items: await readMyItems(req.kidId) };
+}
+
+async function addMyItem(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+
+  const title = String(req.title || '').trim();
+  if (!title) return { ok: false, error: 'title is required' };
+
+  const type = String(req.type || '').trim();
+  if (!MY_ITEM_TYPES.includes(type)) {
+    return { ok: false, error: `type must be one of: ${MY_ITEM_TYPES.join(', ')}` };
+  }
+
+  const category = String(req.category || 'other').trim();
+  if (!MY_ITEM_CATEGORIES.includes(category)) {
+    return { ok: false, error: `category must be one of: ${MY_ITEM_CATEGORIES.join(', ')}` };
+  }
+
+  // New items go to the end of the kid's own list.
+  const existing = await readMyItems(req.kidId);
+  const order = existing.length
+    ? Math.max(...existing.map((doc) => doc.order ?? 0)) + 1
+    : 0;
+
+  const doc = {
+    id: randomUUID(),
+    householdId: HOUSEHOLD_ID,
+    personId: req.kidId,
+    type,
+    title,
+    category,
+    order,
+    status: 'open',
+    source: 'manual',
+    startAt: null,
+    allDay: false,
+    active: true,
+    createdAt: new Date().toISOString(),
+  };
+  await container('planningItems').items.create(doc);
+  return { ok: true, item: doc };
+}
+
+async function updateMyItem(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+  const planningItems = container('planningItems');
+  const { resource: doc } = await planningItems
+    .item(req.itemId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+
+  // The ownership check is the point of this route: a valid PIN proves who you
+  // are, not that the item you named is yours.
+  if (!isMyItem(doc, req.kidId)) return { ok: false, error: 'Item not found' };
+
+  if (req.title !== undefined) {
+    const title = String(req.title || '').trim();
+    if (!title) return { ok: false, error: 'title is required' };
+    doc.title = title;
+  }
+  if (req.category !== undefined) {
+    const category = String(req.category || '').trim();
+    if (!MY_ITEM_CATEGORIES.includes(category)) {
+      return { ok: false, error: `category must be one of: ${MY_ITEM_CATEGORIES.join(', ')}` };
+    }
+    doc.category = category;
+  }
+  if (req.status !== undefined) {
+    const status = String(req.status || '').trim();
+    if (!['open', 'done'].includes(status)) return { ok: false, error: 'status must be open or done' };
+    doc.status = status;
+  }
+
+  await planningItems.item(req.itemId, HOUSEHOLD_ID).replace(doc);
+  return { ok: true, item: doc };
+}
+
+async function deleteMyItem(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+  const planningItems = container('planningItems');
+  const { resource: doc } = await planningItems
+    .item(req.itemId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!isMyItem(doc, req.kidId)) return { ok: false, error: 'Item not found' };
+
+  // Soft delete, matching every other write to this container. #120 specified a
+  // hard delete, but that was written before the parent calendar CRUD landed -
+  // calendar() and the parent routes all test `active === false`, and one row
+  // that vanishes instead is a trap for the next person reading this file.
+  doc.active = false;
+  await planningItems.item(req.itemId, HOUSEHOLD_ID).replace(doc);
+  return { ok: true };
+}
+
 async function saveVoicePlan(req) {
   await requireSelf(req.personId, req.pin, req.kidId);
   const title = String(req.title || '').trim();
@@ -1146,6 +1278,10 @@ const ROUTES = {
   rejectRedemption,
   cancelRedemption,
   saveVoicePlan,
+  myItems,
+  addMyItem,
+  updateMyItem,
+  deleteMyItem,
 };
 
 app.http('hero', {

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -1563,6 +1563,83 @@ async function main() {
   assert.strictEqual(afterCrossKid.length, beforeBlank.length + 4, 'cross-kid save should be rejected without writing');
   console.log('✓ saveVoicePlan rejects cross-kid save');
 
+  // -------------------------------------------------------------------------
+  // My List - kid-owned notes, plans and reminders (#122)
+  // -------------------------------------------------------------------------
+  const addedNote = await ROUTES.addMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    type: 'note', title: 'Library book is due', category: 'school',
+  });
+  assert.strictEqual(addedNote.ok, true, 'addMyItem should succeed');
+  assert.strictEqual(addedNote.item.status, 'open', 'new item starts open');
+  assert.strictEqual(addedNote.item.personId, 'toby', 'item belongs to the caller');
+  assert.strictEqual(addedNote.item.startAt, null, 'a note has no date');
+  console.log('\u2713 addMyItem creates an undated kid-owned note');
+
+  const addedPlan = await ROUTES.addMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    type: 'plan', title: 'Build the lego set', category: 'fun',
+  });
+  assert.ok(addedPlan.item.order > addedNote.item.order, 'new items append to the end');
+  console.log('\u2713 addMyItem appends to the end of the list');
+
+  const badType = await ROUTES.addMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    type: 'chore', title: 'Sneak in a chore', category: 'home',
+  });
+  assert.strictEqual(badType.ok, false, 'chore is not a My List type');
+  console.log('\u2713 addMyItem rejects a type outside note/reminder/plan');
+
+  const badCategory = await ROUTES.addMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    type: 'note', title: 'Whatever', category: 'nonsense',
+  });
+  assert.strictEqual(badCategory.ok, false, 'unknown category is rejected');
+  console.log('\u2713 addMyItem rejects an unknown category');
+
+  const listed = await ROUTES.myItems({ personId: 'toby', pin: '1234', kidId: 'toby' });
+  assert.strictEqual(listed.ok, true, 'myItems should succeed');
+  assert.ok(listed.items.every((item) => item.personId === 'toby'), 'only the caller\u2019s items come back');
+  assert.ok(
+    listed.items.every((item) => ['note', 'reminder', 'plan'].includes(item.type)),
+    'voice tasks and events stay out of My List',
+  );
+  console.log('\u2713 myItems returns only that kid\u2019s note/reminder/plan items');
+
+  const doneRes = await ROUTES.updateMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    itemId: addedNote.item.id, status: 'done',
+  });
+  assert.strictEqual(doneRes.item.status, 'done', 'status flips to done');
+  console.log('\u2713 updateMyItem marks an item done');
+
+  // A valid PIN proves who you are, not that the item you named is yours.
+  const crossKid = await ROUTES.updateMyItem({
+    personId: 'ollie', pin: '1234', kidId: 'ollie',
+    itemId: addedNote.item.id, title: 'Hijacked',
+  });
+  assert.strictEqual(crossKid.ok, false, 'another kid cannot edit this item');
+  const stillMine = (await ROUTES.myItems({ personId: 'toby', pin: '1234', kidId: 'toby' }))
+    .items.find((item) => item.id === addedNote.item.id);
+  assert.strictEqual(stillMine.title, 'Library book is due', 'the title was not changed');
+  console.log('\u2713 updateMyItem refuses to touch another kid\u2019s item');
+
+  const crossDelete = await ROUTES.deleteMyItem({
+    personId: 'ollie', pin: '1234', kidId: 'ollie', itemId: addedNote.item.id,
+  });
+  assert.strictEqual(crossDelete.ok, false, 'another kid cannot delete this item');
+  console.log('\u2713 deleteMyItem refuses to touch another kid\u2019s item');
+
+  await ROUTES.deleteMyItem({
+    personId: 'toby', pin: '1234', kidId: 'toby', itemId: addedNote.item.id,
+  });
+  const afterDelete = await ROUTES.myItems({ personId: 'toby', pin: '1234', kidId: 'toby' });
+  assert.ok(
+    !afterDelete.items.some((item) => item.id === addedNote.item.id),
+    'deleted item is gone from the list',
+  );
+  console.log('\u2713 deleteMyItem removes the owner\u2019s own item');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -934,6 +934,55 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   color: var(--ink-muted);
   margin-top: var(--space-1);
 }
+/* My List - a kid's own notes, plans and reminders. */
+.mylist-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-3);
+}
+.mylist-add {
+  width: 44px; height: 44px; min-width: 44px;
+  border-radius: var(--radius-full); border: 0;
+  background: var(--brand); color: var(--on-brand);
+  font-size: var(--text-xl); font-weight: var(--weight-bold);
+  cursor: pointer; box-shadow: var(--shadow-1);
+}
+.mylist-add:active { transform: scale(0.94); }
+.mylist-filters { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-bottom: var(--space-3); }
+.mylist-cat {
+  font-size: var(--text-xs); color: var(--ink-muted);
+  border: 1px solid var(--border); border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-3);
+}
+.mylist-item.done .title { text-decoration: line-through; color: var(--ink-muted); }
+.mylist-actions { display: flex; align-items: center; gap: var(--space-2); }
+.icon-btn {
+  width: 44px; height: 44px; min-width: 44px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--border); background: var(--surface);
+  font-size: var(--text-base); cursor: pointer; color: var(--ink);
+}
+.icon-btn:active { transform: scale(0.94); }
+.icon-btn[disabled] { opacity: 0.35; cursor: default; }
+
+/* Bottom sheet. .modal-bg centres its child; this pins it to the bottom, which
+   is where a thumb is. */
+.sheet-bg { align-items: flex-end; padding: 0; }
+.sheet {
+  max-width: 34rem;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  text-align: left;
+  transform: translateY(100%);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .sheet { transition: transform var(--dur-base) var(--ease-out); }
+}
+.sheet-bg:not(.hidden) .sheet { transform: translateY(0); }
+.sheet-label {
+  font-size: var(--text-sm); color: var(--ink-muted);
+  font-weight: var(--weight-medium); margin-bottom: var(--space-2);
+}
+.sheet-pills { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+
 .ask-input { font-size: var(--text-base); width: 100%; padding: var(--space-3); border: 2px solid var(--border); border-radius: var(--radius-md); font-family: inherit; color: var(--ink); background: var(--surface-sunken); }
 .ask-input:focus { outline: none; border-color: var(--brand); }
 .pin-err { color: var(--danger); font-size: var(--text-sm); min-height: 1.2em; }
@@ -1133,6 +1182,12 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
           <h2 class="section-title">⭐ One-off Missions</h2>
           <div id="k-oneoff"></div>
         </div>
+        <div class="mylist-head">
+          <h2 class="section-title">🗂️ My List</h2>
+          <button class="mylist-add" id="k-mylist-add" type="button" onclick="openMyItemSheet()" aria-label="Add a note, plan or reminder">+</button>
+        </div>
+        <div class="mylist-filters" id="k-mylist-filters"></div>
+        <div id="k-mylist"></div>
       </div>
     </div>
 
@@ -1441,6 +1496,25 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
     <div class="modal-actions">
       <button class="btn" id="voice-reminder-primary" onclick="handleVoiceReminderPrimary()">Check it</button>
       <button class="btn ghost" id="voice-reminder-secondary" onclick="handleVoiceReminderSecondary()">Maybe later</button>
+    </div>
+  </div>
+</div>
+
+<div id="myitem-sheet" class="modal-bg sheet-bg hidden" aria-hidden="true">
+  <div class="modal sheet">
+    <h3>🗂️ Add to my list</h3>
+    <input class="ask-input" id="myitem-title" type="text" autocomplete="off" placeholder="What do you want to remember?">
+    <div>
+      <div class="sheet-label">What kind?</div>
+      <div class="sheet-pills" id="myitem-types"></div>
+    </div>
+    <div>
+      <div class="sheet-label">Where does it belong?</div>
+      <div class="sheet-pills" id="myitem-cats"></div>
+    </div>
+    <div class="modal-actions">
+      <button class="btn" id="myitem-save" onclick="saveMyItem()">Add it</button>
+      <button class="btn ghost" onclick="closeMyItemSheet()">Cancel</button>
     </div>
   </div>
 </div>
@@ -1849,6 +1923,14 @@ function renderKid(kid) {
   // the API calls and let the Home glance and the Calendar tab disagree about
   // what falls on a given day.
   loadKidCalendar(kid);
+  // Own fetch: My List items have no date, so the calendar action cannot see
+  // them. Loaded once per kid - renderKid() runs on every 60s poll.
+  if (myItemsLoadedFor !== kid.id) {
+    myItemsLoadedFor = kid.id;
+    myItems = [];
+    myItemsFilter = 'all';
+    loadMyItems(kid);
+  }
 
   var ranked = kidsOnly()
     .map(function(k) { return Object.assign({}, k, { pts: (state.stats[k.id] || {}).points || 0 }); })
@@ -2724,6 +2806,225 @@ function syncGoalDots() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// My List (#122): a kid's own notes, plans and reminders.
+//
+// Kept out of state/getState() deliberately. getState() never returned
+// planningItems, and the calendar action that does serve them skips anything
+// without a parseable date - which is every note. So My List has its own
+// fetch, the same shape as loadKidCalendar().
+// ---------------------------------------------------------------------------
+const MY_ITEM_TYPES = [
+  { key: 'note', label: '📝 Note' },
+  { key: 'reminder', label: '⏰ Reminder' },
+  { key: 'plan', label: '🗺️ Plan' },
+];
+const MY_ITEM_CATEGORIES = [
+  { key: 'school', label: '🎒 School' },
+  { key: 'home', label: '🏠 Home' },
+  { key: 'sport', label: '⚽ Sport' },
+  { key: 'fun', label: '🎉 Fun' },
+  { key: 'other', label: '✨ Other' },
+];
+
+let myItems = [];
+let myItemsLoading = false;
+let myItemsFilter = 'all';
+let myItemsLoadedFor = null;
+// Minimal taps: the sheet reopens on whatever was used last, because a kid
+// adding three school notes in a row should not re-pick school three times.
+let myItemLastType = 'note';
+let myItemLastCategory = 'school';
+
+function myItemLabel(list, key) {
+  var found = list.find(function(entry) { return entry.key === key; });
+  return found ? found.label : key;
+}
+
+async function loadMyItems(kid) {
+  if (!kid || !session || session.role !== 'kid') return;
+  myItemsLoading = true;
+  renderMyList();
+  var res;
+  try {
+    res = await api({ action: 'myItems', personId: session.personId, pin: session.pin, kidId: kid.id });
+  } catch (e) {
+    myItemsLoading = false;
+    renderMyList();
+    return;
+  }
+  myItemsLoading = false;
+  if (res && res.ok && Array.isArray(res.items)) myItems = res.items;
+  renderMyList();
+}
+
+function renderMyListFilters() {
+  var el = document.getElementById('k-mylist-filters');
+  if (!el) return;
+  var used = MY_ITEM_CATEGORIES.filter(function(cat) {
+    return myItems.some(function(item) { return item.category === cat.key; });
+  });
+  // Only one category in play means the filter row is noise.
+  if (used.length < 2) { el.innerHTML = ''; return; }
+  var pills = [{ key: 'all', label: 'All' }].concat(used);
+  el.innerHTML = pills.map(function(cat) {
+    return '<button type="button" class="choice-pill' + (myItemsFilter === cat.key ? ' active' : '') + '"'
+      + ' onclick="filterMyList(\'' + cat.key + '\')">' + cat.label + '</button>';
+  }).join('');
+}
+
+function filterMyList(category) {
+  myItemsFilter = category;
+  renderMyList();
+}
+
+function renderMyList() {
+  var el = document.getElementById('k-mylist');
+  if (!el) return;
+
+  renderMyListFilters();
+
+  if (myItemsLoading && myItems.length === 0) {
+    el.innerHTML = '<div class="glance-skel"></div><div class="glance-skel"></div>';
+    return;
+  }
+
+  var visible = myItems.filter(function(item) {
+    return myItemsFilter === 'all' || item.category === myItemsFilter;
+  });
+
+  if (visible.length === 0) {
+    el.innerHTML = myItems.length === 0
+      ? buildEmptyState('📝', 'Nothing on your list yet.', 'Tap + to add a note, plan or reminder.')
+      : buildEmptyState('🔍', 'Nothing in here.', 'Try another category.');
+    return;
+  }
+
+  el.innerHTML = visible.map(function(item) {
+    var done = item.status === 'done';
+    return '<div class="task mylist-item' + (done ? ' done dimmed' : '') + '" id="k-myitem-' + item.id + '">'
+      + '<button class="tick' + (done ? ' done' : '') + '" onclick="toggleMyItem(\'' + item.id + '\')"'
+      +   ' aria-label="' + (done ? 'Mark as not done' : 'Mark as done') + '">' + (done ? '✓' : '') + '</button>'
+      + '<div class="info">'
+      +   '<div class="title">' + esc(item.title) + '</div>'
+      +   '<div class="sub"><span class="mylist-cat">' + myItemLabel(MY_ITEM_CATEGORIES, item.category) + '</span> '
+      +     myItemLabel(MY_ITEM_TYPES, item.type) + '</div>'
+      + '</div>'
+      + '<div class="mylist-actions">'
+      +   '<button class="icon-btn" onclick="deleteMyItemCard(\'' + item.id + '\')" aria-label="Delete">🗑️</button>'
+      + '</div>'
+      + '</div>';
+  }).join('');
+}
+
+function openMyItemSheet() {
+  document.getElementById('myitem-title').value = '';
+  renderMyItemSheetPills();
+  var sheet = document.getElementById('myitem-sheet');
+  sheet.classList.remove('hidden');
+  sheet.setAttribute('aria-hidden', 'false');
+  setTimeout(function() { document.getElementById('myitem-title').focus(); }, 50);
+}
+
+function closeMyItemSheet() {
+  var sheet = document.getElementById('myitem-sheet');
+  sheet.classList.add('hidden');
+  sheet.setAttribute('aria-hidden', 'true');
+}
+
+function renderMyItemSheetPills() {
+  document.getElementById('myitem-types').innerHTML = MY_ITEM_TYPES.map(function(t) {
+    return '<button type="button" class="choice-pill' + (myItemLastType === t.key ? ' active' : '') + '"'
+      + ' onclick="chooseMyItemType(\'' + t.key + '\')">' + t.label + '</button>';
+  }).join('');
+  document.getElementById('myitem-cats').innerHTML = MY_ITEM_CATEGORIES.map(function(c) {
+    return '<button type="button" class="choice-pill' + (myItemLastCategory === c.key ? ' active' : '') + '"'
+      + ' onclick="chooseMyItemCategory(\'' + c.key + '\')">' + c.label + '</button>';
+  }).join('');
+}
+
+function chooseMyItemType(key) { myItemLastType = key; renderMyItemSheetPills(); }
+function chooseMyItemCategory(key) { myItemLastCategory = key; renderMyItemSheetPills(); }
+
+async function saveMyItem() {
+  var title = String(document.getElementById('myitem-title').value || '').trim();
+  if (!title) { toast('Tell me what to add first.'); return; }
+
+  // Optimistic, mirroring doTask: show it, then reconcile. The synthetic id is
+  // replaced by the real one on success and removed on failure.
+  var syntheticId = '_opt_myitem_' + Date.now();
+  var prev = myItems.slice();
+  myItems = prev.concat([{
+    id: syntheticId, personId: session.personId, type: myItemLastType,
+    title: title, category: myItemLastCategory, status: 'open',
+    order: prev.length, source: 'manual', startAt: null,
+  }]);
+  closeMyItemSheet();
+  renderMyList();
+
+  var res;
+  try {
+    res = await api({
+      action: 'addMyItem', personId: session.personId, pin: session.pin, kidId: session.personId,
+      type: myItemLastType, title: title, category: myItemLastCategory,
+    });
+  } catch (e) {
+    myItems = prev; renderMyList(); toast('Connection problem — try again.'); return;
+  }
+  if (!res || res.ok === false) {
+    myItems = prev; renderMyList(); toast((res && res.error) || 'Could not add that.'); return;
+  }
+  myItems = myItems.map(function(item) { return item.id === syntheticId ? res.item : item; });
+  renderMyList();
+}
+
+async function toggleMyItem(itemId) {
+  var item = myItems.find(function(entry) { return entry.id === itemId; });
+  if (!item) return;
+  var nextStatus = item.status === 'done' ? 'open' : 'done';
+  var prev = myItems.slice();
+  myItems = myItems.map(function(entry) {
+    return entry.id === itemId ? Object.assign({}, entry, { status: nextStatus }) : entry;
+  });
+  renderMyList();
+
+  var res;
+  try {
+    res = await api({
+      action: 'updateMyItem', personId: session.personId, pin: session.pin, kidId: session.personId,
+      itemId: itemId, status: nextStatus,
+    });
+  } catch (e) {
+    myItems = prev; renderMyList(); toast('Connection problem — try again.'); return;
+  }
+  if (!res || res.ok === false) {
+    myItems = prev; renderMyList(); toast((res && res.error) || 'Could not update that.');
+  }
+}
+
+async function deleteMyItemCard(itemId) {
+  var item = myItems.find(function(entry) { return entry.id === itemId; });
+  if (!item) return;
+  if (!await askConfirm('Delete “' + item.title + '”?', 'Delete')) return;
+
+  var prev = myItems.slice();
+  myItems = myItems.filter(function(entry) { return entry.id !== itemId; });
+  renderMyList();
+
+  var res;
+  try {
+    res = await api({
+      action: 'deleteMyItem', personId: session.personId, pin: session.pin, kidId: session.personId,
+      itemId: itemId,
+    });
+  } catch (e) {
+    myItems = prev; renderMyList(); toast('Connection problem — try again.'); return;
+  }
+  if (!res || res.ok === false) {
+    myItems = prev; renderMyList(); toast((res && res.error) || 'Could not delete that.');
+  }
+}
+
 function renderRewardShop(kid, balance) {
   var rewards = (state.rewards || []).filter(function(r) { return r.active !== false; });
   var el = document.getElementById('k-rewards');
@@ -3005,6 +3306,10 @@ async function submitPin() {
 function saveSession() { localStorage.setItem('hero-session', JSON.stringify(session)); }
 function logout() {
   closeVoiceReminder();
+  closeMyItemSheet();
+  myItems = [];
+  myItemsLoadedFor = null;
+  myItemsFilter = 'all';
   session = null;
   pushSetupPersonId = null;
   localStorage.removeItem('hero-session');

--- a/scripts/check-design.js
+++ b/scripts/check-design.js
@@ -139,7 +139,7 @@ check(Boolean(bodyMatch), '<body> block exists');
 
 if (bodyMatch) {
   const body = bodyMatch[1];
-  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'toast']);
+  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'myitem-sheet', 'toast']);
   const seenTopLevelIds = new Set();
   let unexpectedTopLevel = 0;
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -322,3 +322,54 @@ test('the voice capture sheet lets the kid pick the item type and saves it', asy
   await expect(page.locator('#voice-reminder-modal')).toBeHidden();
   await expect(page.locator('#toast')).toContainText(/Event saved/i);
 });
+
+// #122. My List: a kid's own notes, plans and reminders, separate from the
+// chores a parent assigns. These items have no date, which is exactly why they
+// need their own fetch - the calendar action skips anything without a parseable
+// startAt, so an undated note is invisible to every other screen in the app.
+test('a kid can add something to their own list and tick it off', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /missions/i }).first().click();
+
+  await expect(page.locator('#k-mylist')).toContainText('Nothing on your list yet');
+
+  await page.locator('#k-mylist-add').click();
+  await expect(page.locator('#myitem-sheet')).toBeVisible();
+  await page.locator('#myitem-title').fill('Library book is due');
+  await page.getByRole('button', { name: /🎒 School/ }).click();
+  await page.getByRole('button', { name: /Add it/ }).click();
+
+  // Sheet closes and the item lands - if the route were wrong this would stay
+  // on screen as an optimistic row and then vanish on the rollback.
+  await expect(page.locator('#myitem-sheet')).toBeHidden();
+  const card = page.locator('#k-mylist .mylist-item').filter({ hasText: 'Library book is due' });
+  await expect(card).toBeVisible();
+  await expect(card).toContainText('🎒 School');
+
+  // Tick it off; it must survive a reload, which is the real proof it persisted
+  // rather than only ever existing in the optimistic local copy.
+  await card.locator('.tick').click();
+  await expect(card).toHaveClass(/done/);
+
+  await page.reload();
+  await page.getByRole('button', { name: /missions/i }).first().click();
+  const after = page.locator('#k-mylist .mylist-item').filter({ hasText: 'Library book is due' });
+  await expect(after).toBeVisible();
+  await expect(after).toHaveClass(/done/);
+});
+
+// One kid's list must never show up on another kid's screen.
+test('my list is private to the kid who wrote it', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /missions/i }).first().click();
+  await page.locator('#k-mylist-add').click();
+  await page.locator('#myitem-title').fill('Ollie secret plan');
+  await page.getByRole('button', { name: /Add it/ }).click();
+  await expect(page.locator('#k-mylist')).toContainText('Ollie secret plan');
+
+  await page.locator('.kid-header-left').click();
+  await pickPerson(page, 'Toby');
+  await page.getByRole('button', { name: /missions/i }).first().click();
+  await expect(page.locator('#k-mylist')).not.toContainText('Ollie secret plan');
+  await expect(page.locator('#k-mylist')).toContainText('Nothing on your list yet');
+});


### PR DESCRIPTION
Closes #122. First of two for #14.

**User story**

> As a kid, I want to jot down my own reminders and plans, not just the chores my parents set me.

## What shipped

A **🗂️ My List** section on the Missions tab. A round `+` opens a bottom sheet with a text field, type pills (Note / Reminder / Plan) and category pills (School / Home / Sport / Fun / Other). Items render as normal task cards with a tick and a delete button. A category filter row appears only once there are at least two categories in play. Add, tick and delete are all optimistic with rollback, mirroring `doTask`.

The sheet reopens on whatever type and category were used last — a kid adding three school notes in a row shouldn't pick "school" three times.

## The API had to be built too

#122 says "Depends on #120", and #120 is closed — but **what #120 actually shipped was the parent calendar's CRUD, not the kid-owned routes it specified.** On `main` today:

- `addPlanningItem` / `updatePlanningItem` / `deletePlanningItem` are all `requireParent`-gated and reject a kid outright
- `validatePlanningPayload` requires an ISO `startAt` and only allows `event|reminder`
- `getState()` never returns `planningItems` at all, which #120 also called for

A note with no date fits none of that. So this PR adds `myItems` / `addMyItem` / `updateMyItem` / `deleteMyItem`, gated by `requireSelf`, writing to the same `planningItems` container on their own routes. Widening the parent routes to admit undated notes would have weakened the validation the calendar depends on.

**Ownership is checked on every write.** A valid PIN proves who you are, not that the item you named is yours — tested in both directions.

## Why My List needs its own fetch

`calendar()` skips any item whose `startAt` won't parse:

```js
const when = new Date(item.startAt);
if (Number.isNaN(when.getTime())) continue;
```

So an undated personal item is invisible to every other screen — **including a voice item whose "when" couldn't be read**, which `saveVoicePlan` deliberately stores with `startAt: null` and the raw text in `notes`. Those have been silently unreachable. They surface here.

## Deviation from #120

#120 specified a **hard** delete for these ("personal scratch items, no audit trail"). This uses a soft delete (`active: false`) instead, because every other write to `planningItems` does and `calendar()` tests it — one row that vanishes where all its neighbours tombstone is a trap for whoever reads this next. #120 was written before the parent calendar CRUD landed, so it couldn't have known.

## Files

- `api/src/functions/hero.js` — four kid-owned routes plus a shared `isMyItem` ownership helper
- `api/test-logic.js` — 9 assertions including cross-kid edit and cross-kid delete
- `frontend/index.html` — section, sheet, filter, optimistic handlers; state cleared on user switch
- `scripts/check-design.js` — register the new sheet as a shell element
- `tests/smoke/smoke.spec.js` — two cases

## Testing

- `node api/test-logic.js` — passes, including the new My List block
- `node scripts/check-frontend.js` — passes
- `node scripts/check-design.js` — passes
- Smoke suite — **20/20 passed** locally

The smoke cases check the two things that would otherwise fail silently: the item **survives a reload** (proving it persisted rather than only ever existing in the optimistic local copy), and one kid's list **does not appear on another kid's screen**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_