### PR TITLE
The artwork is the sign-in screen, and it stays up

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -280,59 +280,41 @@ when the household does not exist, so editing `SEED_PEOPLE` changes nothing for
 a household created weeks ago. `AVATAR_MIGRATIONS` is the only thing that moves
 an existing record — this is the #88 trap, and it has now caught us twice.
 
-### The splash screen
+### The sign-in screen
 
-**Its own screen, showing the artwork and nothing else.** `#screen-splash` sits
-alongside `screen-who` / `screen-kid` / `screen-parent` in `show()`.
+**The artwork is the screen.** Signing in happens on top of it; there is no
+separate splash.
 
-It was first built as a background on the picker's header band. That was wrong:
-it turned the four sign-in tiles into the bottom half of what should be a held
-frame, and made one screen do two jobs. Splash is a held frame; the picker is
-where something is chosen. Separate screens.
+It took three goes to get here, and the failures are the useful part:
 
-- `contain`, not `cover`. This is a composed picture with a deliberate edge —
-  cropping the logo off a tall phone to fill the corners is worse than a thin
-  letterbox.
-- Brand colour underneath, so a slow or failed image is a branded screen rather
-  than white.
-- Clears itself once the app has something to show **and** a minimum beat has
-  passed, so it never flashes on a fast connection. A tap skips it. A backstop
-  timer clears it even if the first load never resolves — a splash must never
-  become a dead end.
-- Once dismissed it does not return. `render()` runs on every 60s poll, and a
-  splash reappearing mid-use would be absurd.
+1. Artwork as a band at the top of the picker, tiles on a solid sheet below —
+   cut the picture in half to show four names.
+2. A separate splash screen that held for a beat then vanished — the artwork got
+   about two seconds and was then gone.
+3. This: the artwork fills the screen and the faces dock along the bottom, so it
+   stays up for as long as it takes someone to choose.
 
-Keep it under ~200KB: it is the first paint on a phone. This one is 720px wide
-at WebP q76.
+- **One row of round avatars** at the foot, not a grid of cards. A card needs
+  its own background and that background is a hole punched in the picture. A
+  face plus a name needs neither.
+- The strip they sit on is boots, backpack and map in the artwork. The logo, the
+  kids and the landscape are all above it and stay untouched.
+- The gradient behind the row **fades up** rather than starting hard, so it
+  reads as light falling off the foot of the picture instead of a panel laid on
+  top. `--scrim-strong` → `--scrim-soft` → transparent.
+- Whose face it is comes from the **ring**, not a card outline — kid colour for
+  a kid, brand for a parent.
+- The `Kid` / `Parent 👑` line is dropped here. At this size the face and the
+  name are the whole message, and a third line per person costs more picture.
 
-The picker keeps its own gradient band and wordmark — they are not a fallback
-for the splash, they are that screen's own design.
+**Sizing by aspect ratio, not width.** The artwork is portrait, roughly 0.45
+wide-to-tall. A phone is close enough that `cover` crops almost nothing. Past
+`3/5` it is not: `cover` zooms into the middle of the logo and drops the sign-in
+row on top of the wordmark. Wider than that, the whole picture is fitted with
+`contain` and the brand colour flanks it — a smaller picture, but an intact one.
 
-### The app icon
-
-The shield and star from the Hero Tasks artwork. It is **redrawn, not cropped**:
-in the artwork the shield's bottom point sits behind the wordmark, so there is
-no clean cut-out. Colours are sampled from the artwork so it reads as the same
-mark.
-
-`scripts/make-icons.py` regenerates every PNG and emits the SVG from one
-geometry definition, so the two cannot drift. It is a one-off tool run by hand —
-there is no build step here and this does not add one.
-
-Three platform rules that each fail silently:
-
-- **`purpose: "any"`** (`icon-192`, `icon-512`) — rounded square with
-  **transparent** corners. Filling them leaves black corners on any launcher
-  that does not mask.
-- **`purpose: "maskable"`** — **full-bleed square**, mark inside the middle 80%.
-  The OS crops to its own shape, so transparent corners become holes and a mark
-  near the edge gets clipped.
-- **`apple-touch-icon`** (180px) — **no transparency at all.** iOS composites on
-  black and rounds it itself, so transparent corners come out black.
-
-A broken icon never looks broken from inside the app — the launcher just shows a
-letter. The smoke suite checks every icon the manifest declares exists and is
-the size it claims.
+More people would shrink the row rather than wrap it. That is the right failure:
+a second row starts eating the picture again.
 
 ### Swipeable card row
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,6 +47,10 @@
      hold contrast against whatever the picture happens to be, not a known
      surface. */
   --text-scrim:   0 1px 6px rgba(28,24,48,0.7);
+  /* The gradient that lifts the sign-in row off the artwork. Deliberately not
+     opaque: the picture should still read through the foot of the screen. */
+  --scrim-strong: rgba(20,12,52,0.82);
+  --scrim-soft:   rgba(20,12,52,0.45);
   /* Colour — per-kid */
   --kid-1: #0ea5a5;
   --kid-2: #f0873a;
@@ -126,78 +130,112 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 
 /* ─── Who screen ──────────────────────────────────────────────────────── */
-.who-band {
-  background: linear-gradient(155deg, var(--brand) 0%, var(--brand-soft) 100%);
-  padding: calc(env(safe-area-inset-top, 0px) + var(--space-7)) var(--space-5) calc(var(--space-7) + var(--space-4));
+/* ─── Sign-in screen ──────────────────────────────────────────────────────
+   The artwork IS this screen. It was first a band at the top with the tiles on
+   a solid sheet below, which cut the picture in half to show four names.
+
+   So the faces dock along the bottom instead: a row of round avatars over a
+   gradient that fades up from the foot of the screen. That strip is boots,
+   backpack and map in the artwork - the logo, the kids and the landscape are
+   all above it and stay untouched.
+
+   No separate splash screen any more. This one is the splash, and it holds for
+   as long as it takes someone to choose, rather than a timed couple of
+   seconds. */
+#screen-who {
+  background: var(--brand) url('img/hero-splash.webp') center top / cover no-repeat;
+  justify-content: flex-end;
+}
+/* The artwork is portrait, about 0.45 wide-to-tall. A phone is close enough
+   that `cover` crops almost nothing. Anything squarer or landscape is not:
+   `cover` there zooms into the middle of the logo and the sign-in row lands on
+   top of the wordmark. Past 3/5 the whole picture is fitted instead and the
+   brand colour flanks it - a smaller picture, but an intact one. */
+@media (min-aspect-ratio: 3/5) {
+  #screen-who { background-size: contain; }
+}
+.who-sheet {
+  flex: none;
+  padding: var(--space-7) var(--space-4) calc(env(safe-area-inset-bottom, 0px) + var(--space-5));
+  /* Fades up rather than starting hard, so it reads as light falling off the
+     bottom of the picture and not as a panel laid on top of it. */
+  background: linear-gradient(
+    to top,
+    var(--scrim-strong) 0%,
+    var(--scrim-soft) 55%,
+    transparent 100%);
+}
+.who-prompt {
   text-align: center;
   color: var(--on-brand);
-  flex-shrink: 0;
-}
-.who-band-emoji { font-size: var(--text-3xl); line-height: 1; }
-.who-band h1 { font-size: var(--text-2xl); font-weight: var(--weight-bold); margin-top: var(--space-3); line-height: var(--leading-tight); }
-.who-band p  { font-size: var(--text-base); opacity: 0.9; margin-top: var(--space-2); }
-
-/* ─── Splash ──────────────────────────────────────────────────────────────
-   The artwork on its own screen, edge to edge, with nothing over it. It is a
-   held frame, not a page: the picker that follows is where anything is done.
-
-   The brand colour sits underneath so a slow or failed image is a branded
-   screen rather than white. `contain` rather than `cover` because this is a
-   picture with a composed edge - cropping the logo off a tall phone to fill
-   the corners would be worse than letterboxing it. */
-.screen-splash {
-  background: var(--brand) url('img/hero-splash.webp') center / contain no-repeat;
-  cursor: pointer;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  text-shadow: var(--text-scrim);
+  margin-bottom: var(--space-4);
 }
 
-.who-sheet {
-  flex: 1;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  background: var(--bg);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  margin-top: calc(-1 * var(--space-5));
-  padding: var(--space-5) var(--space-4) calc(env(safe-area-inset-bottom, 0px) + var(--space-6));
-}
-
-/* Tile grid — person picker */
-.tile-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+/* One row, however many people. Four fits a small phone comfortably; a fifth
+   would shrink rather than wrap, which is the right failure here - a second row
+   would start eating the picture again. */
+#who-grid {
+  display: flex;
+  justify-content: center;
   gap: var(--space-3);
 }
 .who-tile {
-  background: var(--surface);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-1);
-  padding: var(--space-5) var(--space-3);
+  flex: 1 1 0;
+  max-width: 6rem;
+  background: none;
+  border: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-2);
-  min-height: 5.5rem;
+  cursor: pointer;
   touch-action: manipulation;
   transition: transform var(--dur-fast) var(--ease-out);
-  outline: 3px solid transparent;
-  outline-offset: -3px;
 }
-.who-tile:active { transform: scale(0.97); }
-.who-tile.parent { background: var(--ink); color: var(--surface); }
-.who-tile.kid-tile { outline-color: var(--kid-color, var(--brand)); }
-.who-tile .tile-emoji { font-size: var(--text-2xl); line-height: 1; }
+.who-tile:active { transform: scale(0.94); }
+.who-tile .tile-emoji {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-2xl);
+  background: var(--surface);
+  /* The ring is what carries whose face this is - kid colour for a kid, brand
+     for a parent - now that there is no card behind it. */
+  box-shadow: 0 0 0 3px var(--tile-ring, var(--brand)), var(--shadow-2);
+}
+.who-tile.parent .tile-emoji { background: var(--ink); color: var(--surface); }
+.who-tile .tile-name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--on-brand);
+  text-shadow: var(--text-scrim);
+  line-height: var(--leading-tight);
+}
+/* The 'Kid'/'Parent 👑' line goes: at this size the face and the name are the
+   whole message, and a third line per person would need more of the picture. */
+.who-tile .tile-sub { display: none; }
+
+.skel-row {
+  height: 5.5rem;
+  border-radius: var(--radius-lg);
+  background: var(--on-brand-soft);
+}
+
 /* Photo avatars fill whatever round or rounded slot they are dropped into, so
-   the same markup works at 2.5rem in the header and 4.5rem on a picker tile. */
+   the same markup works at 2.5rem in the header and on a sign-in avatar. */
 .avatar-photo {
   width: 100%; height: 100%;
   object-fit: cover;
   border-radius: inherit;
   display: block;
-}
-.who-tile .tile-emoji:has(.avatar-photo) {
-  width: 4.5rem; height: 4.5rem;
-  border-radius: var(--radius-full);
-  overflow: hidden;
-  box-shadow: var(--shadow-1);
 }
 .kid-avatar-wrap { overflow: hidden; }
 .board-row span:has(.avatar-photo) {
@@ -206,22 +244,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   overflow: hidden;
   display: inline-block;
 }
-.who-tile .tile-name  { font-size: var(--text-lg); font-weight: var(--weight-bold); color: inherit; }
-.who-tile .tile-sub   { font-size: var(--text-sm); color: var(--ink-muted); }
-.who-tile.parent .tile-sub { color: var(--on-brand-muted); }
-
-/* Skeleton tiles */
-.skeleton-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-3);
-}
-.skel-tile {
-  background: var(--surface-sunken);
-  border-radius: var(--radius-lg);
-  height: 5.5rem;
-  animation: skel-pulse 1.4s ease-in-out infinite;
-}
+.skeleton-grid .skel-row { animation: skel-pulse 1.4s ease-in-out infinite; }
 @keyframes skel-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
 
 /* ─── Kid screen — header ─────────────────────────────────────────────── */
@@ -1164,9 +1187,6 @@ button.parent-list-row:active { transform: scale(0.99); }
 /* Tablet and up. */
 @media (min-width: 48rem) {
   html { font-size: 106.25%; }
-  /* Four across instead of two: at this width a 2-column picker gives each
-     person a tile wider than it is tall. */
-  .tile-grid { grid-template-columns: repeat(4, 1fr); }
 }
 
 /* Laptop and up: use the width rather than padding it out. */
@@ -1271,24 +1291,15 @@ button.parent-list-row:active { transform: scale(0.99); }
 <!-- ════════════════════════════════════════════════════════════════════ -->
 <!-- WHO SCREEN                                                           -->
 <!-- ════════════════════════════════════════════════════════════════════ -->
-<div id="screen-splash" class="screen screen-splash hidden" onclick="dismissSplash()" role="img" aria-label="Hero Tasks"></div>
-
 <div id="screen-who" class="screen">
-  <div class="who-band">
-    <div class="who-band-emoji">🦸</div>
-    <h1>Hero Tasks</h1>
-    <p>Who are you?</p>
-  </div>
   <div class="who-sheet">
     <div id="loading">
       <div class="skeleton-grid">
-        <div class="skel-tile"></div>
-        <div class="skel-tile"></div>
-        <div class="skel-tile"></div>
-        <div class="skel-tile"></div>
+        <div class="skel-row"></div>
       </div>
     </div>
-    <div class="tile-grid" id="who-grid"></div>
+    <p class="who-prompt">Who are you?</p>
+    <div id="who-grid"></div>
     <div id="setup-warn" class="setup-warn hidden">
       <strong>⚙️ Can't reach the server:</strong> check that <code>API_URL</code> at the top of this
       page's script points at your deployed Function App, and that it's actually running.
@@ -1994,37 +2005,8 @@ function buildEmptyState(emoji, line1, line2) {
     + '</div>';
 }
 
-// The splash is a held frame on launch, not a page. It stays until the app has
-// something to show AND a minimum beat has passed, so it never flashes on a
-// fast connection, and a tap skips it. Once dismissed it does not come back -
-// render() runs on every poll and a splash reappearing mid-use would be absurd.
-var splashPending = true;
-var splashMinElapsed = false;
-
-function dismissSplash() {
-  if (!splashPending) return;
-  splashPending = false;
-  render();
-}
-
-function startSplash() {
-  var el = document.getElementById('screen-splash');
-  if (el) el.classList.remove('hidden');
-  setTimeout(function() {
-    splashMinElapsed = true;
-    if (state) dismissSplash();
-  }, 1400);
-  // A backstop: if the first load never resolves, the splash must not become a
-  // dead end. The picker behind it renders its own error or empty state.
-  setTimeout(dismissSplash, 6000);
-}
-
 function render() {
   if (!state) return;
-  if (splashPending) {
-    if (!splashMinElapsed) { show('screen-splash'); return; }
-    splashPending = false;
-  }
   renderWho();
   const person = session && state.people.find(p => p.id === session.personId);
   if (!person) {
@@ -2042,7 +2024,7 @@ function render() {
 }
 
 function show(id) {
-  ['screen-splash', 'screen-who', 'screen-kid', 'screen-parent'].forEach(function(s) {
+  ['screen-who', 'screen-kid', 'screen-parent'].forEach(function(s) {
     var el = document.getElementById(s);
     var showing = s === id;
     el.classList.toggle('hidden', !showing);
@@ -2105,7 +2087,7 @@ function renderWho() {
     var kidColorAttr = '';
     if (!isParent) {
       var idx = Math.min(kids.findIndex(function(k) { return k.id === p.id; }), 3);
-      kidColorAttr = ' style="--kid-color:var(--kid-' + (idx + 1) + ')"';
+      kidColorAttr = ' style="--kid-color:var(--kid-' + (idx + 1) + ');--tile-ring:var(--kid-' + (idx + 1) + ')"';
     }
     var kidColorVal = isParent ? 'var(--brand)' : 'var(--kid-' + (Math.min(kids.findIndex(function(k) { return k.id === p.id; }), 3) + 1) + ')';
     return '<button class="who-tile ' + (isParent ? 'parent' : 'kid-tile') + '"'
@@ -4947,7 +4929,6 @@ function toast(msg) {
   toastTimer = setTimeout(function() { el.classList.add('hidden'); }, 2500);
 }
 
-startSplash();
 refresh();
 setInterval(refresh, 60000);
 document.addEventListener('visibilitychange', function() { if (!document.hidden) refresh(); });

--- a/scripts/check-design.js
+++ b/scripts/check-design.js
@@ -139,7 +139,7 @@ check(Boolean(bodyMatch), '<body> block exists');
 
 if (bodyMatch) {
   const body = bodyMatch[1];
-  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-splash', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'myitem-sheet', 'toast']);
+  const allowedTopLevelIds = new Set(['confetti-canvas', 'screen-who', 'screen-kid', 'screen-parent', 'pin-modal', 'ask-modal', 'voice-reminder-modal', 'myitem-sheet', 'toast']);
   const seenTopLevelIds = new Set();
   let unexpectedTopLevel = 0;
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -30,10 +30,6 @@ test.beforeEach(async ({ page }) => {
     });
   });
   await page.goto('/index.html');
-  // The splash holds for a beat on launch. Every test below wants the app
-  // behind it, so skip it rather than waiting the beat out 40-odd times.
-  await page.locator('#screen-splash').click({ timeout: 3000 }).catch(() => {});
-  await expect(page.locator('#screen-splash')).toBeHidden();
 });
 
 // Everyone in the seeded household has a PIN, so picking a person opens the PIN
@@ -692,18 +688,14 @@ test('the kid header carries the photo through after signing in', async ({ page 
 // was the mistake: it made the picker's tiles the bottom half of what should be
 // a screen of its own. The artwork belongs to #screen-splash and the picker
 // keeps its own gradient band.
-test('the artwork is on the splash screen, not the picker band', async ({ page }) => {
-  const splashBg = await page.locator('#screen-splash')
-    .evaluate((el) => getComputedStyle(el).backgroundImage);
-  expect(splashBg).toContain('hero-splash.webp');
-
-  const bandBg = await page.locator('.who-band')
-    .evaluate((el) => getComputedStyle(el).backgroundImage);
-  expect(bandBg).not.toContain('hero-splash.webp');
-
-  // A 404 would leave the fallback colour and look deliberate, so fetch it.
+test('the artwork actually loads rather than falling back to flat brand colour', async ({ page }) => {
+  // A 404 leaves the brand-colour fallback, which looks deliberate rather than
+  // broken - so the only way to catch it is to fetch the file.
   const status = await page.evaluate(async () => (await fetch('img/hero-splash.webp')).status);
   expect(status).toBe(200);
+
+  // And the old header band is gone, not merely restyled.
+  await expect(page.locator('.who-band')).toHaveCount(0);
 });
 
 // Existing households were created before the artwork existed. ensureSeeded()
@@ -764,48 +756,57 @@ test('the apple touch icon exists and is the size iOS expects', async ({ page })
   expect(size).toEqual([180, 180]);
 });
 
-// The splash is the artwork on its own screen and nothing else. It was briefly
-// merged into the top of the person picker, which put the four sign-in tiles
-// on the bottom half of what should be a held frame.
-test('the splash is its own screen, with the picker behind it', async ({ page }) => {
-  // beforeEach already dismissed it, so this drives a fresh load.
-  await page.goto('/index.html');
+// The artwork is the sign-in screen itself. It was, in order: a band at the top
+// of the picker (which cut the picture in half), then a separate splash that
+// held for two seconds and vanished. Now it is the screen you sign in on, so it
+// stays up for as long as it takes someone to choose.
+test('the sign-in screen is the artwork, with the faces on it', async ({ page }) => {
+  const screen = page.locator('#screen-who');
+  await expect(screen).toBeVisible();
 
-  const splash = page.locator('#screen-splash');
-  await expect(splash).toBeVisible();
+  const bg = await screen.evaluate((el) => getComputedStyle(el).backgroundImage);
+  expect(bg).toContain('hero-splash.webp');
 
-  // Nothing else is on it. In particular, not the person picker.
-  await expect(page.locator('#screen-who')).toBeHidden();
-  await expect(splash.locator('.who-tile')).toHaveCount(0);
-  await expect(splash).toHaveText('');
+  // Four faces, in one row, at the foot of the screen - not a grid of cards
+  // over the middle of the picture.
+  const tiles = page.locator('.who-tile');
+  await expect(tiles).toHaveCount(4);
+  const boxes = [];
+  for (let i = 0; i < 4; i += 1) boxes.push(await tiles.nth(i).boundingBox());
+  // Within a couple of pixels, not identical: flex sizing lands on fractional
+  // positions and rounding alone can split one row into two apparent values.
+  const tops = boxes.map((b) => b.y);
+  expect(Math.max(...tops) - Math.min(...tops), 'the faces should share one row')
+    .toBeLessThanOrEqual(2);
 
-  // It fills the screen rather than being a band at the top of another screen.
-  const box = await splash.boundingBox();
   const view = page.viewportSize();
-  expect(Math.round(box.width)).toBe(view.width);
-  expect(Math.round(box.height)).toBe(view.height);
-
-  // A tap moves on, and the picker is a separate screen underneath.
-  await splash.click();
-  await expect(splash).toBeHidden();
-  await expect(page.locator('#screen-who')).toBeVisible();
-  await expect(page.locator('.who-tile')).toHaveCount(4);
+  expect(Math.min(...tops), 'the row should sit low, leaving the artwork visible')
+    .toBeGreaterThan(view.height * 0.6);
 });
 
-test('the splash clears itself without a tap', async ({ page }) => {
-  await page.goto('/index.html');
-  await expect(page.locator('#screen-splash')).toBeVisible();
-  // Generous: the point is that it goes on its own, not exactly when.
-  await expect(page.locator('#screen-who')).toBeVisible({ timeout: 8000 });
+test('there is no separate splash screen to sit through', async ({ page }) => {
+  await expect(page.locator('#screen-splash')).toHaveCount(0);
+  // Signing in is reachable immediately, not after a timed hold.
+  await expect(page.locator('.who-tile').first()).toBeVisible({ timeout: 3000 });
+});
+
+test('the artwork survives a landscape window instead of zooming into the logo', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  const size = await page.locator('#screen-who').evaluate((el) => getComputedStyle(el).backgroundSize);
+  expect(size).toBe('contain');
+
+  await page.setViewportSize({ width: 412, height: 915 });
+  const phone = await page.locator('#screen-who').evaluate((el) => getComputedStyle(el).backgroundSize);
+  expect(phone).toBe('cover');
 });
 
 // #183 capped these with max-width and auto margins. .who-sheet is a flex item
 // in a column container, where auto cross-axis margins override align-self:
 // stretch - so it collapsed to its content width and the picker rendered 273px
 // wide on a 412px phone.
-test('the picker fills the phone screen rather than collapsing to its content', async ({ page }) => {
+test('the sign-in bar spans the phone screen rather than collapsing to its content', async ({ page }) => {
   await page.setViewportSize({ width: 412, height: 915 });
   const sheet = await page.locator('.who-sheet').boundingBox();
-  expect(sheet.width).toBe(412);
-  expect(sheet.x).toBe(0);
+  expect(Math.round(sheet.width)).toBe(412);
+  expect(Math.round(sheet.x)).toBe(0);
 });


### PR DESCRIPTION
**User story**

> As anyone opening the app, I want to actually look at the Hero Tasks artwork — and sign in on it, rather than watch it flash past.

## The problem

The splash got about **two seconds** of airtime and then vanished — less than the plain icon it replaced. Ironic, and a waste of the best asset in the project.

So the artwork now **is** the screen you sign in on. It holds for as long as it takes someone to choose.

## Third attempt — the first two are the useful part

1. **Artwork as a band at the top of the picker**, tiles on a solid sheet below → cut the picture in half to show four names.
2. **A separate timed splash** → the picture appeared and vanished.
3. **This**: full-screen artwork, faces docked along the bottom.

All three are written into the design system, because the failures explain the shape better than the result does.

## The decisions

- **A row of round avatars, not a grid of cards.** A card needs its own background, and that background is a hole punched in the picture. A face plus a name needs neither.
- **The strip they sit on is boots, backpack and map** in the artwork. The logo, the kids and the landscape are all above it and stay untouched.
- **The gradient fades up** rather than starting hard, so it reads as light falling off the foot of the picture instead of a panel laid on top.
- **The ring carries whose face it is** — kid colour for a kid, brand for a parent — now that there's no card outline doing that job.
- The `Kid` / `Parent 👑` line is dropped here. At this size the face and the name are the whole message, and a third line per person costs more picture.

## Sized by aspect ratio, not width

The artwork is portrait, roughly **0.45** wide-to-tall. A phone is close enough that `cover` crops almost nothing.

A laptop is not. My first version used `cover` everywhere and on a 1280×800 window it zoomed into the middle of the logo and **dropped the sign-in row on top of the wordmark** — I caught that in a screenshot before pushing. Past `3/5`, the whole picture is fitted with `contain` and the brand colour flanks it: a smaller picture, but an intact one.

## Also removed

`#screen-splash` and its lifecycle, the `🦸` header band (the leftover placeholder at the top of the sign-in screen), and the two-column tile grid.

## Files

- `frontend/index.html` — sign-in screen, scrim tokens, aspect-ratio rule; splash and band removed
- `scripts/check-design.js` — drop the retired screen id
- `docs/design-system.md` — **The sign-in screen**, including what the first two attempts got wrong
- `tests/smoke/smoke.spec.js` — three rewritten, one retitled

## Testing

- `node api/test-logic.js`, `check-frontend.js`, `check-design.js` — all pass
- Smoke suite — **46/46 passed** locally
- Screenshotted at 412×915, 768×1024 and 1280×800

New guards: the faces form **one row** sitting below 60% of screen height (a grid of cards over the middle would fail both), there is **no splash to sit through**, and a landscape window resolves to `contain` while a phone resolves to `cover`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_