### PR TITLE
Splash is its own screen, not the top half of the person picker

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -280,20 +280,33 @@ when the household does not exist, so editing `SEED_PEOPLE` changes nothing for
 a household created weeks ago. `AVATAR_MIGRATIONS` is the only thing that moves
 an existing record — this is the #88 trap, and it has now caught us twice.
 
-### Artwork behind the person picker
+### The splash screen
 
-`.who-band` carries the splash image with the brand gradient **underneath as a
-real fallback**, so a 404 or a slow load shows a branded band rather than a
-white gap. The artwork carries its own wordmark, so the band's `<h1>` is
-`display: none` rather than deleted — it is what shows if the image never
-arrives.
+**Its own screen, showing the artwork and nothing else.** `#screen-splash` sits
+alongside `screen-who` / `screen-kid` / `screen-parent` in `show()`.
 
-Text over artwork gets `--text-scrim`, not a solid bar: it has to hold contrast
-against whatever the picture happens to be without hiding it.
+It was first built as a background on the picker's header band. That was wrong:
+it turned the four sign-in tiles into the bottom half of what should be a held
+frame, and made one screen do two jobs. Splash is a held frame; the picker is
+where something is chosen. Separate screens.
 
-Keep the splash under ~200KB. It is the first paint on a phone, and this one is
-720px wide at WebP q76 — a bigger source buys nothing behind a `cover`
-background.
+- `contain`, not `cover`. This is a composed picture with a deliberate edge —
+  cropping the logo off a tall phone to fill the corners is worse than a thin
+  letterbox.
+- Brand colour underneath, so a slow or failed image is a branded screen rather
+  than white.
+- Clears itself once the app has something to show **and** a minimum beat has
+  passed, so it never flashes on a fast connection. A tap skips it. A backstop
+  timer clears it even if the first load never resolves — a splash must never
+  become a dead end.
+- Once dismissed it does not return. `render()` runs on every 60s poll, and a
+  splash reappearing mid-use would be absurd.
+
+Keep it under ~200KB: it is the first paint on a phone. This one is 720px wide
+at WebP q76.
+
+The picker keeps its own gradient band and wordmark — they are not a fallback
+for the splash, they are that screen's own design.
 
 ### The app icon
 
@@ -383,9 +396,14 @@ thirty characters while type and padding stayed at phone scale.
 
 Two techniques, picked per element:
 
-- Blocks sitting on the page background: `max-width` and auto margins. If the
-  block carries its own gutter, cap at `calc(var(--shell-max) + gutter * 2)` or
-  its content sits inset from the header's by exactly that gutter.
+- Blocks sitting on the page background: `width: 100%`, `max-width`, and auto
+  margins. If the block carries its own gutter, cap at
+  `calc(var(--shell-max) + gutter * 2)` or its content sits inset from the
+  header's by exactly that gutter.
+  **`width: 100%` is load-bearing.** On a flex item, auto cross-axis margins
+  override `align-self: stretch`, so `max-width` + auto margins alone collapses
+  it to its content width — that is how the person picker ended up 273px wide on
+  a 412px phone.
 - Full-bleed bars (headers, nav, the coloured hero): keep the background edge
   to edge and centre the *content* with
   `padding-inline: max(var(--space-4), calc((100% - var(--shell-max)) / 2))`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -127,39 +127,27 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 
 /* ─── Who screen ──────────────────────────────────────────────────────── */
 .who-band {
-  /* The gradient stays underneath as the fallback: if the artwork 404s or is
-     still loading, this is a branded band rather than a white gap. */
-  background:
-    url('img/hero-splash.webp') top center / cover no-repeat,
-    linear-gradient(155deg, var(--brand) 0%, var(--brand-soft) 100%);
+  background: linear-gradient(155deg, var(--brand) 0%, var(--brand-soft) 100%);
   padding: calc(env(safe-area-inset-top, 0px) + var(--space-7)) var(--space-5) calc(var(--space-7) + var(--space-4));
   text-align: center;
   color: var(--on-brand);
   flex-shrink: 0;
-  /* Tall enough to show the logo and the kids beneath it. Capped in vh so a
-     short landscape window does not give the band the whole screen. */
-  min-height: 46vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  position: relative;
 }
-/* The artwork carries its own title, so the band's own wordmark is hidden
-   rather than deleted - it is the fallback when the image cannot load. */
-.who-band-emoji, .who-band h1 { display: none; }
-.who-band p  {
-  font-size: var(--text-lg);
-  font-weight: var(--weight-bold);
-  margin-top: var(--space-2);
-  position: relative;
-  /* A scrim, not a solid bar: the prompt has to stay legible wherever the
-     artwork happens to be light, without hiding the picture. */
-  text-shadow: var(--text-scrim);
-}
-@media (min-width: 64rem) {
-  /* A portrait image cropped to a wide band shows very little, and the picker
-     is what matters on desktop - give the band less of the screen. */
-  .who-band { min-height: 32vh; }
+.who-band-emoji { font-size: var(--text-3xl); line-height: 1; }
+.who-band h1 { font-size: var(--text-2xl); font-weight: var(--weight-bold); margin-top: var(--space-3); line-height: var(--leading-tight); }
+.who-band p  { font-size: var(--text-base); opacity: 0.9; margin-top: var(--space-2); }
+
+/* ─── Splash ──────────────────────────────────────────────────────────────
+   The artwork on its own screen, edge to edge, with nothing over it. It is a
+   held frame, not a page: the picker that follows is where anything is done.
+
+   The brand colour sits underneath so a slow or failed image is a branded
+   screen rather than white. `contain` rather than `cover` because this is a
+   picture with a composed edge - cropping the logo off a tall phone to fill
+   the corners would be worse than letterboxing it. */
+.screen-splash {
+  background: var(--brand) url('img/hero-splash.webp') center / contain no-repeat;
+  cursor: pointer;
 }
 
 .who-sheet {
@@ -1148,6 +1136,11 @@ button.parent-list-row:active { transform: scale(0.99); }
 .home-content-sheet,
 .parent-panel,
 .who-sheet {
+  /* width:100% is load-bearing, not belt-and-braces. .who-sheet is a flex item
+     in a column container, and auto cross-axis margins override align-self:
+     stretch - so max-width + auto margins alone collapsed it to its content
+     width, leaving a 273px picker on a 412px phone. */
+  width: 100%;
   max-width: calc(var(--shell-max) + var(--space-4) * 2);
   margin-left: auto;
   margin-right: auto;
@@ -1278,6 +1271,8 @@ button.parent-list-row:active { transform: scale(0.99); }
 <!-- ════════════════════════════════════════════════════════════════════ -->
 <!-- WHO SCREEN                                                           -->
 <!-- ════════════════════════════════════════════════════════════════════ -->
+<div id="screen-splash" class="screen screen-splash hidden" onclick="dismissSplash()" role="img" aria-label="Hero Tasks"></div>
+
 <div id="screen-who" class="screen">
   <div class="who-band">
     <div class="who-band-emoji">🦸</div>
@@ -1999,8 +1994,37 @@ function buildEmptyState(emoji, line1, line2) {
     + '</div>';
 }
 
+// The splash is a held frame on launch, not a page. It stays until the app has
+// something to show AND a minimum beat has passed, so it never flashes on a
+// fast connection, and a tap skips it. Once dismissed it does not come back -
+// render() runs on every poll and a splash reappearing mid-use would be absurd.
+var splashPending = true;
+var splashMinElapsed = false;
+
+function dismissSplash() {
+  if (!splashPending) return;
+  splashPending = false;
+  render();
+}
+
+function startSplash() {
+  var el = document.getElementById('screen-splash');
+  if (el) el.classList.remove('hidden');
+  setTimeout(function() {
+    splashMinElapsed = true;
+    if (state) dismissSplash();
+  }, 1400);
+  // A backstop: if the first load never resolves, the splash must not become a
+  // dead end. The picker behind it renders its own error or empty state.
+  setTimeout(dismissSplash, 6000);
+}
+
 function render() {
   if (!state) return;
+  if (splashPending) {
+    if (!splashMinElapsed) { show('screen-splash'); return; }
+    splashPending = false;
+  }
   renderWho();
   const person = session && state.people.find(p => p.id === session.personId);
   if (!person) {
@@ -2018,7 +2042,7 @@ function render() {
 }
 
 function show(id) {
-  ['screen-who', 'screen-kid', 'screen-parent'].forEach(function(s) {
+  ['screen-splash', 'screen-who', 'screen-kid', 'screen-parent'].forEach(function(s) {
     var el = document.getElementById(s);
     var showing = s === id;
     el.classList.toggle('hidden', !showing);
@@ -4923,6 +4947,7 @@ function toast(msg) {
   toastTimer = setTimeout(function() { el.classList.add('hidden'); }, 2500);
 }
 
+startSplash();
 refresh();
 setInterval(refresh, 60000);
 document.addEventListener('visibilitychange', function() { if (!document.hidden) refresh(); });

--- a/scripts/check-design.js
+++ b/scripts/check-design.js
@@ -139,7 +139,7 @@ check(Boolean(bodyMatch), '<body> block exists');
 
 if (bodyMatch) {
   const body = bodyMatch[1];
-  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'myitem-sheet', 'toast']);
+  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-splash', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'myitem-sheet', 'toast']);
   const seenTopLevelIds = new Set();
   let unexpectedTopLevel = 0;
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -30,6 +30,10 @@ test.beforeEach(async ({ page }) => {
     });
   });
   await page.goto('/index.html');
+  // The splash holds for a beat on launch. Every test below wants the app
+  // behind it, so skip it rather than waiting the beat out 40-odd times.
+  await page.locator('#screen-splash').click({ timeout: 3000 }).catch(() => {});
+  await expect(page.locator('#screen-splash')).toBeHidden();
 });
 
 // Everyone in the seeded household has a PIN, so picking a person opens the PIN
@@ -684,16 +688,21 @@ test('the kid header carries the photo through after signing in', async ({ page 
   await expect(img).toHaveAttribute('src', /head-/);
 });
 
-test('the splash artwork loads behind the person picker', async ({ page }) => {
-  const band = page.locator('.who-band');
-  const url = await band.evaluate((el) => getComputedStyle(el).backgroundImage);
-  expect(url).toContain('hero-splash.webp');
+// This previously asserted the artwork sat on the picker's header band. That
+// was the mistake: it made the picker's tiles the bottom half of what should be
+// a screen of its own. The artwork belongs to #screen-splash and the picker
+// keeps its own gradient band.
+test('the artwork is on the splash screen, not the picker band', async ({ page }) => {
+  const splashBg = await page.locator('#screen-splash')
+    .evaluate((el) => getComputedStyle(el).backgroundImage);
+  expect(splashBg).toContain('hero-splash.webp');
 
-  // A 404 would leave the fallback gradient and look deliberate, so fetch it.
-  const status = await page.evaluate(async () => {
-    const res = await fetch('img/hero-splash.webp');
-    return res.status;
-  });
+  const bandBg = await page.locator('.who-band')
+    .evaluate((el) => getComputedStyle(el).backgroundImage);
+  expect(bandBg).not.toContain('hero-splash.webp');
+
+  // A 404 would leave the fallback colour and look deliberate, so fetch it.
+  const status = await page.evaluate(async () => (await fetch('img/hero-splash.webp')).status);
   expect(status).toBe(200);
 });
 
@@ -753,4 +762,50 @@ test('the apple touch icon exists and is the size iOS expects', async ({ page })
     img.src = src;
   }), href);
   expect(size).toEqual([180, 180]);
+});
+
+// The splash is the artwork on its own screen and nothing else. It was briefly
+// merged into the top of the person picker, which put the four sign-in tiles
+// on the bottom half of what should be a held frame.
+test('the splash is its own screen, with the picker behind it', async ({ page }) => {
+  // beforeEach already dismissed it, so this drives a fresh load.
+  await page.goto('/index.html');
+
+  const splash = page.locator('#screen-splash');
+  await expect(splash).toBeVisible();
+
+  // Nothing else is on it. In particular, not the person picker.
+  await expect(page.locator('#screen-who')).toBeHidden();
+  await expect(splash.locator('.who-tile')).toHaveCount(0);
+  await expect(splash).toHaveText('');
+
+  // It fills the screen rather than being a band at the top of another screen.
+  const box = await splash.boundingBox();
+  const view = page.viewportSize();
+  expect(Math.round(box.width)).toBe(view.width);
+  expect(Math.round(box.height)).toBe(view.height);
+
+  // A tap moves on, and the picker is a separate screen underneath.
+  await splash.click();
+  await expect(splash).toBeHidden();
+  await expect(page.locator('#screen-who')).toBeVisible();
+  await expect(page.locator('.who-tile')).toHaveCount(4);
+});
+
+test('the splash clears itself without a tap', async ({ page }) => {
+  await page.goto('/index.html');
+  await expect(page.locator('#screen-splash')).toBeVisible();
+  // Generous: the point is that it goes on its own, not exactly when.
+  await expect(page.locator('#screen-who')).toBeVisible({ timeout: 8000 });
+});
+
+// #183 capped these with max-width and auto margins. .who-sheet is a flex item
+// in a column container, where auto cross-axis margins override align-self:
+// stretch - so it collapsed to its content width and the picker rendered 273px
+// wide on a 412px phone.
+test('the picker fills the phone screen rather than collapsing to its content', async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 });
+  const sheet = await page.locator('.who-sheet').boundingBox();
+  expect(sheet.width).toBe(412);
+  expect(sheet.x).toBe(0);
 });


### PR DESCRIPTION
**User story**

> As anyone opening the app, I want the Hero Tasks artwork on its own screen — then a separate screen to choose who I am.

## What I got wrong

I put the artwork on the person picker's **header band**. That made the four sign-in tiles the bottom half of what should be a held frame, and made one screen do two jobs.

The sequence should be, and now is:

```
app icon  →  splash (artwork, full screen, nothing on it)  →  pick a person
```

`#screen-splash` joins `screen-who` / `screen-kid` / `screen-parent` in `show()`. The picker gets its gradient band and wordmark back — those are that screen's own design, not a fallback for the artwork.

## Splash behaviour

- **`contain`, not `cover`.** This is a composed picture with a deliberate edge; cropping the logo off a tall phone to fill the corners is worse than a thin letterbox. (At 412×915 the letterbox is a few pixels — the artwork's aspect is 0.449 against the phone's 0.450.)
- Brand colour underneath, so a slow or failed image is a branded screen rather than white.
- Clears once the app has something to show **and** a minimum beat has passed, so it never flashes on a fast connection. A tap skips it. A backstop timer clears it even if the first load never resolves — a splash must never become a dead end.
- Once dismissed it stays dismissed. `render()` runs on every 60-second poll.

## A real bug this uncovered, from #183

Measuring the picker to check my work: **`.who-sheet` was 273px wide in a 412px viewport.**

`.who-sheet` is a flex item in a column container, and **auto cross-axis margins override `align-self: stretch`** — so the `max-width` + auto margins I added in #183 collapsed it to its content width. That has been live on phones since that PR merged, and my own screenshot in #184 showed it while I looked straight past it.

`width: 100%` fixes it, and is now documented as load-bearing rather than left to be rediscovered.

## One test changed rather than added

`the splash artwork loads behind the person picker` asserted the artwork belongs on `.who-band` — the exact behaviour being undone. It now asserts the artwork is on `#screen-splash` **and explicitly not** on the band.

## Files

- `frontend/index.html` — `#screen-splash`, splash lifecycle, band reverted, the width fix
- `scripts/check-design.js` — register the new top-level screen
- `docs/design-system.md` — **The splash screen**; the `width: 100%` rule in Responsive
- `tests/smoke/smoke.spec.js` — three new cases, one rewritten

## Testing

- `node api/test-logic.js`, `check-frontend.js`, `check-design.js` — all pass
- Smoke suite — **45/45 passed** locally
- Screenshotted splash and picker at 412×915, and measured the sheet width before and after

New guards: the splash fills the viewport and **contains no `.who-tile`** (which is precisely what went wrong), it clears without a tap, and the picker sheet spans the full width of a phone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_