### PR TITLE
Responsive layout: cap and centre content, use the width on wide screens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -252,6 +252,93 @@ spinner on a full screen, and never a blank flash followed by content jumping in
 
 ---
 
+### Swipeable card row
+
+Used for the kid Home prize banner. Native CSS `scroll-snap`, never a carousel
+library — touch, trackpad and keyboard all work for free and it degrades to a
+plain horizontal scroller where snap is unsupported.
+
+- Cards are exactly `100%` wide with **no gap**, so `scrollLeft / clientWidth`
+  is the card index. Dots read that; keep it true or the maths stops working.
+- Open on the card that matters (the prize being saved for), not card one.
+- Guard re-centring behind a signature of what the row is showing. `render()`
+  runs on every 60s poll; without the guard each one snaps the card back under
+  a thumb mid-swipe.
+- A card that leads somewhere is a `<button>`. A swipe ends with a finger on a
+  card too, so ignore a click arriving within 250ms of the last scroll event.
+
+### Bottom sheet
+
+For quick-add flows (My List). `.modal-bg` centres; a sheet pins to the bottom
+where a thumb is: `align-items: flex-end`, `--radius-lg` on the top corners
+only, `--shadow-3`, and it slides up with `transform: translateY(100%) → 0`
+under `prefers-reduced-motion: no-preference`.
+
+Never `window.prompt()` — the browser's own dialog shows the deployment
+hostname, which is how a kid ends up reading `salmon-river-0e879dc00…` in a
+question about chores.
+
+### Move controls
+
+Up/down `▲▼` icon buttons, 44px targets, stacked in a `.move-controls` column.
+
+Reordering is **organisation, not achievement**: no toast, no `celebrate()`, no
+vibration. First-up and last-down are `disabled`, never an error toast.
+
+### Notes on a decision
+
+A grown-up's comment on an approve or decline, shown read-only on the kid's own
+card. `--surface-sunken` with a 💬 for an approval; `--warning-wash` with a 🔧
+for a decline, because that one is a thing to fix. It is a message about a
+decision already made, not a thread — no reply affordance.
+
+### Linking a row to where the action is
+
+A row that summarises something actionable elsewhere becomes a `<button>` that
+scrolls the real target into view and rings it (`.arriving`, a 1.6s
+`box-shadow` pulse). Rows with nowhere to go stay inert `<div>`s — a row that
+looks tappable and does nothing is worse than one that plainly is not.
+
+---
+
+## Responsive
+
+Phone-first, and phone stays the primary case. But the app installs on desktops
+too, and content with no maximum width stretched a task row to ~1900px to hold
+thirty characters while type and padding stayed at phone scale.
+
+**Breakpoints.** 360 (small phone), 430 (large phone), 768 (tablet), 1280
+(laptop), 1920+ (wide). Check all five, on every tab, both roles.
+
+**`--shell-max: 72rem`.** Content caps there and centres.
+
+Two techniques, picked per element:
+
+- Blocks sitting on the page background: `max-width` and auto margins. If the
+  block carries its own gutter, cap at `calc(var(--shell-max) + gutter * 2)` or
+  its content sits inset from the header's by exactly that gutter.
+- Full-bleed bars (headers, nav, the coloured hero): keep the background edge
+  to edge and centre the *content* with
+  `padding-inline: max(var(--space-4), calc((100% - var(--shell-max)) / 2))`.
+  Capping their width instead leaves page background at the sides, which reads
+  as broken rather than centred.
+
+**Scaling type and spacing** is one rule, not one per component: every token is
+rem-based, so step `html { font-size }` at the breakpoint. Use **percentages**
+(`106.25%`, `112.5%`), not px — a px value silently overrides a reader who has
+set a larger default.
+
+**Using the width, not padding it out.** At `64rem`+ the kid Home glance puts
+Today and This Week side by side, and the parent's card lists become
+`repeat(auto-fill, minmax(20rem, 1fr))` — auto-fill so a very wide monitor gets
+three columns rather than two half-metre ones. Grids own their spacing, so zero
+the per-card `margin-bottom` inside them or it doubles up.
+
+**Never a horizontally scrolling page.** Wide content scrolls inside its own
+container.
+
+---
+
 ## Parent HQ
 
 Same tokens, different register:

--- a/docs/mvp-scope-v1.md
+++ b/docs/mvp-scope-v1.md
@@ -37,9 +37,27 @@ Closes #1.
   - Detect low-confidence/ambiguous transcript and require user confirmation or edit.
 - Save only confirmed, structured content.
 
+## What motivates a kid (settled in #9)
+
+Points count toward **real prizes in the Rewards shop** — ice cream, a player
+for the soccer game, picking dinner. Nothing else.
+
+The original build had a pet ladder (Egg → Hatchling → … → MEGA LEGEND), a
+daily streak and achievement badges. All three were removed: hatching an egg
+buys nothing, a streak only ever punishes the day it breaks, and a badge is a
+picture of a badge. The kids ignored them.
+
+> "the kids dont care about streaks, eggs hatching etc - this incentive path
+> replaces that"
+
+The test for anything proposed here: **does it end in a prize the kids can
+hold?** If not, it does not belong. `stats[].streak` and `stats[].badges` are
+still computed server-side but nothing renders them.
+
 ## Non-goals for v1
 - Multi-household support.
-- Advanced analytics/gamification beyond basic progress.
+- Invented currencies — levels, pets, streaks, badges, combo multipliers.
+- Advanced analytics beyond basic progress.
 - Fully autonomous AI scheduling or planning.
 - Third-party integrations (school systems, calendars, smart home platforms).
 - Enterprise-grade org/admin controls.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,6 +67,9 @@
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;
+  /* Widest the content ever gets. Past this the layout centres rather than
+     stretching - see the responsive shell section. */
+  --shell-max: 72rem;
   --space-5: 1.5rem;
   --space-6: 2rem;
   --space-7: 3rem;
@@ -1066,6 +1069,94 @@ button.parent-list-row:active { transform: scale(0.99); }
   background: var(--surface);
 }
 
+/* ─── Responsive shell ─────────────────────────────────────────────────
+   Phone stays the primary case and nothing below changes it. What these rules
+   fix is the app opening on a laptop or a 34-inch monitor: content had no
+   maximum width, so a task row stretched to ~1900px to hold thirty characters
+   while type and padding stayed at phone scale.
+
+   Two techniques, picked per element:
+
+   - Content blocks that sit on the page background just get a max-width and
+     auto margins.
+   - Full-bleed bars (headers, nav, the coloured hero) keep their background
+     edge to edge and centre their CONTENT with a padding-inline that grows.
+     Capping their width instead would leave the page background showing at
+     the sides, which reads as a broken layout rather than a centred one.
+
+   Every token is rem-based, so stepping the root font-size scales type and
+   spacing together rather than needing a rule per component. That is the whole
+   of the "scale with the breakpoint" requirement. The steps are percentages
+   rather than px so they scale from whatever the reader has their browser set
+   to - a px value would silently override someone's larger default.
+
+   Breakpoints checked: 360, 430, 768, 1280, 1920+. */
+/* These each carry their own --space-4 gutter, so the cap has to allow for it
+   or their content sits inset from the header's by exactly that gutter - an
+   18px step at the left edge that reads as a misalignment, because it is one. */
+.tab-content,
+.home-content-sheet,
+.parent-panel,
+.who-sheet {
+  max-width: calc(var(--shell-max) + var(--space-4) * 2);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.kid-header,
+.parent-header,
+.parent-tabbar,
+.tab-bar,
+.who-band,
+.kid-home-hero {
+  padding-inline: max(var(--space-4), calc((100% - var(--shell-max)) / 2));
+}
+
+/* The hero's own children are already full-width of it; the padding above
+   centres them, so the carousel must not add its own inset on top. */
+@media (min-width: 48rem) {
+  .goal-card { padding-inline: 0; }
+}
+
+/* Tablet and up. */
+@media (min-width: 48rem) {
+  html { font-size: 106.25%; }
+  /* Four across instead of two: at this width a 2-column picker gives each
+     person a tile wider than it is tall. */
+  .tile-grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* Laptop and up: use the width rather than padding it out. */
+@media (min-width: 64rem) {
+  .home-glance-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: var(--space-5);
+    align-items: start;
+  }
+  /* auto-fill rather than a fixed 2, so these become three across on a very
+     wide monitor instead of stretching to half a metre each. */
+  #p-pending,
+  #p-reward-requests,
+  #p-approvals-today-by-kid,
+  #p-decided {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: var(--space-3);
+    align-items: start;
+  }
+  /* Those grids own the spacing now; the per-card margin would double it. */
+  #p-pending > .card,
+  #p-reward-requests > .card,
+  #p-approvals-today-by-kid > .card,
+  #p-decided > .card { margin-bottom: 0; }
+}
+
+/* Desktop. */
+@media (min-width: 80rem) {
+  html { font-size: 112.5%; }
+}
+
 /* ─── Confetti canvas ─────────────────────────────────────────────────── */
 #confetti-canvas { position: fixed; inset: 0; pointer-events: none; z-index: 99; }
 
@@ -1188,10 +1279,16 @@ button.parent-list-row:active { transform: scale(0.99); }
         <div class="goal-dots" id="k-goal-dots"></div>
       </div>
       <div class="home-content-sheet">
-        <h2 class="section-title">📅 Today</h2>
-        <div id="k-glance-today"></div>
-        <h2 class="section-title">🗓️ This Week</h2>
-        <div id="k-glance-week"></div>
+        <div class="home-glance-grid">
+          <section>
+            <h2 class="section-title">📅 Today</h2>
+            <div id="k-glance-today"></div>
+          </section>
+          <section>
+            <h2 class="section-title">🗓️ This Week</h2>
+            <div id="k-glance-week"></div>
+          </section>
+        </div>
         <div class="kid-home-actions">
           <button class="btn ghost" onclick="addExtraPrompt()">➕ I did something extra!</button>
           <button class="btn voice-trigger" id="k-voice-reminder-btn" onclick="openVoiceReminderFlow()">🎤 Add a voice reminder</button>

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -581,3 +581,80 @@ test('a plain approve goes straight through with no dialog', async ({ page }) =>
   await expect(page.locator('#ask-modal')).toBeHidden();
   await expect(card).toBeHidden();
 });
+
+// #174. The app installs on desktops. With no maximum width a task row
+// stretched to ~1900px to hold thirty characters, at phone type scale.
+//
+// Checked at every breakpoint the design system names, because the failure is
+// silent - nothing errors, it just reads as a stretched phone page.
+const BREAKPOINTS = [
+  { w: 360, h: 780, label: 'small phone' },
+  { w: 430, h: 932, label: 'large phone' },
+  { w: 768, h: 1024, label: 'tablet' },
+  { w: 1280, h: 800, label: 'laptop' },
+  { w: 1920, h: 1080, label: 'wide' },
+];
+
+for (const bp of BREAKPOINTS) {
+  test(`nothing scrolls sideways at ${bp.w}px (${bp.label})`, async ({ page }) => {
+    await page.setViewportSize({ width: bp.w, height: bp.h });
+    await pickPerson(page, 'Ollie');
+
+    for (const tab of ['home', 'missions', 'rewards', 'leaderboard', 'calendar']) {
+      await page.locator(`#tabbtn-${tab}`).click();
+      const overflows = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(overflows, `${tab} tab overflows at ${bp.w}px`).toBe(false);
+    }
+  });
+}
+
+test('content is capped and centred on a wide screen, not stretched', async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await pickPerson(page, 'Ollie');
+
+  // 72rem at the 112.5% root of the wide breakpoint is ~1296px. The assertion
+  // that matters is simply that it is nowhere near the 1920 viewport.
+  const sheetWidth = await page.locator('.home-content-sheet').evaluate((el) => el.clientWidth);
+  expect(sheetWidth).toBeLessThan(1500);
+
+  // Centred, not left-aligned: equal gap either side, within a pixel.
+  const box = await page.locator('.home-content-sheet').boundingBox();
+  const rightGap = 1920 - (box.x + box.width);
+  expect(Math.abs(box.x - rightGap)).toBeLessThanOrEqual(1);
+
+  // And the width is actually used: Today and This Week sit side by side.
+  const today = await page.locator('#k-glance-today').boundingBox();
+  const week = await page.locator('#k-glance-week').boundingBox();
+  expect(week.x).toBeGreaterThan(today.x + today.width - 1);
+});
+
+test('the parent approval list goes multi-column on a wide screen', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (b) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(b),
+    }).then((r) => r.json());
+    for (const t of ['Grid one', 'Grid two', 'Grid three']) {
+      await post({ action: 'addTask', parentId: 'peter', parentPin: '1234', kidId: 'toby', title: t, points: 1, cycle: 'oneoff' });
+    }
+    const st = await post({ action: 'state' });
+    for (const t of st.tasks.filter((x) => x.title.startsWith('Grid '))) {
+      await post({ action: 'completeTask', personId: 'toby', pin: '1234', taskId: t.id });
+    }
+  });
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const cards = page.locator('#p-pending > .card');
+  expect(await cards.count()).toBeGreaterThanOrEqual(3);
+
+  // Two cards sharing a row is the whole point - one column would put every
+  // card at the same x, each one stretched across the screen.
+  const first = await cards.nth(0).boundingBox();
+  const second = await cards.nth(1).boundingBox();
+  expect(second.x).toBeGreaterThan(first.x);
+  expect(first.width).toBeLessThan(800);
+});


### PR DESCRIPTION
Closes #174.

**User story**

> As a parent, when I open Hero Tasks on my desktop I want it to look like a designed screen — not a phone page stretched across a 34-inch monitor with tiny text and metre-wide rows.

## The starting point

There were **no width breakpoints in the file at all** — the only media queries were `prefers-reduced-motion`. Nothing capped content width, so a task row grew to ~1900px to hold thirty characters while type and padding stayed at phone scale.

## What changed

`--shell-max: 72rem`. Two techniques, picked per element:

- **Content blocks** (`.tab-content`, `.parent-panel`, `.home-content-sheet`, `.who-sheet`) cap and centre. They each carry their own `--space-4` gutter, so the cap allows for it — otherwise their content sits inset from the header's by exactly that gutter, an 18px step at the left edge that reads as a misalignment because it is one.
- **Full-bleed bars** (headers, nav, the coloured hero) keep their background edge to edge and centre their *content* with `padding-inline: max(var(--space-4), calc((100% - var(--shell-max)) / 2))`. Capping their width instead leaves page background showing at the sides, which reads as broken rather than centred.

**Type and spacing scale with one rule, not one per component.** Every token is rem-based, so stepping `html { font-size }` at the breakpoint moves both together. The steps are **percentages** (`106.25%`, `112.5%`) rather than px, so a reader who has set a larger browser default keeps it — a px value would silently override them. (The design check caught my first attempt at raw px, correctly.)

**Using the width rather than padding it out**, at `64rem`+:
- Kid Home puts Today and This Week side by side
- Parent card lists become `repeat(auto-fill, minmax(20rem, 1fr))` — `auto-fill` so a very wide monitor gets three columns rather than two half-metre ones

## Verified, not assumed

Screenshotted both roles at 360 / 430 / 768 / 1280 / 1920. The parent Approvals tab at 1920 now shows **three columns of approval cards** instead of one row per card spanning the screen — the exact complaint that raised this issue. Phone is unchanged at 360 and 430.

## Documentation

These had not been kept up as the app changed, which was a fair thing to be pulled up on. Backfilled:

- **`docs/design-system.md`** — a new **Responsive** section (breakpoints, both centring techniques and when each applies, the rem/percentage scaling rule, the auto-fill reasoning), plus the components added recently and never documented: swipeable card row, bottom sheet, move controls, notes on a decision, and linking a summary row to where the action is.
- **`docs/mvp-scope-v1.md`** — records that points count toward real prizes, and that levels, pets, streaks and badges are now explicit non-goals, per #9. Previously the file said nothing about the direction change.

## Testing

- `node api/test-logic.js`, `check-frontend.js`, `check-design.js` — all pass
- Smoke suite — **36/36 passed** locally, first run

New guards: no sideways scroll on **any kid tab at all five breakpoints** (7 new cases), content capped and centred within a pixel at 1920 with Today/This Week genuinely side by side, and the parent list genuinely multi-column (two cards sharing a row — one column would put every card at the same `x`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_