### PR TITLE
The family view: yesterday joins today, and a miss is named everywhere

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -368,6 +368,28 @@ nobody refusing anything), and Recent activity, worded as a fact with the
 points that were on the table: *"Missed — the window closed. 6 pts were up for
 grabs."*
 
+### The family view
+
+Parent HQ's Approvals tab is the family's one screen, in this order: what's
+waiting on you, reward requests, **Today by kid**, **Yesterday**, today &
+this week, recently decided.
+
+- **Today by kid** counts misses as their own pill (`.pill.bad`, "2 missed")
+  alongside pending, and "All caught up" only appears when there are neither.
+  A row whose window shut on it is tagged **Missed** (`.tag.missed`), not
+  "Not started" — which would understate a door that has already closed.
+- **Yesterday** renders per kid from the completion records alone: done,
+  sent back, missed, each with the points that were at stake. This panel is
+  what the whole windows-and-misses build exists to feed — until misses were
+  recorded there was nothing truthful it could have said. Yesterday's date is
+  derived from `state.today` (the API's local day), minus one day at UTC
+  noon, so no timezone can shift it.
+
+Smoke-testing note: the suite's store is shared across the whole run, so a
+test that seeds chores for a kid must retire them (`deleteTask`) before
+finishing if a later test's premise is "this kid has nothing on". This has
+now bitten twice; clean up seeded chores as part of the test that made them.
+
 ### Nudges and the evening summary
 
 Two messages a day, maximum, per person - the design is a digest, not a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -560,6 +560,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 .day-chip:has(input:focus-visible) { outline: 2px solid var(--brand); outline-offset: 2px; }
 
 .pill.warn    { background: var(--warning-wash); color: var(--warning); }
+.pill.bad     { background: var(--danger-wash); color: var(--danger); }
 
 /* The kid's own face on their card, rather than their name doing all the work. */
 .parent-kid-line { display: flex; align-items: center; gap: var(--space-3); }
@@ -1108,6 +1109,7 @@ button.parent-list-row:active { transform: scale(0.99); }
 .tag.waiting { background: var(--warning-wash); color: var(--warning); }
 .tag.not-started { background: var(--brand-wash); color: var(--brand); }
 .tag.rejected { background: var(--danger-wash); color: var(--danger); }
+.tag.missed { background: var(--danger-wash); color: var(--danger); }
 .check-row {
   display: flex;
   align-items: center;
@@ -1675,6 +1677,10 @@ button.parent-list-row:active { transform: scale(0.99); }
       <section class="parent-section">
         <h2 class="parent-section-title">Today, by kid</h2>
         <div id="p-approvals-today-by-kid"></div>
+      </section>
+      <section class="parent-section">
+        <h2 class="parent-section-title">Yesterday</h2>
+        <div id="p-yesterday"></div>
       </section>
       <section class="parent-section">
         <h2 class="parent-section-title">Today &amp; this week</h2>
@@ -2868,7 +2874,17 @@ function parentCalendarLiveCompletion(item) {
 
 function parentCalendarOverviewStatus(item) {
   var completion = parentCalendarLiveCompletion(item);
-  if (!completion) return { className: 'not-started', label: 'Not started' };
+  if (!completion) {
+    // No live completion. If the sweep has recorded a miss for this chore on
+    // this day, that IS the status - "Not started" would understate a window
+    // that has already shut on it.
+    var dayKey = parentCalendarDayKey(item);
+    var missedRow = item.taskId && dayKey && (state.completions || []).some(function(c) {
+      return c.taskId === item.taskId && c.date === dayKey && c.status === 'missed';
+    });
+    if (missedRow) return { className: 'missed', label: 'Missed' };
+    return { className: 'not-started', label: 'Not started' };
+  }
   if (completion.status === 'approved') return { className: 'approved', label: 'Done' };
   return { className: 'waiting', label: 'Waiting on you' };
 }
@@ -2924,6 +2940,62 @@ function renderParentApprovalsGlance() {
     + '</div>';
 }
 
+// Yesterday, per kid: done and missed, from the completion records alone.
+// This is the panel the whole windows-and-misses build exists to feed - until
+// misses were recorded, every morning looked identical however the day before
+// went, and there was nothing truthful this panel could have said.
+function renderParentYesterday() {
+  var el = document.getElementById('p-yesterday');
+  if (!el) return;
+  // The API's own idea of today, minus one day at UTC noon so no timezone can
+  // shift it across midnight. Falls back to the browser only if state is old
+  // enough to predate the field.
+  var todayKey = (state && state.today) || todayStr();
+  var yesterdayKey = new Date(new Date(todayKey + 'T12:00:00Z').getTime() - 86400000)
+    .toISOString().slice(0, 10);
+  var rows = (state.completions || []).filter(function(c) {
+    return c.date === yesterdayKey && c.taskId;
+  });
+  if (rows.length === 0) {
+    el.innerHTML = buildEmptyPill('Nothing recorded yesterday');
+    return;
+  }
+  var kids = kidsOnly();
+  el.innerHTML = kids.map(function(kid) {
+    var mine = rows.filter(function(c) { return c.kidId === kid.id; });
+    if (mine.length === 0) return '';
+    var done = mine.filter(function(c) { return c.status === 'approved' || c.status === 'pending' || c.status === 'queued'; }).length;
+    var missed = mine.filter(function(c) { return c.status === 'missed'; }).length;
+    var pills = (done > 0 ? '<span class="pill good">' + done + ' done</span>' : '')
+      + (missed > 0 ? '<span class="pill bad">' + missed + ' missed</span>' : '');
+    return '<div class="card parent-card">'
+      + '<div class="parent-item-head">'
+      + '<div class="parent-copy parent-kid-line">'
+      + '<span class="parent-kid-face">' + renderAvatarHtml(kid.emoji, 'var(--brand)', 'head') + '</span>'
+      + '<strong>' + esc(kid.name) + '</strong>'
+      + '</div>'
+      + '<div class="pill-row">' + pills + '</div>'
+      + '</div>'
+      + '<div class="parent-list">' + mine.map(function(c) {
+          var tag = c.status === 'missed'
+            ? { className: 'missed', label: 'Missed' }
+            : c.status === 'approved'
+              ? { className: 'approved', label: 'Done' }
+              : c.status === 'rejected'
+                ? { className: 'rejected', label: 'Sent back' }
+                : { className: 'waiting', label: 'Waiting on you' };
+          return '<div class="parent-list-row">'
+            + '<div class="parent-copy">'
+            + '<span class="parent-list-title">' + esc(c.title || 'Untitled') + '</span>'
+            + (c.points ? '<div class="sub">' + c.points + ' pts</div>' : '')
+            + '</div>'
+            + '<span class="tag ' + tag.className + '">' + tag.label + '</span>'
+            + '</div>';
+        }).join('') + '</div>'
+      + '</div>';
+  }).join('') || buildEmptyPill('Nothing recorded yesterday');
+}
+
 function renderParentApprovalsTodayByKid() {
   var el = document.getElementById('p-approvals-today-by-kid');
   if (!el) return;
@@ -2942,14 +3014,15 @@ function renderParentApprovalsTodayByKid() {
     // Status as pills, not paragraphs. 'Today's chores overview' under every
     // name said nothing the heading had not already said, and a kid with
     // nothing on got a five-line empty state to report zero.
-    var waiting = todayItems.filter(function(item) {
-      return parentCalendarOverviewStatus(item).className === 'waiting';
-    }).length;
+    var statuses = todayItems.map(function(item) { return parentCalendarOverviewStatus(item).className; });
+    var waiting = statuses.filter(function(name) { return name === 'waiting'; }).length;
+    var missedCount = statuses.filter(function(name) { return name === 'missed'; }).length;
     var pills = '<span class="pill neutral">' + todayItems.length + ' chore'
       + (todayItems.length === 1 ? '' : 's') + '</span>'
+      + (missedCount > 0 ? '<span class="pill bad">' + missedCount + ' missed</span>' : '')
       + (waiting > 0
           ? '<span class="pill warn">' + waiting + ' pending</span>'
-          : '<span class="pill good">All caught up</span>');
+          : (missedCount === 0 ? '<span class="pill good">All caught up</span>' : ''));
 
     return '<div class="card parent-card">'
       + '<div class="parent-item-head">'
@@ -3004,6 +3077,7 @@ function jumpToApproval(completionId) {
 function renderParentApprovalsSummary() {
   renderParentApprovalsGlance();
   renderParentApprovalsTodayByKid();
+  renderParentYesterday();
 }
 
 function renderParentCalendarChecklists(item) {

--- a/tests/smoke/server.js
+++ b/tests/smoke/server.js
@@ -96,7 +96,14 @@ process.env.VAPID_PUBLIC_KEY = 'smoke-public';
 process.env.VAPID_PRIVATE_KEY = 'smoke-private';
 
 const { ensureSeeded } = require(path.join(API_ROOT, 'src/lib/seed.js'));
-const { ROUTES } = require(path.join(API_ROOT, 'src/functions/hero.js'));
+const { ROUTES, recordMisses } = require(path.join(API_ROOT, 'src/functions/hero.js'));
+
+// Harness-only: in production the miss sweep runs from the Azure timer, which
+// this server does not have. Tests that need "the sweep has run" trigger it
+// here explicitly. Never added to the real ROUTES table.
+const HARNESS_ROUTES = {
+  __sweepMisses: () => recordMisses(),
+};
 
 // ---------------------------------------------------------------------------
 // HTTP
@@ -123,7 +130,7 @@ const server = http.createServer(async (req, res) => {
       try { payload = JSON.parse(body || '{}'); } catch (e) { payload = {}; }
       try {
         await ensureSeeded();
-        const fn = ROUTES[payload.action || 'state'];
+        const fn = HARNESS_ROUTES[payload.action] || ROUTES[payload.action || 'state'];
         if (!fn) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           return res.end(JSON.stringify({ ok: false, error: 'Unknown action' }));

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -848,11 +848,84 @@ test('a shut window refuses the completion at the API', async ({ page }) => {
     });
     const state = await post({ action: 'state' });
     const task = state.tasks.find((t) => t.title === 'Sweep the step');
-    return post({ action: 'completeTask', taskId: task.id, personId: 'ollie', pin: '1234' });
+    const refusal = await post({ action: 'completeTask', taskId: task.id, personId: 'ollie', pin: '1234' });
+    // Retire the chore: the store is shared across the run, and a later
+    // test's premise is that Ollie has nothing on today.
+    await post({ action: 'deleteTask', taskId: task.id, parentId: 'peter', parentPin: '1234' });
+    return refusal;
   });
   expect(verdict.ok).toBe(false);
   expect(verdict.windowClosed).toBe(true);
   expect(verdict.error).toMatch(/window closed/i);
+});
+
+// The family view: yesterday, per kid, from the recorded facts. Until misses
+// were recorded there was nothing truthful this panel could have said - every
+// morning looked identical however the day before went. Yesterday-dated rows
+// cannot be created through the real routes (the API stamps today), so this
+// drives the real renderer over planted records - the same lexical `state`
+// the page itself renders from.
+test('yesterday shows each kid\u2019s done and missed, from the records', async ({ page }) => {
+  await pickPerson(page, 'Peter');
+  await page.evaluate(() => {
+    const y = new Date(new Date(state.today + 'T12:00:00Z').getTime() - 86400000)
+      .toISOString().slice(0, 10);
+    state.completions.push(
+      { id: 'y1', taskId: 't-veg', kidId: 'toby', title: 'Water the veggies', points: 3, date: y, status: 'approved' },
+      { id: 'y2', taskId: 't-bins', kidId: 'toby', title: 'Bins out', points: 5, date: y, status: 'missed' },
+    );
+    renderParentYesterday();
+  });
+
+  const tobyCard = page.locator('#p-yesterday .parent-card', { hasText: 'Toby' });
+  await expect(tobyCard).toBeVisible();
+  await expect(tobyCard.locator('.pill.good')).toContainText('1 done');
+  await expect(tobyCard.locator('.pill.bad')).toContainText('1 missed');
+  await expect(tobyCard.locator('.parent-list-row', { hasText: 'Bins out' }).locator('.tag.missed'))
+    .toContainText(/missed/i);
+  await expect(tobyCard.locator('.parent-list-row', { hasText: 'Water the veggies' }).locator('.tag.approved'))
+    .toContainText(/done/i);
+});
+
+// A miss reaches the parent's Today view as a pill and a tag, not silence.
+test('a missed chore shows on the parent\u2019s today view', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    // A chore in the morning window (shut - the harness pins ~noon), then the
+    // sweep. This drives the real recordMisses through the real store.
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'ollie', title: 'Feed the chickens', points: 4, cycle: 'daily', windowId: 'morning',
+    });
+    await post({ action: '__sweepMisses' });
+  });
+
+  // The page fetched state before the chore and the sweep existed.
+  await page.reload();
+  await pickPerson(page, 'Peter');
+  const ollieCard = page.locator('#p-approvals-today-by-kid .parent-card', { hasText: 'Ollie' });
+  await expect(ollieCard).toBeVisible();
+  await expect(ollieCard.locator('.pill.bad')).toContainText(/missed/i);
+  const row = ollieCard.locator('.parent-list-row', { hasText: 'Feed the chickens' });
+  await expect(row.locator('.tag.missed')).toContainText(/missed/i);
+
+  // The store is shared across the whole run, and a later test's premise is
+  // that Ollie has nothing on. Retire the chore (the miss row it left is
+  // dated today and counted from calendar items, so it goes quiet with it).
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const fresh = await post({ action: 'state' });
+    const chore = fresh.tasks.find((t) => t.title === 'Feed the chickens');
+    if (chore) await post({ action: 'deleteTask', taskId: chore.id, parentId: 'peter', parentPin: '1234' });
+  });
 });
 
 test('Parent HQ is headed by the parent, not a crown', async ({ page }) => {


### PR DESCRIPTION
Phase 5 — the last phase of the agreed plan before #41 gets its own run.

## What changed

Parent HQ's Approvals tab becomes the family's one screen, in order: what's waiting on you, reward requests, **Today by kid**, **Yesterday** (new), today & this week, recently decided.

- **Today by kid** now counts misses as their own pill (*"1 missed"*, danger-coloured) alongside pending, and *"All caught up"* only appears when there is neither. A chore whose window shut on it is tagged **Missed** rather than *"Not started"* — which would understate a door that has already closed.
- **Yesterday** renders per kid from the completion records alone: done, sent back, missed — each row with the points that were at stake. This panel is what the whole windows-and-misses build exists to feed; until misses were recorded there was nothing truthful it could have said.
- Yesterday's date derives from `state.today` — the API's local day — minus one day at UTC noon, so no browser timezone can shift it.

## Harness

The smoke server gains a **harness-only** `__sweepMisses` action so a test can run the real sweep against the real store. It lives in the server's own route table, never in the production `ROUTES`.

## Two test lessons paid for here, both documented

1. A first draft of the yesterday test asserted only *"panel not empty"* — which the empty-state pill satisfies. Vacuous. It now plants yesterday-dated records and asserts the exact pills and per-row tags.
2. **Seeded chores must be retired by the test that made them.** The suite's store is shared across the run, and Ollie's leftover chores broke a later test whose premise is "this kid has nothing on". Second time this class of order-dependence has bitten; the rule is now in `docs/design-system.md`.

## Checks

API logic tests, `check-design.js`, `check-frontend.js`, smoke **65/65 — run twice** to shake out order-dependence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_