### PR TITLE
The whole artwork, on every screen — it was cropping the best part off

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -314,6 +314,21 @@ It took seven goes to get here, and the failures are the useful part:
 7. This: a **gradient scrim** that fades out upwards. No edge at all, 10% of the
    screen, and the artwork runs unbroken to the bottom.
 
+**The artwork is fitted, never cropped.** It is 720×1604 — 0.449 wide to tall,
+which is *narrower than any real phone*: about 0.46 installed, 0.53–0.56 once
+browser chrome eats the height. `cover` therefore scales it to the width and
+pushes the surplus height off the bottom, and anchored `center top` the bottom
+is all it ever takes — 3% on a tall installed phone, **20% on an iPhone SE**.
+The bottom is the payload: the ball, the boots, the whole foreground. No
+`cover` anchor survives that, because a picture with ~8% expendable sky above
+and ~9% of ground below has nothing to give when a fifth has to go.
+
+So `background-size: contain` at every ratio. The bars that leaves on a squarer
+screen are filled by `#screen-who::before` — an over-scanned, blurred copy of
+the artwork — so the picture's own colours carry to the edge instead of a slab
+of flat brand purple. The blur is decoration; without it the fallback is the
+brand colour, which is what shipped before.
+
 - **What draws a box is an edge, not opacity.** Attempts 5 and 6 both came back
   as "takes up too much room" even though 6 was half the height and translucent.
   Lowering the opacity of a panel does not stop it being a panel: a flat fill, a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -142,27 +142,60 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
    No separate splash screen any more. This one is the splash, and it holds for
    as long as it takes someone to choose, rather than a timed couple of
    seconds. */
-#screen-who {
-  background: var(--brand) url('img/hero-splash.webp') center top / cover no-repeat;
-  justify-content: flex-end;
-}
-/* The artwork is portrait, about 0.45 wide-to-tall. A phone is close enough
-   that `cover` crops almost nothing. Anything squarer or landscape is not:
-   `cover` there zooms into the middle of the logo and the sign-in row lands on
-   top of the wordmark. Past 3/5 the whole picture is fitted instead and the
-   brand colour flanks it - a smaller picture, but an intact one. */
-@media (min-aspect-ratio: 3/5) {
-  #screen-who { background-size: contain; }
-}
-/* A frosted bar, docked to the bottom edge.
-   Loose circles floating on the artwork read as decoration rather than as the
-   way in - nothing anchored them. But a solid panel is a slab: it anchors by
-   covering, and takes a fifth of the screen to hold four faces.
+/* The whole picture, on every screen. The artwork is 720x1604 - 0.449 wide to
+   tall - which is NARROWER than almost every phone: 0.46 installed, 0.53-0.56
+   once browser chrome eats the height. `cover` therefore scales it to the width
+   and pushes the surplus height off the bottom, and anchored `center top` the
+   bottom is all it ever takes: 3% on a tall installed phone, 20% on an iPhone
+   SE. The bottom is the payload - the ball, the boots, the foreground - so the
+   crop landed squarely on the best part and cut the kids off at the chest.
+   There is no `cover` anchor that survives this. Dropping a fifth of a picture
+   that only has ~8% expendable sky at the top and ~9% of ground at the bottom
+   means something real goes whichever end you take it from.
 
-   Glass does the same job for less. There is still a surface with an edge, so
-   it still reads as a strip of controls; the picture just carries on through
-   it. Backdrop blur is progressive - without support it is a plain translucent
-   bar, which is fine. */
+   So: `contain`, always. The picture is never cropped at any aspect ratio.
+   What that costs is bars down the sides on a squarer screen, and ::before
+   pays for them with a blurred, over-scanned copy of the artwork itself -
+   the picture's own colours carry to the edge rather than a slab of flat
+   brand purple. Blur is decoration: without it the fallback is the brand
+   colour underneath, which is what shipped before. */
+#screen-who {
+  background: var(--brand);
+  justify-content: flex-end;
+  overflow: hidden;
+}
+#screen-who::before,
+#screen-who::after {
+  content: '';
+  position: absolute;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+#screen-who::before {
+  /* Over-scanned past the edges so the blur has no soft border of its own. */
+  inset: -6%;
+  background-image: url('img/hero-splash.webp');
+  background-size: cover;
+  filter: blur(28px);
+}
+#screen-who::after {
+  inset: 0;
+  background-image: url('img/hero-splash.webp');
+  background-size: contain;
+}
+/* Above both pseudo-elements: they are painted in the same stacking context. */
+#screen-who > * { position: relative; z-index: 1; }
+/* A scrim at the bottom edge, not a bar.
+   Loose circles floating on the artwork read as decoration rather than as the
+   way in. A solid panel fixed that by covering - a fifth of the screen to hold
+   four faces - and frosted glass halved the height but kept the problem: a
+   flat fill, a blur boundary and a hairline top edge each draw a line, and a
+   line is what makes it a box.
+
+   What actually anchors the faces is the coloured ring on each one plus the
+   row sitting on the bottom edge. Given those, the surface only had to buy
+   contrast for the names, and a gradient that fades out upwards buys it with
+   no edge at all. */
 .who-sheet {
   flex: none;
   padding: var(--space-2) var(--space-4) calc(env(safe-area-inset-bottom, 0px) + var(--space-2));

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -776,7 +776,9 @@ test('the sign-in screen is the artwork, with the faces on it', async ({ page })
   const screen = page.locator('#screen-who');
   await expect(screen).toBeVisible();
 
-  const bg = await screen.evaluate((el) => getComputedStyle(el).backgroundImage);
+  // The artwork is painted by ::after, with ::before behind it as a blurred
+  // fill for the letterbox, so read the pseudo-element and not the box.
+  const bg = await screen.evaluate((el) => getComputedStyle(el, '::after').backgroundImage);
   expect(bg).toContain('hero-splash.webp');
 
   // Four faces, in one row, at the foot of the screen - not a grid of cards
@@ -836,14 +838,45 @@ test('there is no separate splash screen to sit through', async ({ page }) => {
   await expect(page.locator('.who-tile').first()).toBeVisible({ timeout: 3000 });
 });
 
-test('the artwork survives a landscape window instead of zooming into the logo', async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 800 });
-  const size = await page.locator('#screen-who').evaluate((el) => getComputedStyle(el).backgroundSize);
-  expect(size).toBe('contain');
+// This one shipped cropped, and the test it replaces is why. The artwork is
+// 0.449 wide-to-tall - narrower than any real phone - so `cover` scaled it to
+// the width and pushed the surplus height off the bottom, which is where the
+// ball, the boots and the foreground are. 3% lost on a tall installed phone,
+// 20% on an iPhone SE. The old test asserted `cover` at 412x915, and 412x915 is
+// 0.450: the single viewport where that crop is invisible. Walking one point is
+// not coverage when the failure is a function of the ratio - walk the range.
+test('the artwork is never cropped, on any screen', async ({ page }) => {
+  const VIEWS = [
+    [375, 667, 'iPhone SE'],
+    [390, 720, 'iPhone, browser chrome'],
+    [412, 780, 'Android, browser chrome'],
+    [360, 740, 'Galaxy, installed'],
+    [390, 844, 'iPhone, installed'],
+    [412, 915, 'Pixel, installed'],
+    [768, 1024, 'tablet'],
+    [1280, 800, 'laptop, landscape'],
+  ];
+  for (const [width, height, name] of VIEWS) {
+    await page.setViewportSize({ width, height });
+    const size = await page.locator('#screen-who').evaluate(
+      (el) => getComputedStyle(el, '::after').backgroundSize);
+    expect(size, `${name} (${width}x${height}) should show the whole picture`)
+      .toBe('contain');
+  }
+});
 
-  await page.setViewportSize({ width: 412, height: 915 });
-  const phone = await page.locator('#screen-who').evaluate((el) => getComputedStyle(el).backgroundSize);
-  expect(phone).toBe('cover');
+// `contain` leaves bars on a squarer screen. They are filled with a blurred,
+// over-scanned copy of the artwork so its own colours reach the edge, rather
+// than a slab of flat brand purple beside the picture.
+test('the letterbox is filled with the artwork, not a flat slab', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  const fill = await page.locator('#screen-who').evaluate((el) => {
+    const s = getComputedStyle(el, '::before');
+    return { image: s.backgroundImage, size: s.backgroundSize, filter: s.filter };
+  });
+  expect(fill.image, 'the fill should be the artwork itself').toContain('hero-splash.webp');
+  expect(fill.size).toBe('cover');
+  expect(fill.filter, 'the fill should be blurred, not a second sharp copy').toContain('blur');
 });
 
 // #183 capped these with max-width and auto margins. .who-sheet is a flex item


### PR DESCRIPTION
Reported from a real phone: the soccer ball and the foreground were missing, and the picture looked unbalanced. It was.

## The bug

The splash is 720×1604 — **0.449 wide to tall, narrower than any real phone** (about 0.46 installed, 0.53–0.56 once browser chrome takes the height). So `cover` scaled it to the width and pushed the surplus height off the bottom, and anchored `center top` the bottom is all it ever took:

| Device | Viewport | Artwork lost |
|---|---|---|
| iPhone SE / small Android | 375×667 | **20%** |
| iPhone, browser chrome | 390×720 | **17%** |
| Android, browser chrome | 412×780 | **15%** |
| Galaxy, installed | 360×740 | 8% |
| iPhone, installed | 390×844 | 3% |
| Pixel, installed | 412×915 | 0.3% |

The bottom is the payload — the ball, the boots, the whole foreground. On a 375×667 the kids were cut off at the chest and the sign-in row landed on them.

## The fix

No `cover` anchor survives this: there is roughly 8% of expendable sky above and 9% of ground below, so dropping a fifth costs something real whichever end you take it from.

`background-size: contain` at every ratio instead, so the picture is never cropped. The bars that leaves on a squarer screen are filled by `#screen-who::before` — an over-scanned, blurred copy of the artwork — so its own colours carry to the edge rather than a slab of flat brand purple. The blur is decoration; without it the fallback is the brand colour, which is what shipped before.

## Why the tests missed it

The test that should have caught this asserted `background-size: cover` at 412×915 — and **412×915 is 0.450**, the single viewport where the crop is invisible. It was pinned to the one ratio that hides the failure.

Replaced with a walk across eight real viewports, iPhone SE through laptop landscape, asserting the artwork is fitted at each. A failure that is a function of the aspect ratio cannot be caught by sampling one ratio. Added a second test covering the blurred fill.

## Also

Corrected the block comment above `.who-sheet`, which still described the frosted bar that #190 replaced with a scrim.

## Checks

`check-design.js` and `check-frontend.js` pass; smoke suite 57/57.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_