### PR TITLE
Approvals: a note on approve, a required reason on decline

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -161,6 +161,7 @@ async function getState() {
       points: c.points || 0,
       date: c.date,
       status: c.status,
+      comment: c.comment || null,
       createdAt: c.createdAt,
       decidedAt: c.decidedAt || null,
     })),
@@ -860,6 +861,15 @@ async function validateVoiceNote(req) {
   return { ok: true, available, intent, confidence, needsConfirmation };
 }
 
+// A parent's note on a decision. Trimmed, and capped so one pasted essay cannot
+// distort every kid card that renders it.
+const DECISION_COMMENT_MAX = 280;
+
+function normaliseDecisionComment(value) {
+  const text = String(value == null ? '' : value).trim();
+  return text ? text.slice(0, DECISION_COMMENT_MAX) : '';
+}
+
 async function approve(req) {
   await requireParent(req.parentId, req.parentPin);
   const completions = container('completions');
@@ -872,6 +882,7 @@ async function approve(req) {
       completion.points = Number(req.points);
     }
     completion.status = 'approved';
+    completion.comment = normaliseDecisionComment(req.comment);
     completion.decidedAt = new Date().toISOString();
     await completions.item(req.completionId, HOUSEHOLD_ID).replace(completion);
     const quietHours = await getHouseholdQuietHours();
@@ -892,13 +903,22 @@ async function reject(req) {
     .read()
     .catch(() => ({ resource: null }));
   if (completion) {
+    // Required on a decline, unlike approve. A rejection with no reason leaves
+    // the kid with a red cross and no idea what to change, which is the whole
+    // problem this solves - so it is enforced here, not only in the UI.
+    const comment = normaliseDecisionComment(req.comment);
+    if (!comment) return { ok: false, error: 'Tell them what to do to get it approved' };
+
     completion.status = 'rejected';
+    completion.comment = comment;
     completion.decidedAt = new Date().toISOString();
     await completions.item(req.completionId, HOUSEHOLD_ID).replace(completion);
     const quietHours = await getHouseholdQuietHours();
     await sendPushIfAllowed(completion.kidId, {
+      // The reason travels in the notification too - reading it on the lock
+      // screen is the fastest way for the kid to know what to fix.
       title: 'Chore reviewed',
-      body: `${completion.title} needs another try — give it another go!`,
+      body: `${completion.title}: ${comment}`,
       url: '/',
     }, quietHours);
   }

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -1698,6 +1698,74 @@ async function main() {
   assert.strictEqual(crossChores.ok, false, 'another kid cannot reorder these tasks');
   console.log('\u2713 reorderTasks refuses another kid\u2019s task ids');
 
+  // -------------------------------------------------------------------------
+  // Decision comments on approve / reject
+  // -------------------------------------------------------------------------
+  const commentTask = await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234',
+    kidId: 'toby', title: 'Tidy the shed', points: 4, cycle: 'oneoff',
+  });
+  const shedTask = commentTask.tasks.find((t) => t.title === 'Tidy the shed');
+  await ROUTES.completeTask({ personId: 'toby', pin: '1234', taskId: shedTask.id });
+  const pendingShed = (await ROUTES.state()).completions
+    .find((c) => c.taskId === shedTask.id && c.status === 'pending');
+
+  // A decline with no reason must be refused - by the API, not only the UI.
+  const bareReject = await ROUTES.reject({
+    parentId: 'peter', parentPin: '1234', completionId: pendingShed.id,
+  });
+  assert.strictEqual(bareReject.ok, false, 'reject without a comment is refused');
+  const stillPending = (await ROUTES.state()).completions.find((c) => c.id === pendingShed.id);
+  assert.strictEqual(stillPending.status, 'pending', 'a refused reject must not change the status');
+  console.log('\u2713 reject requires a comment and leaves the record untouched without one');
+
+  const blankReject = await ROUTES.reject({
+    parentId: 'peter', parentPin: '1234', completionId: pendingShed.id, comment: '   ',
+  });
+  assert.strictEqual(blankReject.ok, false, 'whitespace is not a reason');
+  console.log('\u2713 reject treats a whitespace-only comment as missing');
+
+  await ROUTES.reject({
+    parentId: 'peter', parentPin: '1234', completionId: pendingShed.id,
+    comment: 'The rake is still out — put it away and re-tick it.',
+  });
+  const rejected = (await ROUTES.state()).completions.find((c) => c.id === pendingShed.id);
+  assert.strictEqual(rejected.status, 'rejected', 'status flips to rejected');
+  assert.strictEqual(
+    rejected.comment, 'The rake is still out — put it away and re-tick it.',
+    'the reason reaches the kid through getState',
+  );
+  console.log('\u2713 reject stores the reason and getState exposes it');
+
+  // Approve: the comment is optional, and absence is null rather than missing.
+  await ROUTES.completeTask({ personId: 'toby', pin: '1234', taskId: shedTask.id });
+  const secondTry = (await ROUTES.state()).completions
+    .find((c) => c.taskId === shedTask.id && c.status === 'pending');
+  await ROUTES.approve({
+    parentId: 'peter', parentPin: '1234', completionId: secondTry.id,
+    comment: 'Much better, thank you!',
+  });
+  const approved = (await ROUTES.state()).completions.find((c) => c.id === secondTry.id);
+  assert.strictEqual(approved.status, 'approved', 'status flips to approved');
+  assert.strictEqual(approved.comment, 'Much better, thank you!', 'approve keeps its note');
+  console.log('\u2713 approve stores an optional note');
+
+  const longTask = await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234',
+    kidId: 'toby', title: 'Long note check', points: 1, cycle: 'oneoff',
+  });
+  const longId = longTask.tasks.find((t) => t.title === 'Long note check').id;
+  await ROUTES.completeTask({ personId: 'toby', pin: '1234', taskId: longId });
+  const longPending = (await ROUTES.state()).completions
+    .find((c) => c.taskId === longId && c.status === 'pending');
+  await ROUTES.approve({
+    parentId: 'peter', parentPin: '1234', completionId: longPending.id,
+    comment: 'x'.repeat(500),
+  });
+  const capped = (await ROUTES.state()).completions.find((c) => c.id === longPending.id);
+  assert.strictEqual(capped.comment.length, 280, 'a long note is capped, not stored whole');
+  console.log('\u2713 a decision comment is capped at 280 characters');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -322,6 +322,21 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   100%    { box-shadow: var(--shadow-1); }
 }
 .arriving { animation: reward-arrive 1.6s var(--ease-out); }
+
+/* A grown-up's note on a decision, shown on the kid's own card. */
+.decision-note {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+  font-size: var(--text-sm);
+  line-height: var(--leading-base);
+  color: var(--ink);
+}
+.decision-note.needs-fixing {
+  background: var(--warning-wash);
+  color: var(--warning);
+}
 .goal-card-title {
   font-size: var(--text-base);
   font-weight: var(--weight-bold);
@@ -3252,11 +3267,18 @@ function renderRecentActivity(kid) {
       ? 'Nice job! ✅ +' + pts + ' pts'
       : '❌ Not quite — you can try again';
     var dateStr = c.decidedAt ? formatRewardDate(c.decidedAt) : (c.date || '');
+    // The grown-up's note. Read-only on purpose: it is a message about a
+    // decision already made, not the start of an argument.
+    var note = c.comment
+      ? '<div class="decision-note' + (isApproved ? '' : ' needs-fixing') + '">'
+        + (isApproved ? '💬 ' : '🔧 ') + esc(c.comment) + '</div>'
+      : '';
     return '<div class="task ' + cls + '">'
       + '<div class="tick" style="border-color:var(' + (isApproved ? '--success' : '--danger') + ');background:var(' + (isApproved ? '--success-wash' : '--danger-wash') + ');pointer-events:none" aria-hidden="true">' + icon + '</div>'
       + '<div class="info">'
       + '<div class="title">' + title + '</div>'
       + '<div class="sub">' + sub + (dateStr ? ' · ' + dateStr : '') + '</div>'
+      + note
       + '</div>'
       + '</div>';
   }).join('');
@@ -3296,6 +3318,7 @@ function renderParent(person) {
         + '</div>'
         + '<div class="approve-row">'
         + '<button class="btn green small" onclick="parentApprove(\'' + c.id + '\', ' + isExtra + ')">✓ Approve' + (isExtra ? ' & set points' : '') + '</button>'
+        + '<button class="btn ghost small" onclick="parentApproveWithNote(\'' + c.id + '\', ' + isExtra + ')" aria-label="Approve with a note">💬 With note</button>'
         + '<button class="btn red-ghost small" onclick="parentReject(\'' + c.id + '\')">✗ Nope</button>'
         + '</div>'
         + '</div>';
@@ -4385,18 +4408,43 @@ async function parentAddAdultAction(itemId) {
   }, 'Adult action added.');
 }
 
+// Approve with no note. The fast path stays one tap - most approvals have
+// nothing to say, and making every one of them go through a dialog would tax
+// the common case to serve the rare one.
 async function parentApprove(completionId, isExtra) {
   var points;
   if (isExtra) {
-    points = prompt('How many points is this worth?', '5');
+    // Was a raw prompt(), which shows the Azure hostname in the browser's own
+    // dialog. Same bug that was fixed for the kid's 'I did something extra'.
+    points = await askText('How many points is this worth?', '5', 'Approve');
     if (points === null) return;
   }
+  await submitApproval(completionId, points, '');
+}
+
+// Approve and say something. The note is read-only for the kid: it is a message
+// about a decision already made, not a thread.
+async function parentApproveWithNote(completionId, isExtra) {
+  var points;
+  if (isExtra) {
+    points = await askText('How many points is this worth?', '5', 'Next');
+    if (points === null) return;
+  }
+  var comment = await askText('Add a note for them (optional)', '', 'Approve');
+  if (comment === null) return;
+  await submitApproval(completionId, points, comment);
+}
+
+async function submitApproval(completionId, points, comment) {
   var prevCompletions = state.completions.slice();
   state.completions = prevCompletions.filter(function(c) { return c.id !== completionId; });
   render();
   var res;
   try {
-    res = await api({ action: 'approve', parentId: session.personId, parentPin: session.pin, completionId, points });
+    res = await api({
+      action: 'approve', parentId: session.personId, parentPin: session.pin,
+      completionId: completionId, points: points, comment: comment,
+    });
   } catch (e) {
     state.completions = prevCompletions; render(); toast('Connection problem — try again.'); return;
   }
@@ -4405,18 +4453,31 @@ async function parentApprove(completionId, isExtra) {
   }
 }
 
+// Declining always asks why. A red cross with no reason leaves the kid with
+// nothing to act on, so there is no path here that skips it - the API refuses
+// an empty comment too, so this is a courtesy, not the only guard.
 async function parentReject(completionId) {
+  var comment = await askText('What do they need to do to get this approved?', '', 'Send it back');
+  if (comment === null) return;
+  if (!String(comment).trim()) {
+    toast('Tell them what to fix first.');
+    return;
+  }
+
   var prevCompletions = state.completions.slice();
   state.completions = prevCompletions.filter(function(c) { return c.id !== completionId; });
   render();
   var res;
   try {
-    res = await api({ action: 'reject', parentId: session.personId, parentPin: session.pin, completionId });
+    res = await api({
+      action: 'reject', parentId: session.personId, parentPin: session.pin,
+      completionId: completionId, comment: comment,
+    });
   } catch (e) {
     state.completions = prevCompletions; render(); toast('Connection problem — try again.'); return;
   }
   if (res && res.ok === false) {
-    state.completions = prevCompletions; render(); toast(res.error || 'Could not reject.'); return;
+    state.completions = prevCompletions; render(); toast(res.error || 'Could not send that back.'); return;
   }
 }
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -490,7 +490,7 @@ test('a Waiting on you row leads to its approval card', async ({ page }) => {
   await expect(highlighted).toHaveCount(1);
   await expect(highlighted).toContainText('Feed the dog');
   await expect(highlighted).toBeInViewport();
-  await expect(highlighted.getByRole('button', { name: /Approve/ })).toBeVisible();
+  await expect(highlighted.getByRole('button', { name: '✓ Approve', exact: true })).toBeVisible();
 });
 
 // Rows with nothing to go to must stay inert rather than looking tappable.
@@ -501,4 +501,83 @@ test('rows that are not waiting on the parent are not links', async ({ page }) =
   for (let i = 0; i < count; i += 1) {
     await expect(notStarted.nth(i)).not.toHaveClass(/parent-list-row-link/);
   }
+});
+
+// Approve/decline notes. Declining without a reason leaves a kid with a red
+// cross and nothing to act on, so the reason is mandatory - and the note has to
+// actually reach the kid's own screen, which is the part source checks can't see.
+async function seedPendingChore(page, title) {
+  return page.evaluate(async (choreTitle) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: choreTitle, points: 2, cycle: 'oneoff',
+    });
+    const state = await post({ action: 'state' });
+    const task = state.tasks.find((t) => t.title === choreTitle);
+    await post({ action: 'completeTask', personId: 'toby', pin: '1234', taskId: task.id });
+    return true;
+  }, title);
+}
+
+test('declining asks why, and the reason reaches the kid', async ({ page }) => {
+  await seedPendingChore(page, 'Sweep the porch');
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-pending .parent-card').filter({ hasText: 'Sweep the porch' });
+  await card.getByRole('button', { name: /Nope/ }).click();
+
+  // The dialog must be the in-app one, and it must ask for the fix.
+  await expect(page.locator('#ask-modal')).toBeVisible();
+  await expect(page.locator('#ask-title')).toContainText('get this approved');
+
+  // Sending it back empty must not go through.
+  await page.locator('#ask-ok').click();
+  await expect(page.locator('#toast')).toContainText('Tell them what to fix');
+  await expect(card).toBeVisible();
+
+  await card.getByRole('button', { name: /Nope/ }).click();
+  await page.locator('#ask-input').fill('The step by the door is still dusty.');
+  await page.locator('#ask-ok').click();
+  await expect(card).toBeHidden();
+
+  // Now the part that matters: the kid can read it on their own screen.
+  await page.getByRole('button', { name: /Switch user/ }).click();
+  await pickPerson(page, 'Toby');
+  const activity = page.locator('#k-activity').filter({ hasText: 'Sweep the porch' });
+  await expect(activity).toContainText('The step by the door is still dusty.');
+});
+
+test('approving can carry a note, and the fast path still needs one tap', async ({ page }) => {
+  await seedPendingChore(page, 'Water the plants');
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-pending .parent-card').filter({ hasText: 'Water the plants' });
+  // The aria-label is the accessible name, so match on that rather than the
+  // visible "💬 With note" - they deliberately differ.
+  await card.getByRole('button', { name: /approve with a note/i }).click();
+  await page.locator('#ask-input').fill('Great job, the pots look happy.');
+  await page.locator('#ask-ok').click();
+  await expect(card).toBeHidden();
+
+  await page.getByRole('button', { name: /Switch user/ }).click();
+  await pickPerson(page, 'Toby');
+  await expect(page.locator('#k-activity')).toContainText('Great job, the pots look happy.');
+});
+
+test('a plain approve goes straight through with no dialog', async ({ page }) => {
+  await seedPendingChore(page, 'Fold the towels');
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-pending .parent-card').filter({ hasText: 'Fold the towels' });
+  await card.getByRole('button', { name: /^✓ Approve$/ }).click();
+  await expect(page.locator('#ask-modal')).toBeHidden();
+  await expect(card).toBeHidden();
 });


### PR DESCRIPTION
**User story**

> As a parent, when I decline something I need to tell them what to do to get it approved — and when I approve, I want the option to say something. As a kid, I want to read that note on my own screen.

## What changed

**Declining always asks why.** The dialog is *"What do they need to do to get this approved?"*. The API refuses an empty or whitespace-only comment as well, so the rule holds even if a request skips the UI — and a refused decline leaves the record `pending` rather than half-applying.

**Approving can carry a note**, via a new `💬 With note` button next to Approve.

**Plain approve stays one tap.** Most approvals have nothing to say, and routing every one of them through a dialog would tax the common case to serve the rare one — so the note is a separate button rather than a step added to the existing flow. There's a test asserting the fast path opens no dialog.

**The kid reads it on their own card**, in Recent activity, read-only — a message about a decision already made, not a thread. A decline note renders in the warning wash with a 🔧; an approval note in the sunken surface with a 💬.

**The reason travels in the push notification.** The lock screen now says what to fix instead of *"give it another go"*.

Comments are trimmed and capped at 280 characters, so one pasted essay can't distort every card that renders it.

## Also fixed along the way

`parentApprove` still used a **raw `prompt()`** for extra-task points — the browser dialog that shows the Azure hostname, the same bug already fixed for the kid's "I did something extra". It's now the in-app dialog. I'd have left it alone, but it sits inside the function this PR rewrites and would have appeared right beside the new in-app dialogs.

## Files

- `api/src/functions/hero.js` — `comment` on approve/reject, required on reject, shared normaliser, exposed through `getState()`
- `api/test-logic.js` — 5 assertions including empty and whitespace-only refusal, and the 280-char cap
- `frontend/index.html` — `askText` dialogs, With note button, kid-side note, styling
- `tests/smoke/smoke.spec.js` — 3 cases

## Testing

- `node api/test-logic.js` — passes
- `node scripts/check-frontend.js` / `check-design.js` — pass
- Smoke suite — **29/29 passed** locally

The decline test follows the reason all the way through: parent declines → switches user → **the kid can read it in their own Recent activity**. Source-level checks can't see that hop, and it's the whole point of the feature.

Three of my own test selectors were wrong first time and worth noting, since two were caused by this PR: adding an `aria-label="Approve with a note"` made a pre-existing `/Approve/` matcher ambiguous, and made `/With note/` fail because the accessible name is the aria-label, not the visible text. Fixed by matching exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_