### PR TITLE
Windows: a chore is due by morning, after school or evening — and late is late

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -68,6 +68,52 @@ function isInQuietHours(quietHours, now = new Date()) {
   return nowMinutes >= start || nowMinutes < end;
 }
 
+// Windows are when a chore is due. A recurring chore carries no time of its
+// own - "daily" says how often, never by when - so before this there was
+// nothing for a deadline to be measured against and nothing could be late.
+//
+// Three named windows for the whole household rather than a clock per chore:
+// three choices to set up instead of one per task, and a nudge can say "before
+// bed" rather than "at 18:00". Defaults live here rather than on the household
+// record on purpose - ensureSeeded() only writes when the household is absent,
+// so seeding them would do nothing for a household created weeks ago. A
+// household may override them; when it has not, these apply immediately.
+const DEFAULT_WINDOWS = Object.freeze([
+  Object.freeze({ id: 'morning',     label: 'Morning',      closesAt: '08:30' }),
+  Object.freeze({ id: 'afterschool', label: 'After school', closesAt: '18:00' }),
+  Object.freeze({ id: 'evening',     label: 'Evening',      closesAt: '21:00' }),
+]);
+
+// What a chore with no window set means. Existing chores predate the concept,
+// and an undated chore has always been understood as "some time today", so the
+// last window of the day is the honest reading rather than exempting it.
+const FALLBACK_WINDOW_ID = 'evening';
+
+async function getHouseholdWindows() {
+  const { resource: household } = await container('households')
+    .item(HOUSEHOLD_ID, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  const custom = household && Array.isArray(household.windows) ? household.windows : null;
+  return custom && custom.length ? custom : DEFAULT_WINDOWS;
+}
+
+function resolveWindow(windows, windowId) {
+  return windows.find((w) => w.id === windowId)
+    || windows.find((w) => w.id === FALLBACK_WINDOW_ID)
+    || windows[windows.length - 1]
+    || null;
+}
+
+// Whether the window has already shut today. Comparing minutes-since-local-
+// midnight needs no date arithmetic: the count resets at local midnight, so at
+// 00:30 the next day the same window reads as open again, which is exactly the
+// daily reset a recurring chore wants.
+function isWindowClosed(windowDef, now = new Date()) {
+  if (!windowDef || !HHMM_RE.test(windowDef.closesAt || '')) return false;
+  return localMinutes(now) >= hhmmToMinutes(windowDef.closesAt);
+}
+
 async function getHouseholdQuietHours() {
   const { resource: household } = await container('households')
     .item(HOUSEHOLD_ID, HOUSEHOLD_ID)
@@ -146,6 +192,8 @@ async function getState() {
   const allRewardRows = await queryHousehold('rewards');
   const redemptionDocs = allRewardRows.filter((r) => r.type === 'redemption');
 
+  const windows = await getHouseholdWindows();
+
   const stats = {};
   people
     .filter((p) => p.role === 'kid')
@@ -163,6 +211,14 @@ async function getState() {
   return {
     ok: true,
     vapidPublicKey: process.env.VAPID_PUBLIC_KEY || '',
+    // `closed` is computed HERE, not in the browser. The server is the only
+    // clock: it is the thing that enforces the close, and a phone whose OS
+    // timezone differs from the household's would otherwise show a different
+    // truth than the API acts on. Stale-while-open is acceptable - the display
+    // refreshes on every state fetch, and a submit against a window that shut
+    // in between gets the API's own refusal with a clear message.
+    windows: windows.map((w) => ({ ...w, closed: isWindowClosed(w) })),
+    fallbackWindowId: FALLBACK_WINDOW_ID,
     people: people.map((p) => ({ id: p.id, name: p.name, emoji: p.emoji, role: p.role, hasPin: !!p.pin })),
     rewards: rewardDocs.map((r) => ({ id: r.id, title: r.title, cost: r.cost, needsApproval: r.needsApproval })),
     redemptions: redemptionDocs
@@ -183,6 +239,7 @@ async function getState() {
       title: t.title,
       points: t.points,
       cycle: t.cycle,
+      windowId: t.windowId || null,
       days: Array.isArray(t.days) && t.days.length ? t.days : null,
       dueBy: t.dueBy || null,
       // Chores created before reordering existed have no order field. Falling
@@ -499,6 +556,12 @@ function choreFallsOnDay(chore, day, anchor) {
 
 async function addTask(req) {
   await requireParent(req.parentId, req.parentPin);
+  const windows = await getHouseholdWindows();
+  let windowId = null;
+  if (req.windowId !== undefined && req.windowId !== null && req.windowId !== '') {
+    if (!windows.some((w) => w.id === req.windowId)) return { ok: false, error: 'unknown window' };
+    windowId = req.windowId;
+  }
   let days = null;
   if (req.cycle === 'weekly' && req.days !== undefined) {
     days = normaliseChoreDays(req.days);
@@ -511,6 +574,8 @@ async function addTask(req) {
     title: req.title,
     points: Number(req.points) || 5,
     cycle: req.cycle || 'daily',
+    // Which window it is due by. Null reads as the fallback window.
+    windowId,
     // Only meaningful on a weekly chore. Null falls back to the creation day.
     days,
     // Due date/time only applies to one-off tasks — daily/weekly recurrence already
@@ -593,6 +658,15 @@ async function updateTask(req) {
       .catch(() => ({ resource: null }));
     if (!kid || kid.role !== 'kid') return { ok: false, error: 'Kid not found' };
     chore.kidId = req.kidId;
+  }
+  if (req.windowId !== undefined) {
+    if (req.windowId === null || req.windowId === '') {
+      chore.windowId = null;
+    } else {
+      const windows = await getHouseholdWindows();
+      if (!windows.some((w) => w.id === req.windowId)) return { ok: false, error: 'unknown window' };
+      chore.windowId = req.windowId;
+    }
   }
   if (req.days !== undefined && req.days !== null) {
     const days = normaliseChoreDays(req.days);
@@ -853,6 +927,25 @@ async function completeTask(req) {
   const chore = chores.find((t) => t.id === req.taskId);
   if (!chore) return { ok: false, error: 'Task not found' };
   await requireSelf(req.personId, req.pin, chore.kidId);
+
+  // The window is what makes the points real: submit inside it or they are
+  // gone. There is no late award and no parent override - that was settled
+  // deliberately, because a door that always reopens is not a deadline.
+  //
+  // One-off chores are left alone. They carry their own dueBy, which is a
+  // different mechanism with its own overdue display, and folding the two
+  // together is a separate decision rather than a detail of this one.
+  if (chore.cycle !== 'oneoff') {
+    const windows = await getHouseholdWindows();
+    const choreWindow = resolveWindow(windows, chore.windowId);
+    if (isWindowClosed(choreWindow)) {
+      return {
+        ok: false,
+        error: `The ${String(choreWindow.label).toLowerCase()} window closed at ${choreWindow.closesAt}.`,
+        windowClosed: true,
+      };
+    }
+  }
 
   // Idempotency: if a client-generated key is supplied, skip creating a
   // duplicate completion record when the same request is replayed (e.g. after
@@ -1490,4 +1583,4 @@ app.timer('choreDueReminder', {
   },
 });
 
-module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, todayStr, localMinutes, HOUSEHOLD_TZ };
+module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, resolveWindow };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -1,6 +1,21 @@
 // Standalone logic test — mocks Cosmos DB in-memory so the actual business logic in
 // hero.js runs for real (seed, add/complete/approve a chore, check points+streak),
 // without needing a live Cosmos DB or Azure Functions host. Not part of the deployed app.
+// The window feature makes 'now' part of the app's behaviour: past 21:00
+// household time a daily chore is refused. Tests must not change meaning with
+// the hour CI happens to run at, so the harness pins the household timezone to
+// a fixed-offset zone chosen so that local time is around noon right now, with
+// the local date equal to the UTC date (the browser in CI runs UTC, and the
+// two ends of the app must agree on what day it is). Etc/GMT zones use
+// inverted signs: Etc/GMT-8 means UTC+8.
+{
+  const utcHour = new Date().getUTCHours();
+  const offset = Math.max(-12, Math.min(14, 12 - utcHour));
+  process.env.HOUSEHOLD_TIMEZONE = offset === 0
+    ? 'Etc/GMT'
+    : `Etc/GMT${offset > 0 ? '-' : '+'}${Math.abs(offset)}`;
+}
+
 const path = require('path');
 const Module = require('module');
 
@@ -1775,32 +1790,112 @@ async function main() {
   // -------------------------------------------------------------------------
   // Local time. The app is a family in Perth (UTC+8) and every date it writes
   // used to be a UTC date, so for the eight hours between local midnight and
-  // 8am the API and the browser disagreed about what day it was - a chore
-  // ticked before school was stamped yesterday and rendered as still to do.
-  // Quiet hours were out by the same eight hours in the other direction.
-  const { todayStr, localMinutes, isInQuietHours: quietCheck } = require('./src/functions/hero.js');
+  // 8am the API and the browser disagreed about what day it was. These assert
+  // the real production timezone, so they run in a child process: the harness
+  // above pins HOUSEHOLD_TIMEZONE to a test zone before hero.js loads, and the
+  // constant is baked in at require time.
+  const { execFileSync } = require('child_process');
+  const perthProbe = execFileSync(process.execPath, ['-e', `
+    const h = require(${JSON.stringify(path.join(__dirname, 'src/functions/hero.js'))});
+    const out = {
+      beforeSchool: h.todayStr(new Date('2026-08-23T23:30:00Z')),
+      midnightMins: h.localMinutes(new Date('2026-08-23T16:00:00Z')),
+      ninePmMins:   h.localMinutes(new Date('2026-08-24T13:00:00Z')),
+      quietLateEvening: h.isInQuietHours({ start: '21:00', end: '07:00' }, new Date('2026-08-24T13:30:00Z')),
+      quietEarlyMorning: h.isInQuietHours({ start: '21:00', end: '07:00' }, new Date('2026-08-23T22:00:00Z')),
+      quietMidMorning: h.isInQuietHours({ start: '21:00', end: '07:00' }, new Date('2026-08-24T02:00:00Z')),
+      windowShutLateEvening: h.isWindowClosed({ id: 'evening', closesAt: '21:00' }, new Date('2026-08-24T13:30:00Z')),
+      windowOpenAfternoon:  h.isWindowClosed({ id: 'evening', closesAt: '21:00' }, new Date('2026-08-24T06:00:00Z')),
+    };
+    process.stdout.write(JSON.stringify(out));
+  `], {
+    env: { ...process.env, HOUSEHOLD_TIMEZONE: 'Australia/Perth' },
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  const perth = JSON.parse(perthProbe.toString());
 
-  const beforeSchool = new Date('2026-08-23T23:30:00Z'); // 07:30 Mon 24th in Perth
-  assert.strictEqual(beforeSchool.toISOString().slice(0, 10), '2026-08-23',
+  assert.strictEqual(new Date('2026-08-23T23:30:00Z').toISOString().slice(0, 10), '2026-08-23',
     'the fixture really is the previous day in UTC, or this proves nothing');
-  assert.strictEqual(todayStr(beforeSchool), '2026-08-24',
+  assert.strictEqual(perth.beforeSchool, '2026-08-24',
     'a chore done before school belongs to today, not yesterday');
   console.log('\u2713 an early-morning completion is dated the local day, not the UTC one');
 
-  assert.strictEqual(localMinutes(new Date('2026-08-23T16:00:00Z')), 0,
-    'local midnight is minute 0 - h23, so it must not come back as 24:00');
-  assert.strictEqual(localMinutes(new Date('2026-08-24T13:00:00Z')), 21 * 60,
-    '9pm local is minute 1260');
+  assert.strictEqual(perth.midnightMins, 0, 'local midnight is minute 0 - h23, not 24:00');
+  assert.strictEqual(perth.ninePmMins, 21 * 60, '9pm local is minute 1260');
   console.log('\u2713 local minutes are measured from local midnight');
 
-  const evenings = { start: '21:00', end: '07:00' };
-  assert.strictEqual(quietCheck(evenings, new Date('2026-08-24T13:30:00Z')), true,
-    '9:30pm local is inside a 21:00-07:00 quiet window');
-  assert.strictEqual(quietCheck(evenings, new Date('2026-08-23T22:00:00Z')), true,
-    '6am local is still inside it');
-  assert.strictEqual(quietCheck(evenings, new Date('2026-08-24T02:00:00Z')), false,
-    '10am local is not - this is the case that used to be silenced');
+  assert.strictEqual(perth.quietLateEvening, true, '9:30pm local is inside a 21:00-07:00 quiet window');
+  assert.strictEqual(perth.quietEarlyMorning, true, '6am local is still inside it');
+  assert.strictEqual(perth.quietMidMorning, false, '10am local is not - the case that used to be silenced');
   console.log('\u2713 quiet hours are read in local time, not UTC');
+
+  assert.strictEqual(perth.windowShutLateEvening, true, '9:30pm is past a 21:00 close');
+  assert.strictEqual(perth.windowOpenAfternoon, false, '2pm is not');
+  console.log('\u2713 a window closes on the household clock, not UTC');
+
+  // -------------------------------------------------------------------------
+  // Windows. The rule: submit inside the window or the points are gone - no
+  // late award, no override. These run in-process against the harness zone,
+  // where the pinned clock reads mid-morning, so "open" cases are open.
+  const stateWithWindows = await ROUTES.state();
+  assert.ok(Array.isArray(stateWithWindows.windows) && stateWithWindows.windows.length === 3,
+    'state carries the three household windows');
+  assert.ok(stateWithWindows.windows.every((w) => typeof w.closed === 'boolean'),
+    'each window says whether it has shut - the server is the only clock');
+  assert.strictEqual(stateWithWindows.fallbackWindowId, 'evening');
+  console.log('\u2713 state exposes the windows, their closed flags, and the fallback');
+
+  const badWindow = await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'ollie',
+    title: 'Ghost chore', points: 1, cycle: 'daily', windowId: 'brunch',
+  });
+  assert.strictEqual(badWindow.ok, false, 'an unknown window is refused');
+  console.log('\u2713 a chore cannot be put in a window that does not exist');
+
+  // The harness pins local time to ~noon, so 'afterschool' (closes 18:00) is
+  // open and 'morning' (closed 08:30) is already shut - both states reachable
+  // deterministically whatever hour CI runs.
+  await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'ollie',
+    title: 'Afternoon chore', points: 2, cycle: 'daily', windowId: 'afterschool',
+  });
+  const afternoonChore = (await ROUTES.state()).tasks.find((t) => t.title === 'Afternoon chore');
+  assert.strictEqual(afternoonChore.windowId, 'afterschool', 'the chosen window is stored and exposed');
+
+  const openTick = await ROUTES.completeTask({ taskId: afternoonChore.id, personId: 'ollie', pin: '1234' });
+  assert.strictEqual(openTick.ok, true, 'inside the window, completing works');
+  console.log('\u2713 a chore in an open window can be completed');
+
+  // Shut every window: closesAt 00:00 means minutes-since-midnight >= 0,
+  // which is every moment of the day. Deterministic whatever hour CI runs.
+  const { resource: household } = await mockContainer('households')
+    .item(HOUSEHOLD_ID, HOUSEHOLD_ID).read();
+  household.windows = [
+    { id: 'morning', label: 'Morning', closesAt: '00:00' },
+    { id: 'afterschool', label: 'After school', closesAt: '00:00' },
+    { id: 'evening', label: 'Evening', closesAt: '00:00' },
+  ];
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
+
+  await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'ollie',
+    title: 'Too late chore', points: 3, cycle: 'daily', windowId: 'evening',
+  });
+  const lateChore = (await ROUTES.state()).tasks.find((t) => t.title === 'Too late chore');
+  const lateTick = await ROUTES.completeTask({ taskId: lateChore.id, personId: 'ollie', pin: '1234' });
+  assert.strictEqual(lateTick.ok, false, 'a shut window refuses the completion');
+  assert.strictEqual(lateTick.windowClosed, true, 'and says why, machine-readably');
+  console.log('\u2713 a shut window means no points - refused at the API, not just greyed out');
+
+  const noWindowChore = (await ROUTES.state()).tasks.find((t) => t.title === 'Water plant');
+  const fallbackTick = await ROUTES.completeTask({ taskId: noWindowChore.id, personId: 'ollie', pin: '1234' });
+  assert.strictEqual(fallbackTick.ok, false,
+    'a chore with no window falls back to the evening window rather than escaping the rule');
+  console.log('\u2713 legacy chores without a window are held to the fallback window');
+
+  // Put the windows back for anything that runs after this.
+  household.windows = null;
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
 
   console.log('\nALL LOGIC TESTS PASSED');
 }

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -303,6 +303,46 @@ rather than shared through a constant because `check-frontend.js` lifts
 `IMG_AVATARS` into a sandbox on its own, and a constant declared outside it is
 not in scope there.
 
+### Windows — when a chore is due
+
+**Do it, submit it inside the window, get it approved — points. Window closes
+with nothing submitted — no points, marked a miss.** That is the household's
+whole mechanic, settled deliberately, including the hard part: **there is no
+late award and no parent override.** A door that always reopens is not a
+deadline.
+
+Three named windows for the whole household, not a clock per chore:
+
+| Window | Closes |
+|---|---|
+| Morning | 08:30 |
+| After school | 18:00 |
+| Evening | 21:00 |
+
+Defaults live in `DEFAULT_WINDOWS` in `hero.js`, overridable per household via
+a `windows` array on the household record — in code rather than the seed,
+because `ensureSeeded()` never touches an existing household (the #88 trap).
+A chore with no `windowId` is held to the **evening** window, not exempted: an
+undated chore has always meant "some time today", and the last window of the
+day is the honest reading of that.
+
+Rules that must not drift:
+
+- **The server is the only clock.** `state.windows[].closed` is computed
+  API-side and the frontend renders it; `completeTask` refuses a shut window
+  with `windowClosed: true`. The browser never computes shutness from its own
+  clock — a phone in the wrong timezone would show a different truth than the
+  API acts on.
+- **A miss stays on screen.** The row greys, says why, strikes the points —
+  it does not vanish. A miss that disappears overnight teaches nothing.
+- **One-offs are separate.** They carry their own `dueBy` and overdue display;
+  folding the two mechanisms together is a decision, not a default.
+- **Tests pin the clock.** "Now" is part of behaviour, so `test-logic.js` and
+  the smoke server pin `HOUSEHOLD_TIMEZONE` to a fixed-offset zone where local
+  time is ~noon — morning has always shut, evening is always open, whatever
+  hour CI runs. A window of `closesAt: '00:00'` is shut at every moment of the
+  day, which is the deterministic way to test refusal.
+
 ### How often a chore repeats
 
 Three options, and the middle one is the interesting one:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -715,6 +715,12 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .task.overdue .tick { border-color: var(--danger); }
 .task.overdue .sub  { color: var(--danger); font-weight: var(--weight-medium); }
+/* A shut window. Dimmed but still on the list - a miss that vanished overnight
+   would teach nothing; one that sits there until tomorrow is the record. */
+.task.missed { opacity: 0.6; }
+.task.missed .tick { border-color: var(--danger); cursor: default; }
+.task.missed .sub  { color: var(--danger); font-weight: var(--weight-medium); }
+.task.missed .pts-badge { text-decoration: line-through; }
 .task.dimmed { opacity: 0.72; }
 .task-side { display: flex; flex-direction: column; align-items: flex-end; gap: var(--space-2); }
 .task-exiting {
@@ -1691,6 +1697,10 @@ button.parent-list-row:active { transform: scale(0.99); }
               <option value="oneoff">One-off</option>
             </select>
           </div>
+          <div class="field" id="p-window-wrap">
+            <label>Due by</label>
+            <select id="p-window"></select>
+          </div>
           <div class="field hidden" id="p-days-wrap">
             <label>Which days</label>
             <div class="day-picker" id="p-days">
@@ -2494,10 +2504,14 @@ function glanceChoreCard(item) {
   var sub = c
     ? (c.status === 'approved' ? 'Done — points banked! 💰' : c.status === 'queued' ? 'Saved offline — syncing soon 📡' : 'Waiting for a grown-up to check ⏳')
     : '';
+  var ws = choreWindowState(task, c);
+  if (!c && ws) sub = ws.missed ? ws.missedText : (sub ? sub + ' · ' + ws.stake : ws.stake);
+  var missed = !!(ws && ws.missed);
   var action = c
     ? ((c.status === 'pending' || c.status === 'queued') ? 'undoTask(\'' + c.id + '\')' : '')
-    : 'doTask(\'' + task.id + '\')';
-  return '<div class="task ' + cls + '">'
+    : (missed ? '' : 'doTask(\'' + task.id + '\')');
+  if (missed) tickIcon = '❌';
+  return '<div class="task ' + cls + (missed ? ' missed' : '') + '">'
     + '<button class="tick" ' + (action ? 'onclick="' + action + '"' : 'disabled') + '>' + tickIcon + '</button>'
     + '<div class="info">'
     + '<div class="title">' + esc(task.title) + '</div>'
@@ -3286,16 +3300,24 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
     var cls = c ? (c.status === 'approved' ? 'done-approved' : c.status === 'queued' ? 'done-queued' : 'done-pending') : '';
     var tickIcon = c ? (c.status === 'approved' ? '✅' : c.status === 'queued' ? '📡' : '⏳') : '';
     var isOverdue = !c && t.dueBy && new Date(t.dueBy) < new Date();
+    // A recurring chore lives or dies by its window. Once it has shut with
+    // nothing submitted, the points are gone for today and the row says so -
+    // greyed and unclickable, not silently vanished. One-offs keep their own
+    // dueBy mechanics.
+    var ws = choreWindowState(t, c);
+    var missed = !!(ws && ws.missed);
     var sub = c
       ? (c.status === 'approved' ? 'Done — points banked! 💰' : c.status === 'queued' ? 'Saved offline — syncing soon 📡' : 'Waiting for a grown-up to check ⏳')
       : (t.cycle === 'weekly'
           ? (t.days && t.days.length ? 'On ' + daysLabel(t.days) : 'Any time this week')
           : '');
+    if (!c && ws) sub = missed ? ws.missedText : (sub ? sub + ' · ' + ws.stake : ws.stake);
     if (!c && t.dueBy) sub = isOverdue ? '⚠️ Overdue — was due ' + formatDue(t.dueBy) : 'Due ' + formatDue(t.dueBy);
     var action = c
       ? ((c.status === 'pending' || c.status === 'queued') ? 'undoTask(\'' + c.id + '\')' : '')
-      : 'doTask(\'' + t.id + '\')';
-    return '<div class="task ' + cls + ' ' + (isOverdue ? 'overdue' : '') + '">'
+      : (missed ? '' : 'doTask(\'' + t.id + '\')');
+    if (missed) tickIcon = '❌';
+    return '<div class="task ' + cls + ' ' + (isOverdue ? 'overdue' : '') + (missed ? ' missed' : '') + '">'
       + '<button class="tick" ' + (action ? 'onclick="' + action + '"' : 'disabled') + '>' + tickIcon + '</button>'
       + '<div class="info">'
       + '<div class="title">' + esc(t.title) + '</div>'
@@ -3874,6 +3896,17 @@ function renderParent(person) {
     }).join('');
   }
 
+  var windowSel = document.getElementById('p-window');
+  if (windowSel) {
+    var windowCurrent = windowSel.value;
+    windowSel.innerHTML = ((state.windows) || []).map(function(w) {
+      return '<option value="' + w.id + '">' + esc(w.label) + ' — by ' + w.closesAt + '</option>';
+    }).join('');
+    // Default new chores to the fallback window rather than the first option,
+    // so an untouched form matches what the API would assume anyway.
+    windowSel.value = windowCurrent || state.fallbackWindowId || '';
+  }
+
   var sel = document.getElementById('p-kid');
   var current = sel.value;
   var kidOptions = kidsOnly().map(function(k) {
@@ -3913,7 +3946,7 @@ function renderParent(person) {
               return '<div class="parent-list-row">'
                 + '<div class="parent-copy">'
                 + '<span class="parent-list-title">' + esc(t.title) + '</span>'
-                + '<div class="sub">' + howOften(t) + ' · ' + t.points + ' pts' + (t.dueBy ? ' · due ' + formatDue(t.dueBy) : '') + '</div>'
+                + '<div class="sub">' + howOften(t) + (t.cycle !== 'oneoff' ? ' · ' + windowLabel(choreWindow(t)) : '') + ' · ' + t.points + ' pts' + (t.dueBy ? ' · due ' + formatDue(t.dueBy) : '') + '</div>'
                 + '</div>'
                 + '<button class="btn ghost small" onclick="parentEditTask(\'' + t.id + '\')">Edit</button>'
                 + '<button class="btn red-ghost small" onclick="parentDeleteTask(\'' + t.id + '\')">Remove</button>'
@@ -4713,6 +4746,52 @@ var WEEKDAYS = [
   { value: 0, short: 'Sun' },
 ];
 
+// The household's windows arrive on state. A chore with no windowId reads as
+// the fallback window - same rule as the API, which is the one that enforces.
+function choreWindow(t) {
+  var windows = (state && state.windows) || [];
+  var id = t.windowId || (state && state.fallbackWindowId);
+  for (var i = 0; i < windows.length; i++) {
+    if (windows[i].id === id) return windows[i];
+  }
+  return windows.length ? windows[windows.length - 1] : null;
+}
+
+function windowLabel(w) {
+  if (!w) return '';
+  var mins = hhmmToMinutes(w.closesAt);
+  var h = Math.floor(mins / 60), m = mins % 60;
+  var ampm = h >= 12 ? 'pm' : 'am';
+  var h12 = h % 12 === 0 ? 12 : h % 12;
+  return 'closes ' + h12 + (m ? ':' + String(m).padStart(2, '0') : '') + ' ' + ampm;
+}
+
+function hhmmToMinutes(value) {
+  var parts = String(value || '').split(':');
+  return (Number(parts[0]) * 60) + Number(parts[1] || 0);
+}
+
+// The server decides. Its clock is the one that enforces the close, and a
+// phone set to a different timezone would otherwise display a different truth
+// than the API acts on.
+function isWindowShut(w) {
+  return !!(w && w.closed);
+}
+
+// The window facts a chore row needs, shared by the Home glance card and the
+// Missions lists so the two can never drift apart. Null for one-offs - they
+// carry their own dueBy mechanics.
+function choreWindowState(task, completion) {
+  if (!task || task.cycle === 'oneoff') return null;
+  var w = choreWindow(task);
+  if (!w) return null;
+  return {
+    missed: !completion && isWindowShut(w),
+    stake: windowLabel(w),
+    missedText: 'Missed — ' + String(w.label || '').toLowerCase() + ' window closed at ' + w.closesAt,
+  };
+}
+
 function dayShort(value) {
   var match = WEEKDAYS.find(function(d) { return d.value === value; });
   return match ? match.short : '';
@@ -4741,6 +4820,8 @@ function updateDueVisibility() {
   var cycle = document.getElementById('p-cycle').value;
   document.getElementById('p-due-wrap').classList.toggle('hidden', cycle !== 'oneoff');
   document.getElementById('p-days-wrap').classList.toggle('hidden', cycle !== 'weekly');
+  // One-offs carry their own due datetime; the window is for recurring chores.
+  document.getElementById('p-window-wrap').classList.toggle('hidden', cycle === 'oneoff');
 }
 
 async function parentAddTask() {
@@ -4756,6 +4837,7 @@ async function parentAddTask() {
     title,
     cycle,
     days,
+    windowId: cycle === 'oneoff' ? null : (document.getElementById('p-window').value || null),
     points: Number(document.getElementById('p-points').value) || 5,
     dueBy: cycle === 'oneoff' && dueInput ? new Date(dueInput).toISOString() : null,
   };
@@ -5113,6 +5195,18 @@ async function parentEditTask(taskId) {
   var kidIndex = Number(kidInput.trim()) - 1;
   var kid = kids[kidIndex];
   if (!kid) { toast('Choose a valid kid number.'); return; }
+  var windowId = null;
+  if (cycle !== 'oneoff') {
+    var windows = (state.windows || []);
+    var windowPrompt = 'Due by which window?\n'
+      + windows.map(function(w, index) { return (index + 1) + ') ' + w.label + ' — by ' + w.closesAt; }).join('  ');
+    var currentWindowIndex = windows.findIndex(function(w) { return w.id === (task.windowId || state.fallbackWindowId); });
+    var windowInput = prompt(windowPrompt, String((currentWindowIndex === -1 ? windows.length : currentWindowIndex + 1)));
+    if (windowInput === null) return;
+    var windowChoice = windows[Number(windowInput.trim()) - 1];
+    if (!windowChoice) { toast('Choose a window number.'); return; }
+    windowId = windowChoice.id;
+  }
   var days = null;
   if (cycle === 'weekly') {
     var daysPrompt = 'Which days? Numbers separated by commas.\n'
@@ -5150,6 +5244,7 @@ async function parentEditTask(taskId) {
     points,
     cycle,
     days,
+    windowId,
     kidId: kid.id,
     dueBy,
   });

--- a/tests/smoke/server.js
+++ b/tests/smoke/server.js
@@ -8,6 +8,21 @@
 // stubs the API at the network layer invents its own responses and sails
 // straight past that class of bug. Running the real handler against a real
 // (if temporary) store is what makes the test able to see it.
+// The window feature makes 'now' part of the app's behaviour: past 21:00
+// household time a daily chore is refused. Tests must not change meaning with
+// the hour CI happens to run at, so the harness pins the household timezone to
+// a fixed-offset zone chosen so that local time is around noon right now, with
+// the local date equal to the UTC date (the browser in CI runs UTC, and the
+// two ends of the app must agree on what day it is). Etc/GMT zones use
+// inverted signs: Etc/GMT-8 means UTC+8.
+{
+  const utcHour = new Date().getUTCHours();
+  const offset = Math.max(-12, Math.min(14, 12 - utcHour));
+  process.env.HOUSEHOLD_TIMEZONE = offset === 0
+    ? 'Etc/GMT'
+    : `Etc/GMT${offset > 0 ? '-' : '+'}${Math.abs(offset)}`;
+}
+
 const http = require('http');
 const fs = require('fs');
 const path = require('path');

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -793,6 +793,68 @@ test('a completion counts for its own day, not the whole week', async ({ page })
   expect(verdict.legacyWednesday, 'a chore with no named days keeps the weekly rule').toBe(true);
 });
 
+// Windows are what make the points real: submit before the close or they are
+// gone for the day. The server is the only clock - the harness pins household
+// time to ~noon, so 'morning' has always shut and 'evening' is always open,
+// whatever hour CI runs at.
+test('a chore states its window and stake, and a shut window reads as missed', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: 'Feed the fish', points: 2, cycle: 'daily', windowId: 'evening',
+    });
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: 'Make the bed', points: 3, cycle: 'daily', windowId: 'morning',
+    });
+  });
+  // The page fetched state before these chores existed; sign-in renders from
+  // that cache rather than refetching.
+  await page.reload();
+  await pickPerson(page, 'Toby');
+  // Daily chores render on the Home glance, fed by the calendar call - give it
+  // a beat rather than racing the fetch.
+
+  // Open window: the row names its stake and can be ticked.
+  const open = page.locator('.task', { hasText: 'Feed the fish' }).first();
+  await expect(open).toBeVisible();
+  await expect(open).toContainText(/closes 9\s?pm/i);
+  await expect(open.locator('.tick')).toBeEnabled();
+
+  // Shut window: greyed, says missed, tick disabled, points struck through.
+  const missed = page.locator('.task.missed', { hasText: 'Make the bed' }).first();
+  await expect(missed).toBeVisible();
+  await expect(missed).toContainText(/missed/i);
+  await expect(missed.locator('.tick')).toBeDisabled();
+});
+
+// The refusal is the API's, not just the row's - a stale page that still shows
+// a tick cannot sneak a completion past a shut window.
+test('a shut window refuses the completion at the API', async ({ page }) => {
+  const verdict = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'ollie', title: 'Sweep the step', points: 2, cycle: 'daily', windowId: 'morning',
+    });
+    const state = await post({ action: 'state' });
+    const task = state.tasks.find((t) => t.title === 'Sweep the step');
+    return post({ action: 'completeTask', taskId: task.id, personId: 'ollie', pin: '1234' });
+  });
+  expect(verdict.ok).toBe(false);
+  expect(verdict.windowClosed).toBe(true);
+  expect(verdict.error).toMatch(/window closed/i);
+});
+
 test('Parent HQ is headed by the parent, not a crown', async ({ page }) => {
   await pickPerson(page, 'Peter');
   const title = page.locator('#p-hq-title');


### PR DESCRIPTION
Phase 2 of the agreed plan. The rule this serves: **do it and submit it inside the window → points on approval. Window shuts with nothing submitted → no points.** No late award, no parent override — settled deliberately.

## API

- Three household windows — Morning 08:30, After school 18:00, Evening 21:00 — with per-household override on the household record. Defaults live in code rather than the seed, because `ensureSeeded()` never touches an existing household (the #88 trap).
- Chores carry `windowId`. **Absent means the evening window, not an exemption** — an undated chore has always meant "some time today", and the last window of the day is the honest reading.
- `completeTask` refuses a recurring chore whose window has shut, with `windowClosed: true` and a message naming the window and its close time. One-offs keep their own `dueBy` mechanics — folding the two together is a decision, not a default.
- `state` exposes the windows with a **server-computed** `closed` flag. The server is the only clock: a phone set to the wrong timezone must not be able to display a different truth than the thing that enforces.

## Frontend

- Allocate and edit pick a window ("Due by: Evening — by 21:00", defaulting to the fallback).
- Rows on Home and Missions read **"closes 9 pm"** while open. Once missed: greyed, ❌, points struck through, and the reason stated — still on the list, because a miss that vanishes overnight teaches nothing.
- Both renderers share one `choreWindowState()` helper so Home and Missions cannot drift apart.

## Tests — and what they caught

"Now" is part of behaviour now, which showed up immediately: the first CI-time run of the logic suite failed because it happened to execute at 21:30 Perth, when the evening window is legitimately shut. So:

- The logic harness and the smoke server **pin `HOUSEHOLD_TIMEZONE` to a fixed-offset zone reading ~noon** — morning has always shut, evening is always open, whatever hour CI runs. Deterministic, not time-of-day-flaky.
- The Perth-semantics tests moved to a **child process with the real timezone**, since the constant bakes in at require time.
- Refusal is tested via a household override of `closesAt: '00:00'` — shut at every moment of every day, no clock dependence at all.

New coverage: windows in state with closed flags; unknown window refused; open window completes; shut window refused at the API; legacy chores held to the fallback; both rendered states on the kid's Home.

**Found by the suite itself:** the first cut enforced in the API but left the Home glance card unaware — no stake shown, and a tick offered that the API would refuse. Both renderers now share the helper.

## Docs

New **Windows** section in `docs/design-system.md`, recording the no-reopen rule, the fallback reasoning, the server-is-the-clock rule, and the pinned-clock testing technique.

## Checks

API logic tests, `check-design.js`, `check-frontend.js`, smoke **63/63**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_