### PR TITLE
Misses are recorded: a shut window with nothing submitted becomes a fact

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -256,6 +256,7 @@ async function getState() {
       points: c.points || 0,
       date: c.date,
       status: c.status,
+      windowId: c.windowId || null,
       comment: c.comment || null,
       createdAt: c.createdAt,
       decidedAt: c.decidedAt || null,
@@ -1291,6 +1292,83 @@ async function cancelRedemption(req) {
   return getState();
 }
 
+// A miss is a record that the points were not earned. Nothing more: nothing is
+// deducted, no streak breaks - that was settled in #9, and points-not-earned
+// is already the consequence. What the record buys is the pattern ("bins:
+// missed 3 of the last 7") and a yesterday that starts from something instead
+// of blank. Without it the app knows what was done but never what should have
+// been, and every morning looks identical however the day before went.
+//
+// Misses live in the completions container as status: 'missed' rows rather
+// than a container of their own, so one stream holds everything that happened
+// to a chore. They carry the forfeited points for display; nothing counts
+// them - balances only ever sum approved rows.
+//
+// The sweep runs from the same 15-minute timer as due reminders. Idempotency
+// is the record's own id: miss-<taskId>-<date> is deterministic, so a second
+// sweep of the same window finds the create refused and moves on. That also
+// holds across restarts, which a "have I run today" flag would not.
+function choreDueToday(chore, dateStr) {
+  if (chore.cycle === 'daily') return true;
+  if (chore.cycle !== 'weekly') return false;
+  // The weekday of a local date, taken at UTC noon of that date so no
+  // timezone can shift it across midnight.
+  const weekday = new Date(`${dateStr}T12:00:00Z`).getUTCDay();
+  if (Array.isArray(chore.days) && chore.days.length) return chore.days.includes(weekday);
+  const anchor = new Date(`${chore.createdAt || dateStr}T12:00:00Z`);
+  return weekday === anchor.getUTCDay();
+}
+
+async function recordMisses(now = new Date()) {
+  const dateStr = todayStr(now);
+  const [chores, completions, windows] = await Promise.all([
+    queryHousehold('chores'),
+    queryHousehold('completions'),
+    getHouseholdWindows(),
+  ]);
+  const completionsContainer = container('completions');
+  const settledToday = new Set(
+    completions
+      .filter((c) => c.date === dateStr && c.taskId)
+      .map((c) => c.taskId)
+  );
+
+  let recorded = 0;
+  for (const chore of chores) {
+    if (chore.active === false) continue;
+    if (chore.cycle === 'oneoff') continue; // dueBy is its own mechanism
+    if (!choreDueToday(chore, dateStr)) continue;
+    const windowDef = resolveWindow(windows, chore.windowId);
+    if (!isWindowClosed(windowDef, now)) continue;
+    if (settledToday.has(chore.id)) continue; // submitted in time, any status
+
+    try {
+      await completionsContainer.items.create({
+        // Deterministic id = the idempotency. One miss per chore per day,
+        // however many sweeps run.
+        id: `miss-${chore.id}-${dateStr}`,
+        householdId: HOUSEHOLD_ID,
+        taskId: chore.id,
+        kidId: chore.kidId,
+        title: chore.title,
+        // The points that were on the table, for display. Never summed:
+        // balances only count approved rows.
+        points: Number(chore.points) || 0,
+        date: dateStr,
+        status: 'missed',
+        windowId: windowDef ? windowDef.id : null,
+        createdAt: now.toISOString(),
+      });
+      recorded += 1;
+    } catch (err) {
+      // 409 means this sweep already ran for this chore today. Anything else
+      // is real.
+      if (!err || err.code !== 409) throw err;
+    }
+  }
+  return { recorded };
+}
+
 async function sendDueReminders(now = new Date()) {
   await ensureSeeded();
   const [chores, completions, quietHours] = await Promise.all([
@@ -1580,7 +1658,12 @@ app.timer('choreDueReminder', {
     } catch (err) {
       context.error(err);
     }
+    try {
+      await recordMisses();
+    } catch (err) {
+      context.error(err);
+    }
   },
 });
 
-module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, resolveWindow };
+module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, recordMisses, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, resolveWindow };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -31,6 +31,14 @@ function mockContainer(name) {
   return {
     items: {
       create: async (doc) => {
+        // Real Cosmos refuses a duplicate id with 409; recordMisses leans on
+        // that for idempotency, so the mock must refuse too or the tests
+        // would pass against a store more forgiving than production.
+        if (map.has(doc.id)) {
+          const err = new Error('Entity with the specified id already exists');
+          err.code = 409;
+          throw err;
+        }
         map.set(doc.id, doc);
         return { resource: doc };
       },
@@ -1894,6 +1902,69 @@ async function main() {
   console.log('\u2713 legacy chores without a window are held to the fallback window');
 
   // Put the windows back for anything that runs after this.
+  household.windows = null;
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
+
+  // -------------------------------------------------------------------------
+  // Misses. A miss is a record that the points were not earned - nothing is
+  // deducted and nothing else happens, but the record is what lets yesterday
+  // start from something instead of blank.
+  const { recordMisses } = require('./src/functions/hero.js');
+
+  // Shut everything again so due-but-unsubmitted chores are sweepable.
+  household.windows = [
+    { id: 'morning', label: 'Morning', closesAt: '00:00' },
+    { id: 'afterschool', label: 'After school', closesAt: '00:00' },
+    { id: 'evening', label: 'Evening', closesAt: '00:00' },
+  ];
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
+
+  await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'toby',
+    title: 'Empty the dishwasher', points: 6, cycle: 'daily', windowId: 'evening',
+  });
+  const sweep1 = await recordMisses();
+  const missRows = (await ROUTES.state()).completions.filter((c) => c.status === 'missed');
+  const dishMiss = missRows.find((c) => c.title === 'Empty the dishwasher');
+  assert.ok(dishMiss, 'a due, unsubmitted chore in a shut window is recorded as missed');
+  assert.strictEqual(dishMiss.points, 6, 'the miss names the points that were on the table');
+  assert.strictEqual(dishMiss.windowId, 'evening', 'and which window shut on it');
+  console.log('\u2713 a shut window with nothing submitted becomes a recorded miss');
+
+  const sweep2 = await recordMisses();
+  const missCountAfter = (await ROUTES.state()).completions
+    .filter((c) => c.status === 'missed' && c.title === 'Empty the dishwasher').length;
+  assert.strictEqual(missCountAfter, 1, 'a second sweep records nothing new');
+  assert.strictEqual(sweep2.recorded, 0, 'and says so');
+  console.log('\u2713 the sweep is idempotent - one miss per chore per day, however often it runs');
+
+  // The 'Afternoon chore' was completed earlier while its window was open, so
+  // even though every window is shut now, it must not be marked missed.
+  const afternoonMissed = (await ROUTES.state()).completions
+    .some((c) => c.status === 'missed' && c.title === 'Afternoon chore');
+  assert.strictEqual(afternoonMissed, false, 'a chore submitted in time is never a miss');
+  console.log('\u2713 submitting in time keeps a chore off the miss list');
+
+  // A weekly chore not due today is not "missed" today.
+  const notToday = [(new Date(`${(await ROUTES.state()).today}T12:00:00Z`).getUTCDay() + 3) % 7];
+  await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'toby',
+    title: 'Wash the car', points: 8, cycle: 'weekly', days: notToday, windowId: 'evening',
+  });
+  await recordMisses();
+  const carMissed = (await ROUTES.state()).completions
+    .some((c) => c.status === 'missed' && c.title === 'Wash the car');
+  assert.strictEqual(carMissed, false, 'a weekly chore is only missable on its own days');
+  console.log('\u2713 a weekly chore is only missable on the days it is due');
+
+  // Balances never count a miss - the points named on the record stay unearned.
+  const tobyStats = (await ROUTES.state()).stats['toby'];
+  const approvedTotal = (await ROUTES.state()).completions
+    .filter((c) => c.kidId === 'toby' && c.status === 'approved')
+    .reduce((sum, c) => sum + (c.points || 0), 0);
+  assert.strictEqual(tobyStats.points, approvedTotal, 'points are the sum of approved rows and nothing else');
+  console.log('\u2713 a miss changes no balance - the only consequence is points not earned');
+
   household.windows = null;
   await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -343,6 +343,31 @@ Rules that must not drift:
   hour CI runs. A window of `closesAt: '00:00'` is shut at every moment of the
   day, which is the deterministic way to test refusal.
 
+### Misses — the record that points were not earned
+
+A miss is **a fact, not a punishment**. When a window shuts with nothing
+submitted, the 15-minute sweep writes a `status: 'missed'` row into the
+completions container — the forfeited points named on it for display, counted
+by nothing. Balances only ever sum `approved` rows; that invariant is tested.
+
+Mechanics that must hold:
+
+- **Idempotency is the record's own id**: `miss-<taskId>-<date>`. A second
+  sweep gets the 409 and moves on. This survives restarts, which a
+  "have I run today" flag would not. The in-memory test mocks refuse duplicate
+  ids for the same reason real Cosmos does — a mock more forgiving than
+  production would let this test pass while the mechanism was broken.
+- **Submitting in time — any status — keeps a chore off the miss list.**
+  Pending and even rejected completions count as "the kid acted".
+- **A weekly chore is only missable on the days it is due.**
+- **One-offs are excluded** — `dueBy` overdue display is its own mechanism.
+
+Where a miss shows: the kid's calendar (⛔, struck through, its own
+`.calendar-event.missed` class — same visual family as rejected, but a miss is
+nobody refusing anything), and Recent activity, worded as a fact with the
+points that were on the table: *"Missed — the window closed. 6 pts were up for
+grabs."*
+
 ### How often a chore repeats
 
 Three options, and the middle one is the interesting one:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -836,6 +836,14 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   background: var(--danger-wash);
   color: var(--danger);
 }
+/* A recorded miss - the window shut with nothing submitted. Same visual family
+   as rejected (something did not happen) but its own class: a miss is nobody
+   refusing anything. */
+.calendar-event.missed {
+  background: var(--danger-wash);
+  color: var(--danger);
+  text-decoration: line-through;
+}
 
 /* ─── Buttons ─────────────────────────────────────────────────────────── */
 .btn {
@@ -2448,6 +2456,7 @@ function statusIcon(status) {
   if (status === 'approved') return '✅';
   if (status === 'pending') return '⏳';
   if (status === 'rejected') return '❌';
+  if (status === 'missed') return '⛔';
   return '•';
 }
 
@@ -3817,7 +3826,7 @@ function renderRedemptions(kid) {
 function renderRecentActivity(kid) {
   var el = document.getElementById('k-activity');
   var decided = state.completions.filter(function(c) {
-    return c.kidId === kid.id && (c.status === 'approved' || c.status === 'rejected');
+    return c.kidId === kid.id && (c.status === 'approved' || c.status === 'rejected' || c.status === 'missed');
   }).sort(function(a, b) {
     return String(b.decidedAt || b.date || '').localeCompare(String(a.decidedAt || a.date || ''));
   }).slice(0, 5);
@@ -3830,11 +3839,16 @@ function renderRecentActivity(kid) {
     var title = task ? esc(task.title) : esc(c.taskTitle || 'Mission');
     var pts   = task ? task.points : (c.points || 0);
     var isApproved = c.status === 'approved';
+    var isMissed = c.status === 'missed';
     var cls  = isApproved ? 'done-approved' : 'done-rejected';
-    var icon = isApproved ? '✅' : '❌';
+    var icon = isApproved ? '✅' : (isMissed ? '⛔' : '❌');
+    // A miss is stated as a fact, not a telling-off. The points that were on
+    // the table are named because that IS the consequence - nothing else is.
     var sub  = isApproved
       ? 'Nice job! ✅ +' + pts + ' pts'
-      : '❌ Not quite — you can try again';
+      : (isMissed
+          ? 'Missed — the window closed. ' + pts + ' pts were up for grabs'
+          : '❌ Not quite — you can try again');
     var dateStr = c.decidedAt ? formatRewardDate(c.decidedAt) : (c.date || '');
     // The grown-up's note. Read-only on purpose: it is a message about a
     // decision already made, not the start of an argument.

--- a/tests/smoke/server.js
+++ b/tests/smoke/server.js
@@ -41,7 +41,18 @@ function mockContainer(name) {
   const map = getMap(name);
   return {
     items: {
-      create: async (doc) => { map.set(doc.id, doc); return { resource: doc }; },
+      create: async (doc) => {
+        // Real Cosmos refuses a duplicate id with 409; recordMisses leans on
+        // that for idempotency, so the mock must refuse too or the tests
+        // would pass against a store more forgiving than production.
+        if (map.has(doc.id)) {
+          const err = new Error('Entity with the specified id already exists');
+          err.code = 409;
+          throw err;
+        }
+        map.set(doc.id, doc);
+        return { resource: doc };
+      },
       upsert: async (doc) => { map.set(doc.id, doc); return { resource: doc }; },
       query: (q) => ({
         fetchAll: async () => {


### PR DESCRIPTION
Phase 3. Until now the app knew what was done but never what should have been — every morning looked identical however the day before went.

## What it does

The existing 15-minute timer now sweeps: any recurring chore **due today**, in a window that has **shut**, with **nothing submitted**, gets a `status: 'missed'` row in the completions container.

**A miss is a record, not a punishment** — settled in #9. It names the points that were on the table; nothing counts them. A test pins the invariant that balances are the sum of `approved` rows and nothing else.

## Mechanics

- **Idempotency is the record's own id** — `miss-<taskId>-<date>`. A second sweep gets Cosmos's 409 and moves on. Survives restarts, which a "have I run today" flag would not.
- **Submitting in time — any status, rejected included — keeps a chore off the miss list.** Acting counts.
- **A weekly chore is only missable on the days it is due.**
- **One-offs are excluded** — their `dueBy` overdue display is its own mechanism.

## A mock made honest

The in-memory test stores silently overwrote on duplicate id, where real Cosmos throws 409 — a store *more forgiving than production*, which would have let the idempotency test pass with the mechanism broken. Both mocks (logic harness and smoke server) now refuse duplicates the way Cosmos does. All pre-existing tests still pass under the stricter mock.

## Kid-facing

- The calendar shows a miss as ⛔ with its own `.calendar-event.missed` class — same visual family as rejected, deliberately not the same thing: a miss is nobody refusing anything.
- Recent activity words it as a fact, naming the stake: *"Missed — the window closed. 6 pts were up for grabs."*

## Checks

API logic tests (5 new), `check-design.js`, `check-frontend.js`, smoke 63/63.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_