### PR TITLE
Manual reordering for a kid's own list and their own chores

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -147,6 +147,10 @@ async function getState() {
       points: t.points,
       cycle: t.cycle,
       dueBy: t.dueBy || null,
+      // Chores created before reordering existed have no order field. Falling
+      // back to 0 here keeps them ahead of nothing in particular rather than
+      // sorting as undefined, which would scatter them unpredictably.
+      order: t.order ?? 0,
       createdAt: t.createdAt,
     })),
     completions: completions.map((c) => ({
@@ -445,9 +449,50 @@ async function addTask(req) {
     // defines "when", and a recurring due-time is a separate feature (ties into
     // reminders, issue #11) rather than a natural extension of this field.
     dueBy: req.cycle === 'oneoff' && req.dueBy ? req.dueBy : null,
+    // New chores go to the end of that kid's list, so adding one never
+    // reshuffles an order the kid set themselves.
+    order: await nextChoreOrder(req.kidId),
     createdAt: todayStr(),
     active: true,
   });
+  return getState();
+}
+
+async function nextChoreOrder(kidId) {
+  const chores = await queryHousehold('chores');
+  const mine = chores.filter((c) => c.active !== false && c.kidId === kidId);
+  return mine.length ? Math.max(...mine.map((c) => c.order ?? 0)) + 1 : 0;
+}
+
+// Reordering is the one thing a kid may change about a chore a parent set them.
+// It writes `order` and nothing else - title, points, cycle and kidId stay
+// behind updateTask's requireParent gate. Reading the doc and assigning a
+// single field (rather than spreading the request over it) is what makes that
+// true by construction rather than by remembering to check.
+async function reorderTasks(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+  const ids = Array.isArray(req.taskIds) ? req.taskIds.map(String) : null;
+  if (!ids) return { ok: false, error: 'taskIds must be an array' };
+
+  const chores = container('chores');
+  const all = await queryHousehold('chores');
+  const mine = all.filter((c) => c.active !== false && c.kidId === req.kidId);
+
+  // The id set must match this kid's chores exactly. That rejects a foreign id
+  // and a partial list in one check - a partial list would silently renumber
+  // only some rows and leave the rest colliding.
+  const mineIds = mine.map((c) => String(c.id)).sort();
+  const sent = [...ids].sort();
+  if (mineIds.length !== sent.length || mineIds.some((id, i) => id !== sent[i])) {
+    return { ok: false, error: 'taskIds must list exactly your own tasks' };
+  }
+
+  await Promise.all(ids.map(async (id, index) => {
+    const chore = mine.find((c) => String(c.id) === id);
+    if (chore.order === index) return;
+    chore.order = index;
+    await chores.item(chore.id, HOUSEHOLD_ID).replace(chore);
+  }));
   return getState();
 }
 
@@ -1197,6 +1242,28 @@ async function updateMyItem(req) {
   return { ok: true, item: doc };
 }
 
+async function reorderMyItems(req) {
+  await requireSelf(req.personId, req.pin, req.kidId);
+  const ids = Array.isArray(req.itemIds) ? req.itemIds.map(String) : null;
+  if (!ids) return { ok: false, error: 'itemIds must be an array' };
+
+  const mine = await readMyItems(req.kidId);
+  const mineIds = mine.map((doc) => String(doc.id)).sort();
+  const sent = [...ids].sort();
+  if (mineIds.length !== sent.length || mineIds.some((id, i) => id !== sent[i])) {
+    return { ok: false, error: 'itemIds must list exactly your own items' };
+  }
+
+  const planningItems = container('planningItems');
+  await Promise.all(ids.map(async (id, index) => {
+    const doc = mine.find((entry) => String(entry.id) === id);
+    if (doc.order === index) return;
+    doc.order = index;
+    await planningItems.item(doc.id, HOUSEHOLD_ID).replace(doc);
+  }));
+  return { ok: true, items: await readMyItems(req.kidId) };
+}
+
 async function deleteMyItem(req) {
   await requireSelf(req.personId, req.pin, req.kidId);
   const planningItems = container('planningItems');
@@ -1282,6 +1349,8 @@ const ROUTES = {
   addMyItem,
   updateMyItem,
   deleteMyItem,
+  reorderMyItems,
+  reorderTasks,
 };
 
 app.http('hero', {

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -1640,6 +1640,64 @@ async function main() {
   );
   console.log('\u2713 deleteMyItem removes the owner\u2019s own item');
 
+  // -------------------------------------------------------------------------
+  // Manual reordering (#123)
+  // -------------------------------------------------------------------------
+  const mineNow = (await ROUTES.myItems({ personId: 'toby', pin: '1234', kidId: 'toby' })).items;
+  assert.ok(mineNow.length >= 2, 'need at least two items to reorder');
+  const reversed = mineNow.map((item) => item.id).reverse();
+
+  const reordered = await ROUTES.reorderMyItems({
+    personId: 'toby', pin: '1234', kidId: 'toby', itemIds: reversed,
+  });
+  assert.strictEqual(reordered.ok, true, 'reorderMyItems should succeed');
+  assert.deepStrictEqual(
+    reordered.items.map((item) => item.id), reversed,
+    'items come back in the order that was sent',
+  );
+  console.log('\u2713 reorderMyItems rewrites the order');
+
+  // A partial list would silently renumber some rows and leave the rest
+  // colliding, so it has to be rejected outright rather than half-applied.
+  const partial = await ROUTES.reorderMyItems({
+    personId: 'toby', pin: '1234', kidId: 'toby', itemIds: [reversed[0]],
+  });
+  assert.strictEqual(partial.ok, false, 'a partial id list is rejected');
+  console.log('\u2713 reorderMyItems rejects a partial id list');
+
+  const foreign = await ROUTES.reorderMyItems({
+    personId: 'toby', pin: '1234', kidId: 'toby',
+    itemIds: reversed.slice(0, -1).concat(['not-my-item']),
+  });
+  assert.strictEqual(foreign.ok, false, 'an unknown id is rejected');
+  console.log('\u2713 reorderMyItems rejects an id that is not yours');
+
+  // Chore reordering: a kid may change the order and nothing else.
+  const tobyChores = (await ROUTES.state()).tasks.filter((t) => t.kidId === 'toby');
+  assert.ok(tobyChores.length >= 2, 'need at least two chores to reorder');
+  const choreIds = tobyChores.map((t) => t.id);
+  const flipped = [choreIds[1], choreIds[0]].concat(choreIds.slice(2));
+  const beforeTitles = new Map(tobyChores.map((t) => [t.id, t.title]));
+  const beforePoints = new Map(tobyChores.map((t) => [t.id, t.points]));
+
+  await ROUTES.reorderTasks({ personId: 'toby', pin: '1234', kidId: 'toby', taskIds: flipped });
+  const afterChores = (await ROUTES.state()).tasks.filter((t) => t.kidId === 'toby');
+  const byId = new Map(afterChores.map((t) => [t.id, t]));
+  assert.strictEqual(byId.get(flipped[0]).order, 0, 'first sent id gets order 0');
+  assert.strictEqual(byId.get(flipped[1]).order, 1, 'second sent id gets order 1');
+  for (const id of choreIds) {
+    assert.strictEqual(byId.get(id).title, beforeTitles.get(id), 'title must not change');
+    assert.strictEqual(byId.get(id).points, beforePoints.get(id), 'points must not change');
+    assert.strictEqual(byId.get(id).kidId, 'toby', 'kidId must not change');
+  }
+  console.log('\u2713 reorderTasks writes order and leaves title/points/kidId alone');
+
+  const crossChores = await ROUTES.reorderTasks({
+    personId: 'ollie', pin: '1234', kidId: 'ollie', taskIds: flipped,
+  });
+  assert.strictEqual(crossChores.ok, false, 'another kid cannot reorder these tasks');
+  console.log('\u2713 reorderTasks refuses another kid\u2019s task ids');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -963,6 +963,11 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .icon-btn:active { transform: scale(0.94); }
 .icon-btn[disabled] { opacity: 0.35; cursor: default; }
+.move-controls { display: flex; flex-direction: column; gap: var(--space-1); }
+.move-controls .icon-btn {
+  width: 44px; height: 34px; min-width: 44px;
+  font-size: var(--text-xs); line-height: 1;
+}
 
 /* Bottom sheet. .modal-bg centres its child; this pins it to the bottom, which
    is where a thumb is. */
@@ -2670,7 +2675,17 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
     el.innerHTML = emptyLine1 ? buildEmptyState(emptyEmoji, emptyLine1, emptyLine2) : '';
     return;
   }
-  el.innerHTML = tasks.map(function(t) {
+  // The kid's own order wins. Chores predating this feature all carry order 0,
+  // so createdAt breaks the tie and they keep the arrangement they always had.
+  tasks = tasks.slice().sort(function(a, b) {
+    var byOrder = (a.order || 0) - (b.order || 0);
+    if (byOrder !== 0) return byOrder;
+    return String(a.createdAt || '').localeCompare(String(b.createdAt || ''));
+  });
+  // Only a kid may reorder, and only their own list. The parent's task views
+  // render through their own markup, so this stays out of Parent HQ entirely.
+  var canReorder = session && session.role === 'kid';
+  el.innerHTML = tasks.map(function(t, idx) {
     var c = cycleCompletion(t);
     var cls = c ? (c.status === 'approved' ? 'done-approved' : c.status === 'queued' ? 'done-queued' : 'done-pending') : '';
     var tickIcon = c ? (c.status === 'approved' ? '✅' : c.status === 'queued' ? '📡' : '⏳') : '';
@@ -2689,8 +2704,10 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
       + (sub ? '<div class="sub">' + sub + '</div>' : '')
       + '</div>'
       + '<span class="pts-badge">+' + t.points + '</span>'
+      + (canReorder ? moveControlsHtml('moveTask', idx, tasks.length, elId) : '')
       + '</div>';
   }).join('');
+  taskListOrder[elId] = tasks.map(function(t) { return t.id; });
 }
 
 // The kid Home hero: a swipeable row of every prize, and how far off each one is.
@@ -2878,6 +2895,28 @@ function filterMyList(category) {
   renderMyList();
 }
 
+// Up/down controls. Reordering is organisation, not achievement, so there is no
+// toast, no confetti and no vibration here (design-system.md reserves those for
+// completing a chore). First-up and last-down are inert rather than an error.
+function moveControlsHtml(handler, index, total, listId) {
+  var lead = listId === undefined ? '' : "'" + listId + "', ";
+  return '<div class="move-controls">'
+    + '<button class="icon-btn" aria-label="Move up" ' + (index === 0 ? 'disabled' : '')
+    +   ' onclick="' + handler + '(' + lead + index + ', -1)">\u25B2</button>'
+    + '<button class="icon-btn" aria-label="Move down" ' + (index === total - 1 ? 'disabled' : '')
+    +   ' onclick="' + handler + '(' + lead + index + ', 1)">\u25BC</button>'
+    + '</div>';
+}
+
+function reorderedCopy(list, index, delta) {
+  var target = index + delta;
+  if (target < 0 || target >= list.length) return null;
+  var next = list.slice();
+  var moved = next.splice(index, 1)[0];
+  next.splice(target, 0, moved);
+  return next;
+}
+
 function renderMyList() {
   var el = document.getElementById('k-mylist');
   if (!el) return;
@@ -2900,7 +2939,7 @@ function renderMyList() {
     return;
   }
 
-  el.innerHTML = visible.map(function(item) {
+  el.innerHTML = visible.map(function(item, idx) {
     var done = item.status === 'done';
     return '<div class="task mylist-item' + (done ? ' done dimmed' : '') + '" id="k-myitem-' + item.id + '">'
       + '<button class="tick' + (done ? ' done' : '') + '" onclick="toggleMyItem(\'' + item.id + '\')"'
@@ -2911,6 +2950,7 @@ function renderMyList() {
       +     myItemLabel(MY_ITEM_TYPES, item.type) + '</div>'
       + '</div>'
       + '<div class="mylist-actions">'
+      +   moveControlsHtml('moveMyItem', idx, visible.length)
       +   '<button class="icon-btn" onclick="deleteMyItemCard(\'' + item.id + '\')" aria-label="Delete">🗑️</button>'
       + '</div>'
       + '</div>';
@@ -3000,6 +3040,87 @@ async function toggleMyItem(itemId) {
   if (!res || res.ok === false) {
     myItems = prev; renderMyList(); toast((res && res.error) || 'Could not update that.');
   }
+}
+
+// Which ids each rendered list is showing, so a move knows what it is moving.
+var taskListOrder = {};
+
+async function moveTask(listId, index, delta) {
+  var visibleIds = taskListOrder[listId] || [];
+  var movedVisible = reorderedCopy(visibleIds, index, delta);
+  if (!movedVisible) return;
+
+  // The API requires every one of this kid's chore ids, not just the list on
+  // screen - Missions splits them across weekly and one-off, and daily chores
+  // are not in either. So splice the reordered sublist back into the full set.
+  var mine = (state.tasks || [])
+    .filter(function(t) { return t.kidId === session.personId; })
+    .slice()
+    .sort(function(a, b) {
+      var byOrder = (a.order || 0) - (b.order || 0);
+      if (byOrder !== 0) return byOrder;
+      return String(a.createdAt || '').localeCompare(String(b.createdAt || ''));
+    });
+
+  var cursor = 0;
+  var fullIds = mine.map(function(t) {
+    return visibleIds.indexOf(t.id) === -1 ? t.id : movedVisible[cursor++];
+  });
+
+  var prevTasks = (state.tasks || []).slice();
+  var rank = {};
+  fullIds.forEach(function(id, i) { rank[id] = i; });
+  state.tasks = (state.tasks || []).map(function(t) {
+    return rank[t.id] === undefined ? t : Object.assign({}, t, { order: rank[t.id] });
+  });
+  render();
+
+  var res;
+  try {
+    res = await api({
+      action: 'reorderTasks', personId: session.personId, pin: session.pin, kidId: session.personId,
+      taskIds: fullIds,
+    });
+  } catch (e) {
+    state.tasks = prevTasks; render(); toast('Connection problem — try again.'); return;
+  }
+  if (!res || res.ok === false) {
+    state.tasks = prevTasks; render(); toast((res && res.error) || 'Could not move that.'); return;
+  }
+  if (res.tasks) { state = res; render(); }
+}
+
+async function moveMyItem(index, delta) {
+  // Reorder against the filtered view the kid is looking at, then send the full
+  // list: the API requires every id, and a filtered subset would be rejected.
+  var visible = myItems.filter(function(item) {
+    return myItemsFilter === 'all' || item.category === myItemsFilter;
+  });
+  var movedVisible = reorderedCopy(visible, index, delta);
+  if (!movedVisible) return;
+
+  var prev = myItems.slice();
+  var visibleIds = visible.map(function(item) { return item.id; });
+  var cursor = 0;
+  var next = myItems.map(function(item) {
+    return visibleIds.indexOf(item.id) === -1 ? item : movedVisible[cursor++];
+  });
+  myItems = next;
+  renderMyList();
+
+  var res;
+  try {
+    res = await api({
+      action: 'reorderMyItems', personId: session.personId, pin: session.pin, kidId: session.personId,
+      itemIds: next.map(function(item) { return item.id; }),
+    });
+  } catch (e) {
+    myItems = prev; renderMyList(); toast('Connection problem — try again.'); return;
+  }
+  if (!res || res.ok === false) {
+    myItems = prev; renderMyList(); toast((res && res.error) || 'Could not move that.'); return;
+  }
+  if (Array.isArray(res.items)) { myItems = res.items; renderMyList(); }
 }
 
 async function deleteMyItemCard(itemId) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -373,3 +373,66 @@ test('my list is private to the kid who wrote it', async ({ page }) => {
   await expect(page.locator('#k-mylist')).not.toContainText('Ollie secret plan');
   await expect(page.locator('#k-mylist')).toContainText('Nothing on your list yet');
 });
+
+// #123. A kid can put their own list in the order they care about. The API
+// requires every one of their ids, so the interesting part is that moving one
+// row inside a filtered or split view still sends a complete, valid list.
+//
+// The smoke server keeps one in-memory store for the whole run, so Ollie's list
+// already has rows from earlier tests. These assert on the relative order of two
+// rows they add themselves rather than on the whole list.
+test('a kid can reorder their own list, and it sticks', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /missions/i }).first().click();
+
+  for (const title of ['Alpha row', 'Beta row']) {
+    await page.locator('#k-mylist-add').click();
+    await page.locator('#myitem-title').fill(title);
+    await page.getByRole('button', { name: /Add it/ }).click();
+    await expect(page.locator('#k-mylist')).toContainText(title);
+  }
+
+  const titles = () => page.locator('#k-mylist .mylist-item .title').allTextContents();
+  const indexOf = async (label) => (await titles()).indexOf(label);
+
+  // New items append, so Alpha sits directly above Beta.
+  expect(await indexOf('Beta row')).toBe((await indexOf('Alpha row')) + 1);
+
+  await page.locator('#k-mylist .mylist-item')
+    .nth(await indexOf('Beta row'))
+    .getByRole('button', { name: 'Move up' })
+    .click();
+  await expect.poll(async () => (await indexOf('Beta row')) < (await indexOf('Alpha row'))).toBe(true);
+
+  // A reload is the real proof - an optimistic swap alone would look identical.
+  await page.reload();
+  await page.getByRole('button', { name: /missions/i }).first().click();
+  await expect.poll(async () => (await indexOf('Beta row')) < (await indexOf('Alpha row'))).toBe(true);
+});
+
+// The ends must be inert, not an error toast.
+test('moving past the ends of the list is a no-op', async ({ page }) => {
+  await pickPerson(page, 'Ollie');
+  await page.getByRole('button', { name: /missions/i }).first().click();
+
+  await page.locator('#k-mylist-add').click();
+  await page.locator('#myitem-title').fill('Ends check row');
+  await page.getByRole('button', { name: /Add it/ }).click();
+  await expect(page.locator('#k-mylist')).toContainText('Ends check row');
+
+  const rows = page.locator('#k-mylist .mylist-item');
+  await expect(rows.first().getByRole('button', { name: 'Move up' })).toBeDisabled();
+  await expect(rows.last().getByRole('button', { name: 'Move down' })).toBeDisabled();
+
+  // Reordering is organisation, not achievement: no toast, no celebration.
+  await rows.first().getByRole('button', { name: 'Move down' }).click();
+  await expect(page.locator('#toast')).toBeHidden();
+});
+
+// Reordering is organisation, not achievement - the parent's own task views
+// must not sprout kid reorder controls.
+test('Parent HQ task rows have no reorder controls', async ({ page }) => {
+  await pickPerson(page, 'Peter');
+  await page.getByRole('button', { name: /^Tasks$/i }).first().click();
+  await expect(page.locator('#p-tab-tasks .move-controls')).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #123. Second of two for #14 — this completes the epic.

**User story**

> As a kid, I want my list in the order I care about, not the order things happened to be added.

## What shipped

Up/down controls (▲▼, 44px targets) on My List items and on a kid's own chores. `renderTaskList` sorts by `order`. Reordering is **organisation, not achievement** — no toast, no confetti, no vibration, per `docs/design-system.md`. First-up and last-down are inert, never an error toast.

## The security-relevant bit

`reorderTasks` is the one thing a kid may change about a chore a parent set them. It reads the doc and assigns a **single field**:

```js
chore.order = index;
await chores.item(chore.id, HOUSEHOLD_ID).replace(chore);
```

Title, points, cycle and `kidId` stay behind `updateTask`'s `requireParent` gate **by construction** — there is no path for a request field to reach them — rather than by remembering to check a denylist. The test asserts all four are unchanged after a reorder.

Both reorder routes require the id set to match the caller's own rows **exactly**. That rejects a foreign id and a partial list in one check — a partial list would renumber some rows and leave the rest colliding on the same `order`.

## Two things that needed fixing along the way

**`getState()` never returned a chore's `order`.** The frontend literally could not sort by it. Added, defaulting to `0` for chores created before this feature; `createdAt` breaks the tie so existing chores keep the arrangement they always had rather than scattering.

**Missions splits a kid's chores across weekly and one-off**, and daily chores are in neither list. So moving a row inside one list splices that reordered sublist back into the full ordered set before sending — the API wants every id, and sending just the visible list would be rejected. Same technique on the My List side, where a category filter can hide rows.

`reorderPlanningItems`, which #123 refers to as coming "from #120", does not exist — like the rest of #120's specified API. This adds `reorderMyItems` alongside the routes from #179.

## Files

- `api/src/functions/hero.js` — `reorderMyItems`, `reorderTasks`, `order` on `addTask` and in `getState`'s task projection
- `api/test-logic.js` — 5 assertions including cross-kid and field-tampering
- `frontend/index.html` — shared move controls, sorted `renderTaskList`, both handlers
- `tests/smoke/smoke.spec.js` — 3 cases

## Testing

- `node api/test-logic.js` — passes
- `node scripts/check-frontend.js` / `check-design.js` — pass
- Smoke suite — **23/23 passed** locally

Smoke covers: a reorder **survives a reload** (an optimistic swap alone would look identical), the ends are disabled and fire no toast, and Parent HQ's task rows grow no reorder controls.

Note on the tests: the smoke server keeps one in-memory store for the whole run, so Ollie's list already has rows from earlier cases. My first draft asserted on the whole list and failed for that reason. These assert on the **relative order of two rows they add themselves**, which is what the feature actually promises.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_