### PR TITLE
Put the app on the family's clock instead of UTC

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -6,8 +6,45 @@ const { sendPush } = require('../lib/push');
 const { extractVoiceIntent } = require('../lib/llm');
 const { findConflicts, suggestAlternateSlots } = require('../lib/calendar');
 
-function todayStr() {
-  return new Date().toISOString().slice(0, 10);
+// Everything this app calls "today", or "9pm", means the family's local day -
+// not UTC. Perth runs UTC+8, and with no conversion at all the two collide
+// badly: a chore ticked at 7am was stamped with yesterday's date, and quiet
+// hours set for the evening landed in the middle of the school day. The
+// frontend was already using browser-local dates, so for the eight hours
+// either side of UTC midnight the two ends of the app disagreed about what
+// day it was and a just-completed chore rendered as still outstanding.
+//
+// Intl does the conversion, DST included, with no dependency and no
+// hand-rolled offset arithmetic to drift. 'en-CA' is here because it formats
+// as YYYY-MM-DD, which is the shape every date in this codebase already uses.
+const HOUSEHOLD_TZ = process.env.HOUSEHOLD_TIMEZONE || 'Australia/Perth';
+
+const LOCAL_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: HOUSEHOLD_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const LOCAL_TIME_FORMAT = new Intl.DateTimeFormat('en-GB', {
+  timeZone: HOUSEHOLD_TZ,
+  hour: '2-digit',
+  minute: '2-digit',
+  // h23 rather than hour12:false - the latter renders midnight as 24 on some
+  // ICU builds, which would put it a whole day out of range.
+  hourCycle: 'h23',
+});
+
+function todayStr(now = new Date()) {
+  return LOCAL_DATE_FORMAT.format(now);
+}
+
+// Minutes since local midnight, for comparing against an HH:MM setting.
+function localMinutes(now = new Date()) {
+  const parts = LOCAL_TIME_FORMAT.formatToParts(now);
+  const hour = Number(parts.find((part) => part.type === 'hour').value);
+  const minute = Number(parts.find((part) => part.type === 'minute').value);
+  return (hour * 60) + minute;
 }
 
 const HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
@@ -25,7 +62,7 @@ function isInQuietHours(quietHours, now = new Date()) {
   }
   const start = hhmmToMinutes(quietHours.start);
   const end = hhmmToMinutes(quietHours.end);
-  const nowMinutes = (now.getUTCHours() * 60) + now.getUTCMinutes();
+  const nowMinutes = localMinutes(now);
   if (start === end) return true;
   if (start < end) return nowMinutes >= start && nowMinutes < end;
   return nowMinutes >= start || nowMinutes < end;
@@ -1453,4 +1490,4 @@ app.timer('choreDueReminder', {
   },
 });
 
-module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders };
+module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, todayStr, localMinutes, HOUSEHOLD_TZ };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -663,15 +663,21 @@ async function main() {
   });
   console.log('✓ approve sends reward-earned push to the completed chore kid');
 
-  const now = new Date();
-  const startQuiet = new Date(now.getTime() - (60 * 1000));
-  const endQuiet = new Date(now.getTime() + (60 * 1000));
-  const hhmm = (d) => `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`;
+  // A window of one minute either side of now. Built from LOCAL time, because
+  // that is what a parent types into the setting and what the code now reads.
+  // This previously built it from getUTCHours() and passed only because the
+  // code was reading UTC too - two matching mistakes cancelling out.
+  const { localMinutes: nowLocalMinutes } = require('./src/functions/hero.js');
+  const nowMinutesLocal = nowLocalMinutes(new Date());
+  const hhmm = (minutes) => {
+    const wrapped = ((minutes % 1440) + 1440) % 1440;
+    return `${String(Math.floor(wrapped / 60)).padStart(2, '0')}:${String(wrapped % 60).padStart(2, '0')}`;
+  };
   await updateQuietHours({
     parentId: 'peter',
     parentPin: '1234',
-    start: hhmm(startQuiet),
-    end: hhmm(endQuiet),
+    start: hhmm(nowMinutesLocal - 1),
+    end: hhmm(nowMinutesLocal + 1),
   });
 
   await chores.items.create({
@@ -1765,6 +1771,36 @@ async function main() {
   const capped = (await ROUTES.state()).completions.find((c) => c.id === longPending.id);
   assert.strictEqual(capped.comment.length, 280, 'a long note is capped, not stored whole');
   console.log('\u2713 a decision comment is capped at 280 characters');
+
+  // -------------------------------------------------------------------------
+  // Local time. The app is a family in Perth (UTC+8) and every date it writes
+  // used to be a UTC date, so for the eight hours between local midnight and
+  // 8am the API and the browser disagreed about what day it was - a chore
+  // ticked before school was stamped yesterday and rendered as still to do.
+  // Quiet hours were out by the same eight hours in the other direction.
+  const { todayStr, localMinutes, isInQuietHours: quietCheck } = require('./src/functions/hero.js');
+
+  const beforeSchool = new Date('2026-08-23T23:30:00Z'); // 07:30 Mon 24th in Perth
+  assert.strictEqual(beforeSchool.toISOString().slice(0, 10), '2026-08-23',
+    'the fixture really is the previous day in UTC, or this proves nothing');
+  assert.strictEqual(todayStr(beforeSchool), '2026-08-24',
+    'a chore done before school belongs to today, not yesterday');
+  console.log('\u2713 an early-morning completion is dated the local day, not the UTC one');
+
+  assert.strictEqual(localMinutes(new Date('2026-08-23T16:00:00Z')), 0,
+    'local midnight is minute 0 - h23, so it must not come back as 24:00');
+  assert.strictEqual(localMinutes(new Date('2026-08-24T13:00:00Z')), 21 * 60,
+    '9pm local is minute 1260');
+  console.log('\u2713 local minutes are measured from local midnight');
+
+  const evenings = { start: '21:00', end: '07:00' };
+  assert.strictEqual(quietCheck(evenings, new Date('2026-08-24T13:30:00Z')), true,
+    '9:30pm local is inside a 21:00-07:00 quiet window');
+  assert.strictEqual(quietCheck(evenings, new Date('2026-08-23T22:00:00Z')), true,
+    '6am local is still inside it');
+  assert.strictEqual(quietCheck(evenings, new Date('2026-08-24T02:00:00Z')), false,
+    '10am local is not - this is the case that used to be silenced');
+  console.log('\u2713 quiet hours are read in local time, not UTC');
 
   console.log('\nALL LOGIC TESTS PASSED');
 }

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -334,6 +334,37 @@ to be expressed.
 - Chips, not a multi-select: seven options that are always the same seven read
   faster as a row you tap.
 
+### Dates and times are the family's, not UTC
+
+**Everything the app calls "today", or "9pm", means local time in
+`HOUSEHOLD_TZ`** (`Australia/Perth`, overridable with `HOUSEHOLD_TIMEZONE`).
+Use `todayStr()` and `localMinutes()` in `hero.js`; never `getUTCHours()` or
+`new Date().toISOString().slice(0, 10)` for anything a person will read as a
+day or a time.
+
+This was wrong for a long time and the failure was invisible for sixteen hours
+out of every twenty-four:
+
+- The frontend already used **browser-local** dates. The API used **UTC**. For
+  the eight hours between local midnight and 8am Perth the two disagreed about
+  what day it was, so a chore ticked before school was stored against
+  yesterday and then rendered as still outstanding.
+- Quiet hours set to `21:00–07:00` were applied in UTC, which in Perth is
+  **05:00–15:00** — silent through the school day, wide open at 2am.
+
+The conversion goes through `Intl.DateTimeFormat` with an explicit `timeZone`,
+which handles DST anywhere without a dependency. Two details worth keeping:
+`en-CA` is used because it formats as `YYYY-MM-DD`, the shape every date in
+this codebase already has; and the time formatter uses `hourCycle: 'h23'`
+rather than `hour12: false`, because the latter renders midnight as `24` on
+some ICU builds, putting it a full day out of range.
+
+Note the test that broke when this was fixed: it built its quiet-hours window
+from `getUTCHours()` and had only ever passed because the code read UTC too.
+Two matching mistakes cancelling out is the failure mode to watch for here —
+assert against a **fixed instant with a known local equivalent**, not against
+"now" formatted the same way the code formats it.
+
 ### The sign-in screen
 
 **The artwork is the screen.** Signing in happens on top of it; there is no


### PR DESCRIPTION
Groundwork for the windows/points work — and it fixes two live bugs on the way.

## The problem

The API had **no timezone handling at all**. Perth is UTC+8, and the frontend was already using browser-local dates, so the two ends of the app disagreed about what day it was for eight hours out of every twenty-four.

Two consequences, both invisible unless you looked at the right hour:

- **A chore ticked before 8am was stamped with yesterday's date** by the API. The frontend then compared it against its own local date, failed to match, and rendered the chore as still outstanding. The kid did it and the app said they hadn't.
- **Quiet hours were read with `getUTCHours()`.** Set to `21:00–07:00` expecting evening-to-morning, they actually applied **05:00–15:00 Perth** — silent right through the school day, wide open at 2am.

## The fix

`todayStr()` and a new `localMinutes()` go through `Intl.DateTimeFormat` with an explicit `timeZone` — DST handled, no dependency, no hand-rolled offset arithmetic to drift. `HOUSEHOLD_TZ` defaults to `Australia/Perth`, overridable with `HOUSEHOLD_TIMEZONE`.

Two details worth keeping: `en-CA` is used because it formats as `YYYY-MM-DD`, the shape every date in this codebase already has; and the time formatter uses `hourCycle: 'h23'` rather than `hour12: false`, because the latter renders midnight as `24` on some ICU builds — a full day out of range.

## Why this lands first

The window work behind it is unbuildable otherwise. *"Closes 9:00 pm"* computed in UTC would close at **5am Perth**.

## One existing test broke, which is the fix working

It built its quiet-hours window from `getUTCHours()` and had only ever passed because the code read UTC as well — two matching mistakes cancelling out. It now builds the window in local time.

The new tests deliberately assert against **fixed instants with known local equivalents** rather than formatting "now" the same way the code does, which is the trap that hid this. One of them asserts the fixture really is the previous day in UTC first, so the test proves something rather than passing vacuously.

## Checks

API logic tests pass (3 new), `check-design.js`, `check-frontend.js`, smoke suite 61/61.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_