### PR TITLE
Sign-in bar becomes a fading scrim instead of a frosted panel

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -295,7 +295,7 @@ not in scope there.
 **The artwork is the screen.** Signing in happens on top of it; there is no
 separate splash.
 
-It took three goes to get here, and the failures are the useful part:
+It took seven goes to get here, and the failures are the useful part:
 
 1. Artwork as a band at the top of the picker, tiles on a solid sheet below —
    cut the picture in half to show four names.
@@ -308,17 +308,29 @@ It took three goes to get here, and the failures are the useful part:
    controls. Nothing anchored them and nothing said "this is the way in".
 5. A **solid panel** docked to the bottom — anchored, but it anchors by
    covering: a fifth of the screen of flat white to hold four faces.
-6. This: a **frosted glass bar** on the bottom edge. 11% of the screen, and the
-   picture carries on through it.
+6. A **frosted glass bar** on the bottom edge — 11% of the screen instead of a
+   fifth, but still a box. Flat fill, blur boundary and a hairline along the
+   top: three separate edges for the eye to find.
+7. This: a **gradient scrim** that fades out upwards. No edge at all, 10% of the
+   screen, and the artwork runs unbroken to the bottom.
 
-- **A surface is what anchors, not position.** An edge and a radius say "these
-  are controls" in a way position alone cannot. But the surface does not have to
-  be opaque to do that — glass anchors just as well and costs half the height.
-- **Dark glass, not light.** A white bar over the foot of this artwork — boots
-  and backpack in shadow — just turns grey. Dark tint with white labels keeps
-  the colour underneath.
-- `backdrop-filter` is progressive. Without it this is a plain translucent bar,
-  which is fine.
+- **What draws a box is an edge, not opacity.** Attempts 5 and 6 both came back
+  as "takes up too much room" even though 6 was half the height and translucent.
+  Lowering the opacity of a panel does not stop it being a panel: a flat fill, a
+  blur boundary and a hairline top edge each give the eye a line to find. A
+  gradient has none, so it reads as shading on the picture rather than a surface
+  parked on it. Reach for less edge before less opacity.
+- **What anchors is the rings, not the bar.** Attempt 4 failed because loose
+  circles in the sky read as decoration — but the fix was a coloured ring on
+  each face plus a row along the bottom edge, not the panel that came with it.
+  Once the rings were there the panel was only paying for itself in contrast,
+  and a scrim buys that more cheaply.
+- **Dark, not light.** A white scrim over the foot of this artwork — boots and
+  backpack in shadow — just turns grey. Dark tint with white labels keeps the
+  colour underneath.
+- **The names carry their own contrast.** With a thin scrim there is no plate
+  behind them, so `text-shadow: var(--text-scrim)` does that work. Without it
+  they break up over the bright patches at the foot of the picture.
 - **Every person is the same kind of thing.** Same circle, same ring weight,
   same name. A parent on a dark disc beside a kid's photo read as two different
   categories rather than four ways into one app.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,10 +51,6 @@
      opaque: the picture should still read through the foot of the screen. */
   --scrim-strong: rgba(20,12,52,0.82);
   --scrim-soft:   rgba(20,12,52,0.45);
-  /* Frosted glass for a bar that has to sit ON artwork: enough surface to read
-     as a control strip, sheer enough that the picture carries on through it. */
-  --glass:        rgba(20,12,52,0.42);
-  --glass-edge:   rgba(255,255,255,0.18);
   /* Colour — per-kid */
   --kid-1: #0ea5a5;
   --kid-2: #f0873a;
@@ -169,11 +165,14 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
    bar, which is fine. */
 .who-sheet {
   flex: none;
-  padding: var(--space-3) var(--space-4) calc(env(safe-area-inset-bottom, 0px) + var(--space-3));
-  background: var(--glass);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  border-top: 1px solid var(--glass-edge);
+  padding: var(--space-2) var(--space-4) calc(env(safe-area-inset-bottom, 0px) + var(--space-2));
+  /* A scrim that fades out upwards, not a panel. The frosted bar this replaced
+     had a flat fill, a blur and a hairline along its top, and all three of them
+     drew an edge - so it read as a box parked on the artwork however low its
+     opacity went. A gradient has no edge to see: it is dark enough under the
+     names to hold them and gone by the time it reaches the picture. The rings
+     round the faces do the anchoring the panel used to do. */
+  background: linear-gradient(to top, var(--scrim-soft), transparent);
 }
 
 /* One row, however many people. Four fits a small phone comfortably; a fifth
@@ -227,6 +226,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   /* White on dark glass. A light bar over the foot of this artwork - which is
      boots and backpack in shadow - just turns grey. */
   color: var(--on-brand);
+  /* Its own contrast, because the scrim behind it is thin by design. */
+  text-shadow: var(--text-scrim);
   line-height: var(--leading-tight);
 }
 /* The 'Kid' / 'Parent 👑' line stays off. Four people in one household do not

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -857,6 +857,34 @@ test('the sign-in bar spans the phone screen rather than collapsing to its conte
   expect(Math.round(sheet.x)).toBe(0);
 });
 
+// Twice now the sign-in bar has drifted back into being a box sitting on the
+// artwork - first a solid coloured panel, then a frosted one. What draws the
+// box is an edge: a flat fill, a blur boundary or a hairline along the top all
+// give the eye a line to find, at any opacity. The bar is a gradient that fades
+// out upwards instead, so there is no edge to see. This guards the shape of the
+// thing rather than an exact colour, which is free to be retuned.
+test('the sign-in bar is a fading scrim, not a panel with an edge', async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 });
+  const style = await page.locator('.who-sheet').evaluate((el) => {
+    const s = getComputedStyle(el);
+    return {
+      image: s.backgroundImage,
+      colour: s.backgroundColor,
+      topBorder: s.borderTopWidth,
+      blur: s.backdropFilter || s.webkitBackdropFilter,
+    };
+  });
+  expect(style.image, 'the bar should be a gradient').toContain('gradient');
+  expect(style.colour, 'no flat fill under the gradient').toMatch(/rgba\(0, 0, 0, 0\)|transparent/);
+  expect(parseFloat(style.topBorder), 'no hairline along the top').toBe(0);
+  expect(style.blur || 'none', 'no blur boundary').toBe('none');
+
+  // And it stays a thin strip: a tenth of the screen or so, not a fifth.
+  const sheet = await page.locator('.who-sheet').boundingBox();
+  expect(sheet.height / 915, 'the bar should stay under an eighth of the screen')
+    .toBeLessThan(0.125);
+});
+
 // "Appy not wordy". Parent HQ reported zero with a four-line empty state, three
 // times on one screen, and put "Today's chores overview" under every kid's name.
 // Status is a colour and two words now.


### PR DESCRIPTION
The frosted glass bar from #188 was half the height of the solid panel it replaced and still came back as "too much background behind the icons". Opacity was never the problem: a flat fill, a blur boundary and a hairline along the top each draw an edge, and an edge is what makes it read as a box parked on the artwork.

## What changed

- **`.who-sheet` is now a gradient that fades out upwards** — no flat fill, no `backdrop-filter`, no `border-top`. Dark enough under the names to hold them, gone by the time it reaches the picture. 10% of the screen, down from 11%, and the artwork runs unbroken to the bottom.
- **Names carry their own contrast** via `text-shadow: var(--text-scrim)`, since there is no longer a plate behind them. Without it they break up over the bright patches at the foot of the artwork.
- **Dropped `--glass` and `--glass-edge`** — nothing else used them.

## Regression guard

New smoke test, `the sign-in bar is a fading scrim, not a panel with an edge`. It asserts the *shape* rather than an exact colour, which stays free to be retuned: a gradient is present, there is no flat fill under it, no top border, no backdrop-filter, and the bar stays under an eighth of the screen. This layout has drifted back into being a box twice now.

## Docs

`docs/design-system.md` records attempt 7 alongside the six before it, and corrects a takeaway that had the causation backwards — it credited the surface with anchoring the faces when the coloured rings were doing that work. The new note is: reach for less edge before less opacity.

## Checks

`check-design.js` and `check-frontend.js` pass; smoke suite 56/56.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_