### PR TITLE
Prep lists: packed the night before, worth points — the soccer case

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -337,7 +337,12 @@ async function validatePrepLists(prepLists) {
       if (!text) return { ok: false, error: 'prepLists item text is required' };
       items.push({ text, done: !!(item && item.done) });
     }
-    normalized.push({ personId: personCheck.personId, items });
+    let points = 0;
+    if (list.points !== undefined && list.points !== null && list.points !== '') {
+      points = Number(list.points);
+      if (!Number.isInteger(points) || points < 0) return { ok: false, error: 'prepLists points must be a whole number' };
+    }
+    normalized.push({ personId: personCheck.personId, items, points });
   }
   return { ok: true, prepLists: normalized };
 }
@@ -752,6 +757,97 @@ async function getConflictsForItem(item) {
   const conflicts = findConflicts(candidate, schedule);
   const suggestedTimes = conflicts.length > 0 ? suggestAlternateSlots(candidate, schedule) : [];
   return { conflicts, suggestedTimes };
+}
+
+// When prep for an event is due: the close of the LAST window on the day
+// before the event - "packed for Sunday soccer by Saturday 9pm". Being ready
+// the night before is the thing being rewarded, which is why the deadline is
+// not the event's own morning. A per-event override (prepDueBy, ISO) wins
+// when set.
+async function prepDeadlinePassed(item, now = new Date()) {
+  if (item.prepDueBy) {
+    const override = new Date(item.prepDueBy);
+    if (!Number.isNaN(override.getTime())) return now.getTime() >= override.getTime();
+  }
+  const eventDate = todayStr(new Date(item.startAt));
+  const nowDate = todayStr(now);
+  if (nowDate > eventDate) return true;    // the event day is over
+  if (nowDate === eventDate) return true;  // the night before has passed
+  // Some earlier day. Only the day immediately before can close it.
+  const dayBefore = new Date(new Date(`${eventDate}T12:00:00Z`).getTime() - 86400000)
+    .toISOString().slice(0, 10);
+  if (nowDate !== dayBefore) return false;
+  const windows = await getHouseholdWindows();
+  const lastClose = Math.max(...windows
+    .filter((w) => HHMM_RE.test(w.closesAt || ''))
+    .map((w) => hhmmToMinutes(w.closesAt)));
+  return Number.isFinite(lastClose) && localMinutes(now) >= lastClose;
+}
+
+// A kid ticking one item on their own prep list. requireSelf plus a check the
+// list is actually theirs - the parent-only updatePlanningItem stays the only
+// way to touch anyone else's.
+async function tickPrepItem(req) {
+  const personId = String(req.personId || '').trim();
+  await requireSelf(personId, req.pin, personId);
+  const planningItems = container('planningItems');
+  const { resource: item } = await planningItems
+    .item(req.planningItemId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!item || item.active === false) return { ok: false, error: 'Not found' };
+  const list = (item.prepLists || []).find((l) => l.personId === personId);
+  if (!list) return { ok: false, error: 'Not your list' };
+  const index = Number(req.itemIndex);
+  if (!Number.isInteger(index) || index < 0 || index >= list.items.length) {
+    return { ok: false, error: 'No such item' };
+  }
+  if (await prepDeadlinePassed(item)) {
+    return { ok: false, error: 'Too late — packing closed the night before.', windowClosed: true };
+  }
+  list.items[index].done = !!req.done;
+  await planningItems.item(req.planningItemId, HOUSEHOLD_ID).replace(item);
+  return { ok: true, item };
+}
+
+// Everything ticked and the kid says "packed". Creates a pending completion -
+// the same shape as any chore, so the parent's approval flow needs nothing
+// new. Idempotent by id, like a miss.
+async function confirmPrep(req) {
+  const personId = String(req.personId || '').trim();
+  await requireSelf(personId, req.pin, personId);
+  const planningItems = container('planningItems');
+  const { resource: item } = await planningItems
+    .item(req.planningItemId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!item || item.active === false) return { ok: false, error: 'Not found' };
+  const list = (item.prepLists || []).find((l) => l.personId === personId);
+  if (!list) return { ok: false, error: 'Not your list' };
+  if (!list.items.length || !list.items.every((entry) => entry.done)) {
+    return { ok: false, error: 'Tick everything off first.' };
+  }
+  if (await prepDeadlinePassed(item)) {
+    return { ok: false, error: 'Too late — packing closed the night before.', windowClosed: true };
+  }
+  try {
+    await container('completions').items.create({
+      id: `prep-${item.id}-${personId}`,
+      householdId: HOUSEHOLD_ID,
+      taskId: '',
+      planningItemId: item.id,
+      kidId: personId,
+      title: `Packed for ${item.title}`,
+      points: Number(list.points) || 0,
+      date: todayStr(),
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    if (!err || err.code !== 409) throw err;
+    // Already confirmed - not an error worth showing a kid.
+  }
+  return getState();
 }
 
 async function addPlanningItem(req) {
@@ -1366,6 +1462,39 @@ async function recordMisses(now = new Date()) {
       if (!err || err.code !== 409) throw err;
     }
   }
+
+  // Prep lists miss by the same rule they earn: the night before closed with
+  // no confirmation. Only for events still ahead (or today) - the sweep must
+  // not backfill history for events that predate the feature.
+  const planningItems = await queryHousehold('planningItems');
+  for (const item of planningItems) {
+    if (item.active === false || item.type !== 'event') continue;
+    const eventDate = todayStr(new Date(item.startAt));
+    if (eventDate < dateStr) continue;
+    if (!(await prepDeadlinePassed(item, now))) continue;
+    for (const list of item.prepLists || []) {
+      if (!list.items || !list.items.length) continue;
+      const confirmed = completions.some((c) => c.id === `prep-${item.id}-${list.personId}`);
+      if (confirmed) continue;
+      try {
+        await completionsContainer.items.create({
+          id: `prep-miss-${item.id}-${list.personId}`,
+          householdId: HOUSEHOLD_ID,
+          taskId: '',
+          planningItemId: item.id,
+          kidId: list.personId,
+          title: `Packed for ${item.title}`,
+          points: Number(list.points) || 0,
+          date: dateStr,
+          status: 'missed',
+          createdAt: now.toISOString(),
+        });
+        recorded += 1;
+      } catch (err) {
+        if (!err || err.code !== 409) throw err;
+      }
+    }
+  }
   return { recorded };
 }
 
@@ -1735,6 +1864,8 @@ const ROUTES = {
   deleteMyItem,
   reorderMyItems,
   reorderTasks,
+  tickPrepItem,
+  confirmPrep,
 };
 
 app.http('hero', {

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2023,6 +2023,87 @@ async function main() {
   assert.strictEqual(repeat.sent, 0, 'one summary per day, however many ticks follow');
   console.log('\u2713 parents get one evening summary counting done and missed, once');
 
+  // -------------------------------------------------------------------------
+  // Prep lists: the soccer case. The list carries the points; the deadline is
+  // the last window's close on the night BEFORE the event; miss it and the
+  // points are gone but the event stays.
+  const { ROUTES: R } = require('./src/functions/hero.js');
+
+  // Sunday soccer: two local days ahead, so tonight is not yet the night
+  // before and nothing can close it.
+  const inTwoDays = new Date(at('09:00').getTime() + 2 * 86400000);
+  const soccerEvent = await R.addPlanningItem({
+    parentId: 'peter', parentPin: '1234',
+    type: 'event', title: 'Soccer', personId: 'ollie',
+    startAt: inTwoDays.toISOString(),
+    prepLists: [{ personId: 'ollie', points: 10, items: [
+      { text: 'boots' }, { text: 'water bottle' },
+    ] }],
+  });
+  assert.strictEqual(soccerEvent.ok, true, 'the event with a prep list saves');
+  assert.strictEqual(soccerEvent.item.prepLists[0].points, 10, 'the list carries its points');
+
+  // Another kid cannot touch Ollie's list.
+  const wrongKid = await R.tickPrepItem({
+    personId: 'toby', pin: '1234', planningItemId: soccerEvent.item.id, itemIndex: 0, done: true,
+  });
+  assert.strictEqual(wrongKid.ok, false, "someone else's list is refused");
+  console.log('\u2713 a prep list can only be ticked by its own kid');
+
+  // Confirm before everything is ticked: refused.
+  const tooSoon = await R.confirmPrep({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id });
+  assert.strictEqual(tooSoon.ok, false, 'confirm with unticked items is refused');
+
+  await R.tickPrepItem({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id, itemIndex: 0, done: true });
+  await R.tickPrepItem({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id, itemIndex: 1, done: true });
+  const packed = await R.confirmPrep({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id });
+  assert.strictEqual(packed.ok, true, 'everything ticked, in time: confirmed');
+  const prepRow = packed.completions.find((c) => c.id === `prep-${soccerEvent.item.id}-ollie`);
+  assert.ok(prepRow, 'the confirmation is a completion row');
+  assert.strictEqual(prepRow.status, 'pending', 'pending a parent, like any chore');
+  assert.strictEqual(prepRow.points, 10, "carrying the list's points");
+  assert.ok(prepRow.title.includes('Soccer'), 'and naming the event');
+  console.log('\u2713 ticked, confirmed in time: a pending completion worth the list points');
+
+  const twice = await R.confirmPrep({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id });
+  assert.strictEqual(twice.ok, true, 'a second confirm is quietly idempotent');
+  const prepRows = twice.completions.filter((c) => c.id === `prep-${soccerEvent.item.id}-ollie`);
+  assert.strictEqual(prepRows.length, 1, 'and creates nothing new');
+  console.log('\u2713 confirming twice cannot double the reward');
+
+  // The night before, after the last window: too late to tick or confirm,
+  // and the sweep records the miss. Event TOMORROW, "now" tonight at 21:30.
+  const prepTomorrow = new Date(at('09:00').getTime() + 86400000);
+  const camp = await R.addPlanningItem({
+    parentId: 'peter', parentPin: '1234',
+    type: 'event', title: 'Cub camp', personId: 'toby',
+    startAt: prepTomorrow.toISOString(),
+    prepLists: [{ personId: 'toby', points: 12, items: [{ text: 'sleeping bag' }, { text: 'torch' }] }],
+  });
+  const prepLateNow = at('21:30');
+  const prepLateTick = await R.tickPrepItem({
+    personId: 'toby', pin: '1234', planningItemId: camp.item.id, itemIndex: 0, done: true,
+  });
+  // tickPrepItem reads the real clock; at pinned ~noon the night-before close
+  // has not passed, so ticking works - the DEADLINE math is what needs the
+  // fixed instant, via recordMisses(prepLateNow).
+  assert.strictEqual(prepLateTick.ok, true, 'at pinned noon the list is still open');
+  await recordMisses(prepLateNow);
+  const campMiss = (await R.state()).completions.find((c) => c.id === `prep-miss-${camp.item.id}-toby`);
+  assert.ok(campMiss, 'an unconfirmed list is missed once the night before closes');
+  assert.strictEqual(campMiss.points, 12, 'naming the points that were on the table');
+  await recordMisses(prepLateNow);
+  const campMisses = (await R.state()).completions.filter((c) => c.id === `prep-miss-${camp.item.id}-toby`);
+  assert.strictEqual(campMisses.length, 1, 'and only once');
+  console.log('\u2713 an unconfirmed prep list is missed when the night before closes, once');
+
+  // The confirmed one is never missed, even after its deadline.
+  await recordMisses(new Date(inTwoDays.getTime() - 3 * 3600000));
+  const soccerMissed = (await R.state()).completions
+    .some((c) => c.id === `prep-miss-${soccerEvent.item.id}-ollie`);
+  assert.strictEqual(soccerMissed, false, 'a confirmed list is never swept as missed');
+  console.log('\u2713 confirming in time keeps the list off the miss sweep');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -390,6 +390,31 @@ test that seeds chores for a kid must retire them (`deleteTask`) before
 finishing if a later test's premise is "this kid has nothing on". This has
 now bitten twice; clean up seeded chores as part of the test that made them.
 
+### Prep lists — packed the night before, worth points
+
+The soccer case: Ollie plays Sunday morning, so **being ready by Saturday
+night is the thing rewarded** — not attending. The rules, all settled:
+
+- **The list carries the points; the event carries none.** `prepLists`
+  entries hold `points`, settable from the parent calendar checklist ("Set
+  pts"). `planningUpdatePayload` round-trips them — dropping the field there
+  would silently zero a list's reward on every unrelated edit.
+- **The deadline is the last window's close on the day before the event**
+  (`prepDeadlinePassed`), with an optional per-event `prepDueBy` ISO override
+  winning when set. After it: ticking and confirming are refused with
+  `windowClosed: true`, and the sweep records `prep-miss-<itemId>-<kidId>`.
+- **A kid ticks only their own list** — `tickPrepItem` is `requireSelf` plus
+  a personId match; the parent-only `updatePlanningItem` remains the only way
+  to touch anyone else's.
+- **Confirming creates an ordinary pending completion**
+  (`prep-<itemId>-<kidId>`, deterministic so a double-tap cannot double the
+  reward) titled "Packed for <event>" and worth the list's points — the
+  parent's existing approval flow needs nothing new.
+- The kid's Home glance renders the checklist with live ticks and a Packed
+  button that unlocks only when everything is ticked. (The original render
+  looked the list up as `prepLists[kidId]` when it is an array of
+  `{personId, items}` — that 🎒 line had never once run.)
+
 ### Nudges and the evening summary
 
 Two messages a day, maximum, per person - the design is a digest, not a

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1231,10 +1231,29 @@ button.parent-list-row:active { transform: scale(0.99); }
   margin: var(--space-3) 0 var(--space-2);
 }
 .glance-prep {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
   font-size: var(--text-sm);
-  color: var(--ink-muted);
+}
+.prep-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+.prep-item.done span { text-decoration: line-through; color: var(--ink-muted); }
+.prep-item.locked { cursor: default; }
+.prep-item input { accent-color: var(--brand); width: 1.1rem; height: 1.1rem; }
+.prep-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
   margin-top: var(--space-1);
 }
+.prep-missed { color: var(--danger); font-weight: var(--weight-medium); }
 /* My List - a kid's own notes, plans and reminders. */
 .mylist-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -2536,15 +2555,50 @@ function glanceChoreCard(item) {
     + '</div>';
 }
 
-// Events and reminders are not actionable by a kid - creating and editing them
-// stays parent-only - so these render as a plain card with no tick.
+// The event itself stays read-only for a kid - creating and editing is
+// parent-only - but their OWN prep list on it is theirs to tick. The list
+// carries the points and closes the night before: being ready is what is
+// being rewarded, not attending.
+//
+// (The original version of this looked the list up as prepLists[kidId], but
+// prepLists is an array of {personId, items} - so the 🎒 line had never once
+// rendered. Found while designing #41, which imports lists into exactly this
+// spot.)
 function glanceEventCard(item, kidId) {
   var when = item.allDay
     ? 'All day'
     : (item.startAt ? new Date(item.startAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : '');
+  var list = (item.prepLists || []).find(function(l) { return l.personId === kidId; });
   var prep = '';
-  if (item.prepLists && item.prepLists[kidId] && item.prepLists[kidId].length) {
-    prep = '<div class="glance-prep">🎒 ' + item.prepLists[kidId].map(esc).join(', ') + '</div>';
+  if (list && list.items && list.items.length) {
+    var confirmed = (state.completions || []).some(function(c) {
+      return c.id === 'prep-' + item.id + '-' + kidId;
+    });
+    var missed = (state.completions || []).some(function(c) {
+      return c.id === 'prep-miss-' + item.id + '-' + kidId;
+    });
+    var allTicked = list.items.every(function(entry) { return entry.done; });
+    var rows = list.items.map(function(entry, index) {
+      return '<label class="prep-item' + (entry.done ? ' done' : '') + (missed || confirmed ? ' locked' : '') + '">'
+        + '<input type="checkbox"' + (entry.done ? ' checked' : '') + (missed || confirmed ? ' disabled' : '')
+        + ' onchange="tickPrep(\'' + jsq(item.id) + '\', ' + index + ', this.checked)">'
+        + '<span>' + esc(entry.text) + '</span>'
+        + '</label>';
+    }).join('');
+    var footer;
+    if (confirmed) {
+      footer = '<div class="sub">Packed and confirmed ✅' + (list.points ? ' · ' + list.points + ' pts pending' : '') + '</div>';
+    } else if (missed) {
+      footer = '<div class="sub prep-missed">Missed — packing closed the night before'
+        + (list.points ? ' · ' + list.points + ' pts were up for grabs' : '') + '</div>';
+    } else {
+      footer = '<div class="prep-footer">'
+        + '<span class="sub">Pack by the night before' + (list.points ? ' · ' + list.points + ' pts' : '') + '</span>'
+        + '<button class="btn small" ' + (allTicked ? '' : 'disabled ')
+        + 'onclick="confirmPrepPacked(\'' + jsq(item.id) + '\')">Packed ✔</button>'
+        + '</div>';
+    }
+    prep = '<div class="glance-prep">🎒 ' + rows + footer + '</div>';
   }
   return '<div class="task">'
     + '<button class="tick" disabled>' + (item.kind === 'reminder' ? '🔔' : '📌') + '</button>'
@@ -2555,6 +2609,34 @@ function glanceEventCard(item, kidId) {
     + prep
     + '</div>'
     + '</div>';
+}
+
+async function tickPrep(planningItemId, itemIndex, done) {
+  var result = await api({
+    action: 'tickPrepItem',
+    personId: session.personId, pin: session.pin,
+    planningItemId: planningItemId, itemIndex: itemIndex, done: done,
+  });
+  if (toastApiError(result)) { await refresh(); return; }
+  // Update the local copy so the confirm button's enabled state follows the
+  // tick without a refetch round-trip.
+  (kidCalendarItems || []).forEach(function(item) {
+    if (item.id !== planningItemId) return;
+    var list = (item.prepLists || []).find(function(l) { return l.personId === session.personId; });
+    if (list && list.items[itemIndex]) list.items[itemIndex].done = done;
+  });
+  var kid = state.people.find(function(person) { return person.id === session.personId; });
+  if (kid) renderKidGlance(kid);
+}
+
+async function confirmPrepPacked(planningItemId) {
+  var result = await api({
+    action: 'confirmPrep',
+    personId: session.personId, pin: session.pin,
+    planningItemId: planningItemId,
+  });
+  if (toastApiError(result)) return;
+  toast('Packed! Waiting for a grown-up to check 🎒');
 }
 
 function glanceCard(item, kidId) {
@@ -3095,7 +3177,9 @@ function renderParentCalendarChecklists(item) {
         + '</label>';
     }).join('') || '<div class="sub">No prep items yet.</div>';
     return '<div class="parent-calendar-checklist">'
-      + '<strong>' + esc(kidLabel) + '</strong>'
+      + '<strong>' + esc(kidLabel)
+      + ' <button class="btn ghost small" onclick="parentSetPrepPoints(\'' + jsq(item.id) + '\', ' + listIndex + ')">'
+      + (Number(list.points) > 0 ? list.points + ' pts' : 'Set pts') + '</button></strong>'
       + items
       + '</div>';
   }).join('') || '<div class="sub">No kid prep lists yet.</div>';
@@ -4987,6 +5071,9 @@ function planningUpdatePayload(item) {
     prepLists: Array.isArray(item.prepLists) ? item.prepLists.map(function(list) {
       return {
         personId: list.personId,
+        // Round-tripped, not rebuilt: dropping points here would silently
+        // zero a list's reward on every unrelated edit.
+        points: Number(list.points) || 0,
         items: (list.items || []).map(function(entry) {
           return { text: entry.text, done: !!entry.done };
         }),
@@ -5158,6 +5245,22 @@ async function parentAddPrepItem(itemId) {
     }
     prepList.items.push({ text: text, done: false });
   }, 'Prep item added.');
+}
+
+// The decided rule: the LIST carries the points and the event carries none -
+// being ready is what is rewarded, not attending.
+async function parentSetPrepPoints(itemId, listIndex) {
+  var item = (parentCalendarItems || []).find(function(entry) { return entry.id === itemId; });
+  var current = item && item.prepLists && item.prepLists[listIndex]
+    ? (Number(item.prepLists[listIndex].points) || 0) : 0;
+  var input = prompt('Points for getting this packed in time?', String(current || 10));
+  if (input === null) return;
+  var points = Number(input.trim());
+  if (!Number.isInteger(points) || points < 0) { toast('Points must be a whole number.'); return; }
+  await parentUpdatePlanningItem(itemId, function(payload) {
+    if (!payload.prepLists[listIndex]) return;
+    payload.prepLists[listIndex].points = points;
+  }, 'Prep list is worth ' + points + ' pts.');
 }
 
 async function parentAddAdultAction(itemId) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -928,6 +928,68 @@ test('a missed chore shows on the parent\u2019s today view', async ({ page }) =>
   });
 });
 
+// The soccer case, rendered: the kid sees their prep list on the event, ticks
+// it, and Packed only unlocks when everything is ticked. This is the surface
+// the original prepLists[kidId] lookup bug kept blank - that code had never
+// once run.
+test('a kid can tick their prep list and confirm packed', async ({ page }) => {
+  const eventId = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const state = await post({ action: 'state' });
+    // Two local days ahead, so the night-before deadline cannot be shut
+    // whatever hour this runs.
+    const start = new Date(new Date(state.today + 'T12:00:00Z').getTime() + 2 * 86400000);
+    const made = await post({
+      action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
+      type: 'event', title: 'Soccer match', personId: 'ollie',
+      startAt: start.toISOString(),
+      prepLists: [{ personId: 'ollie', points: 10, items: [{ text: 'boots' }, { text: 'shin pads' }] }],
+    });
+    return made.item.id;
+  });
+
+  await page.reload();
+  await pickPerson(page, 'Ollie');
+
+  const card = page.locator('.task', { hasText: 'Soccer match' }).first();
+  await expect(card).toBeVisible();
+  await expect(card.locator('.prep-item')).toHaveCount(2);
+
+  const packed = card.getByRole('button', { name: /packed/i });
+  await expect(packed).toBeDisabled();
+
+  await card.locator('.prep-item input').nth(0).check();
+  await card.locator('.prep-item input').nth(1).check();
+  await expect(packed).toBeEnabled();
+  await packed.click();
+
+  // The confirmation is a completion pending the parent, worth the list.
+  await expect.poll(async () => page.evaluate(async (id) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const fresh = await post({ action: 'state' });
+    const row = fresh.completions.find((c) => c.id === 'prep-' + id + '-ollie');
+    return row ? row.status + ':' + row.points : null;
+  }, eventId)).toBe('pending:10');
+
+  // Tidy: retire the event so later tests' premises hold.
+  await page.evaluate(async (id) => {
+    const real = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await real({ action: 'deletePlanningItem', planningItemId: id, parentId: 'peter', parentPin: '1234' });
+  }, eventId);
+});
+
 test('Parent HQ is headed by the parent, not a crown', async ({ page }) => {
   await pickPerson(page, 'Peter');
   const title = page.locator('#p-hq-title');


### PR DESCRIPTION
The remaining phase of the agreed plan — and the one the plan was named for. Ollie plays Sunday morning; **being ready by Saturday night is the thing being rewarded**, not attending.

## The rules, as decided

- **The list carries the points; the event carries none.** `prepLists` entries hold `points`, settable from the parent calendar checklist ("Set pts").
- **The deadline is the last window's close on the day *before* the event**, with an optional per-event `prepDueBy` override winning when set. After it: ticking and confirming are refused, and the sweep records the miss.
- **No reopening** — same hard close as chores.

## API

- `tickPrepItem` — a kid ticks only their own list (`requireSelf` plus a personId match); the parent-only `updatePlanningItem` remains the only way to touch anyone else's. This closes the gap found during the #41 design: until now **no route existed** for a kid to tick anything.
- `confirmPrep` — everything ticked, in time, becomes an ordinary **pending completion** (`prep-<itemId>-<kidId>`, deterministic, so a double-tap cannot double the reward) titled *"Packed for Soccer"* and worth the list's points. The existing approval flow needs nothing new.
- `recordMisses` sweeps unconfirmed lists once the night before closes — same deterministic-id idempotency as chore misses.

## Frontend

- The kid's Home glance renders the checklist with live ticks and a **Packed ✔** button that unlocks only when everything is ticked. The original render looked the list up as `prepLists[kidId]` when it is an array of `{personId, items}` — **that 🎒 line had never once run.** Found during the #41 design; fixed here, where the feature makes it matter.
- `planningUpdatePayload` now **round-trips `points`** — without that, every unrelated parent edit would have silently zeroed a list's reward.

## Tests

Logic — the full soccer case: wrong kid refused; confirm-before-ticking refused; confirm in time → pending at the list's points, naming the event; double-confirm idempotent; unconfirmed list missed exactly once when the night before closes; a confirmed list never swept.

Rendered: the kid ticks the two items, Packed unlocks, and the pending completion carries the points.

## Checks

API logic tests (6 new), `check-design.js`, `check-frontend.js`, smoke **66/66 — twice**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_