### PR TITLE
Approvals: put what needs the parent at the top, and make it clickable

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -321,7 +321,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   0%, 70% { box-shadow: 0 0 0 3px var(--brand); }
   100%    { box-shadow: var(--shadow-1); }
 }
-.task.arriving { animation: reward-arrive 1.6s var(--ease-out); }
+.arriving { animation: reward-arrive 1.6s var(--ease-out); }
 .goal-card-title {
   font-size: var(--text-base);
   font-weight: var(--weight-bold);
@@ -784,6 +784,14 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .parent-list-row + .parent-list-row { margin-top: 0; }
 .parent-list-row .btn.small { flex: none; }
+/* Only rows that lead somewhere become buttons; these strip the UA chrome so
+   they sit flush with the inert rows beside them, and signal they are tappable. */
+button.parent-list-row {
+  width: 100%; text-align: left; font: inherit; color: inherit;
+  border: 0; cursor: pointer;
+}
+button.parent-list-row:active { transform: scale(0.99); }
+.parent-list-row-link { box-shadow: inset 0 0 0 1px var(--border); }
 .parent-statline {
   display: flex;
   align-items: center;
@@ -1275,14 +1283,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 
   <main class="parent-main">
     <div id="p-tab-approvals" class="parent-panel">
-      <section class="parent-section">
-        <h2 class="parent-section-title">Today &amp; this week</h2>
-        <div id="p-approvals-glance"></div>
-      </section>
-      <section class="parent-section">
-        <h2 class="parent-section-title">Today, by kid</h2>
-        <div id="p-approvals-today-by-kid"></div>
-      </section>
+      <!-- Work waiting on the parent comes first. This is the tab they land on,
+           and everything below is context for a decision, not a decision. -->
       <section class="parent-section">
         <h2 class="parent-section-title">Awaiting your approval</h2>
         <div id="p-pending"></div>
@@ -1290,6 +1292,14 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
       <section class="parent-section">
         <h2 class="parent-section-title">Reward requests</h2>
         <div id="p-reward-requests"></div>
+      </section>
+      <section class="parent-section">
+        <h2 class="parent-section-title">Today, by kid</h2>
+        <div id="p-approvals-today-by-kid"></div>
+      </section>
+      <section class="parent-section">
+        <h2 class="parent-section-title">Today &amp; this week</h2>
+        <div id="p-approvals-glance"></div>
       </section>
       <section class="parent-section">
         <h2 class="parent-section-title">Recently decided</h2>
@@ -2393,16 +2403,42 @@ function renderParentApprovalsTodayByKid() {
           ? buildEmptyState('🗓️', 'No chores today.', 'Nothing is due for ' + esc(kid.name) + ' today.')
           : '<div class="parent-list">' + todayItems.map(function(item) {
               var status = parentCalendarOverviewStatus(item);
-              return '<div class="parent-list-row">'
-                + '<div class="parent-copy">'
+              // A row saying 'Waiting on you' is the only one with something to
+              // go to, so only that one becomes a button. The rest stay inert
+              // rather than looking tappable and doing nothing.
+              var completion = status.className === 'waiting' ? parentCalendarLiveCompletion(item) : null;
+              var inner = '<div class="parent-copy">'
                 + '<span class="parent-list-title">' + esc(item.title || 'Untitled') + '</span>'
                 + '<div class="sub">' + esc(parentCalendarItemTime(item)) + (item.points ? ' · ' + item.points + ' pts' : '') + '</div>'
                 + '</div>'
-                + '<span class="tag ' + status.className + '">' + esc(status.label) + '</span>'
-                + '</div>';
+                + '<span class="tag ' + status.className + '">' + esc(status.label) + '</span>';
+              if (!completion) return '<div class="parent-list-row">' + inner + '</div>';
+              return '<button type="button" class="parent-list-row parent-list-row-link"'
+                + ' onclick="jumpToApproval(\'' + jsq(completion.id) + '\')"'
+                + ' aria-label="Go to the approval for ' + esc(item.title || 'this chore') + '">'
+                + inner + '</button>';
             }).join('') + '</div>')
       + '</div>';
   }).join('') || buildEmptyState('👧', 'Add a kid to start assigning tasks.', 'Once a kid is added, today’s overview will show up here.');
+}
+
+// Take the parent to the decision the row is about. Approving happens on the
+// pending card, so this scrolls to it and rings it rather than trying to
+// duplicate the approve/reject buttons inside the overview.
+function jumpToApproval(completionId) {
+  var row = document.getElementById('p-pending-' + completionId);
+  if (!row) {
+    // The completion was decided in another tab or on another device since this
+    // overview was drawn. Refresh rather than silently doing nothing.
+    toast('That one is already dealt with.');
+    refresh();
+    return;
+  }
+  row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  row.classList.remove('arriving');
+  void row.offsetWidth;
+  row.classList.add('arriving');
+  setTimeout(function() { row.classList.remove('arriving'); }, 1700);
 }
 
 function renderParentApprovalsSummary() {
@@ -3249,7 +3285,7 @@ function renderParent(person) {
     el.innerHTML = pending.map(function(c) {
       var kid = state.people.find(function(k) { return k.id === c.kidId; }) || { name: '?', emoji: '❓' };
       var isExtra = !c.taskId;
-      return '<div class="card parent-card">'
+      return '<div class="card parent-card" id="p-pending-' + c.id + '">'
         + '<div class="parent-summary-row">'
         + '<span class="parent-kid-mark">' + avatarText(kid.emoji) + '</span>'
         + '<div class="parent-copy">'

--- a/scripts/check-frontend.js
+++ b/scripts/check-frontend.js
@@ -107,9 +107,16 @@ check(/Today, by kid/.test(html), 'approvals tab includes Today, by kid title');
 const approvalsGlanceIndex = html.indexOf('id="p-approvals-glance"');
 const approvalsTodayByKidIndex = html.indexOf('id="p-approvals-today-by-kid"');
 const approvalsPendingIndex = html.indexOf('id="p-pending"');
-check(approvalsGlanceIndex !== -1 && approvalsPendingIndex !== -1 && approvalsGlanceIndex < approvalsPendingIndex, 'at-a-glance section appears before pending approvals list');
-check(approvalsGlanceIndex !== -1 && approvalsTodayByKidIndex !== -1 && approvalsGlanceIndex < approvalsTodayByKidIndex, 'today-by-kid section appears after at-a-glance section');
-check(approvalsTodayByKidIndex !== -1 && approvalsPendingIndex !== -1 && approvalsTodayByKidIndex < approvalsPendingIndex, 'today-by-kid section appears before pending approvals list');
+// Work waiting on the parent comes first on the tab they land on. These
+// assertions previously encoded the opposite order; the order changed, so they
+// were updated rather than dropped - the point is that the order is deliberate.
+const approvalsRewardReqIndex = html.indexOf('id="p-reward-requests"');
+check(approvalsPendingIndex !== -1 && approvalsTodayByKidIndex !== -1 && approvalsPendingIndex < approvalsTodayByKidIndex, 'pending approvals list appears before today-by-kid section');
+check(approvalsPendingIndex !== -1 && approvalsGlanceIndex !== -1 && approvalsPendingIndex < approvalsGlanceIndex, 'pending approvals list appears before at-a-glance section');
+check(approvalsRewardReqIndex !== -1 && approvalsTodayByKidIndex !== -1 && approvalsRewardReqIndex < approvalsTodayByKidIndex, 'reward requests appear before today-by-kid section');
+check(approvalsTodayByKidIndex !== -1 && approvalsGlanceIndex !== -1 && approvalsTodayByKidIndex < approvalsGlanceIndex, 'today-by-kid section appears before at-a-glance section');
+check(/onclick="jumpToApproval\(/.test(html), 'waiting-on-you rows link through to their approval');
+check(/id="p-pending-' \+ c\.id \+ '"/.test(html), 'pending approval cards carry an id to jump to');
 check(/function loadParentApprovalsGlance\(\)/.test(html), 'approvals at-a-glance loader exists');
 check(/action:\s*'calendar'[\s\S]*parentId:\s*session\.personId[\s\S]*parentPin:\s*session\.pin/.test(html), 'approvals at-a-glance reuses calendar action with parent credentials');
 check(/function renderParentApprovalsGlance\(\)/.test(html), 'approvals at-a-glance renderer exists');

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -436,3 +436,69 @@ test('Parent HQ task rows have no reorder controls', async ({ page }) => {
   await page.getByRole('button', { name: /^Tasks$/i }).first().click();
   await expect(page.locator('#p-tab-tasks .move-controls')).toHaveCount(0);
 });
+
+// Approvals is the tab a parent lands on. What is waiting on them has to be at
+// the top of it, not below two sections of context.
+test('Approvals opens with what is waiting on the parent, at the top', async ({ page }) => {
+  await pickPerson(page, 'Peter');
+
+  const headings = await page.locator('#p-tab-approvals .parent-section-title').allTextContents();
+  expect(headings[0]).toMatch(/Awaiting your approval/);
+  expect(headings[1]).toMatch(/Reward requests/);
+  expect(headings.slice(2).join(' ')).toMatch(/Today, by kid/);
+});
+
+// A "Waiting on you" row was a plain div - it looked actionable and did
+// nothing. It must now lead to the card where the decision is actually made.
+//
+// The seed ships no chores, so this creates one and completes it first. That
+// setup goes through the real API (the page's own route intercept forwards it
+// to the same handler), and every assertion below is still on rendered UI. An
+// earlier version of this test skipped itself when it found no waiting row,
+// which meant the behaviour it exists for was never actually checked.
+test('a Waiting on you row leads to its approval card', async ({ page }) => {
+  const pending = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: 'Feed the dog', points: 3, cycle: 'daily',
+    });
+    const state = await post({ action: 'state' });
+    const task = state.tasks.find((t) => t.title === 'Feed the dog');
+    await post({ action: 'completeTask', personId: 'toby', pin: '1234', taskId: task.id });
+    return true;
+  });
+  expect(pending).toBe(true);
+
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const waitingRow = page.locator('#p-approvals-today-by-kid .parent-list-row-link')
+    .filter({ hasText: 'Feed the dog' });
+  await expect(waitingRow).toHaveCount(1);
+  await expect(waitingRow).toContainText('Waiting on you');
+
+  await waitingRow.click();
+
+  // It must land on the real approval card, in view, with the buttons on it.
+  const highlighted = page.locator('#p-pending .arriving');
+  await expect(highlighted).toHaveCount(1);
+  await expect(highlighted).toContainText('Feed the dog');
+  await expect(highlighted).toBeInViewport();
+  await expect(highlighted.getByRole('button', { name: /Approve/ })).toBeVisible();
+});
+
+// Rows with nothing to go to must stay inert rather than looking tappable.
+test('rows that are not waiting on the parent are not links', async ({ page }) => {
+  await pickPerson(page, 'Peter');
+  const notStarted = page.locator('#p-approvals-today-by-kid .parent-list-row').filter({ hasText: 'Not started' });
+  const count = await notStarted.count();
+  for (let i = 0; i < count; i += 1) {
+    await expect(notStarted.nth(i)).not.toHaveClass(/parent-list-row-link/);
+  }
+});


### PR DESCRIPTION
**User story**

> As a parent, when I open Approvals I want the things waiting on me right there at the top — and when I tap one, I want to land on it.

## Two problems

**Order.** "Awaiting your approval" was the *third* section, below "Today & this week" and "Today, by kid". The tab shows a badge counting pending approvals, then opened on two sections of context instead of the thing being counted.

New order — work first, context second:

| Before | After |
|---|---|
| Today & this week | **Awaiting your approval** |
| Today, by kid | **Reward requests** |
| Awaiting your approval | Today, by kid |
| Reward requests | Today & this week |
| Recently decided | Recently decided |

Reward requests moved up alongside pending approvals because it's the same thing — a decision waiting on the parent — not context.

**Clickability.** A "Waiting on you" row in *Today, by kid* was a plain `<div>` with **no handler at all**. It looked actionable and did nothing. Those rows are now buttons that scroll to the matching approval card and ring it, reusing the arrival highlight from the prize tap-through in #178.

Only rows that lead somewhere become buttons. "Not started" and "Done" stay inert — looking tappable and doing nothing is the bug being fixed here, not a pattern to spread. There's a test asserting exactly that.

If the completion was decided on another device since the overview was drawn, the jump refreshes and says so rather than silently failing.

## Files

- `frontend/index.html` — section order, `jumpToApproval()`, linked rows, ids on pending cards, `.arriving` generalised beyond `.task`
- `scripts/check-frontend.js` — the ordering assertions **encoded the old order**, so they were updated to encode the new one rather than dropped; plus checks that the link and its target exist
- `tests/smoke/smoke.spec.js` — three cases

## Testing

- `node api/test-logic.js` — passes
- `node scripts/check-frontend.js` / `check-design.js` — pass
- Smoke suite — **26/26 passed** locally

Worth flagging on the main test: my first version ended `test.skip(...)` when it found no waiting row — and it **skipped every run**, because the seed ships no chores at all, so a "Waiting on you" row was impossible. A self-skipping test reads as green while checking nothing. It now creates a chore and completes it through the real API first (the page's own route intercept forwards that to the same handler), then asserts on rendered UI: the row exists, the click lands on the real approval card, and that card is in view with its Approve button on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_