### PR TITLE
A parent-gated fresh start, the prepDueBy override wired in, and a demo seed

### DIFF
--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -1,0 +1,22 @@
+# Manually-triggered maintenance job: wipe activity/chores/calendar on the
+# LIVE app and seed the family's real schedule. Runs from a GitHub runner
+# because the dev container's egress policy cannot reach azurewebsites.net.
+# Never runs on its own - workflow_dispatch only.
+name: Seed demo data
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Wipe and seed the live app
+        run: node scripts/seed-demo.mjs

--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -378,6 +378,7 @@ async function validatePlanningPayload(req, currentItem = null) {
     prepLists: [],
     adultActions: [],
     notes: null,
+    prepDueBy: null,
     externalRef: null,
     allDay: false,
   };
@@ -431,6 +432,19 @@ async function validatePlanningPayload(req, currentItem = null) {
   if (req.source !== undefined) {
     if (!['manual', 'voice', 'email'].includes(req.source)) return { ok: false, error: 'invalid source' };
     next.source = req.source;
+  }
+
+  // Per-event override for when prep is due. Absent, the rule is the last
+  // window's close on the day before (prepDeadlinePassed) - this exists for
+  // prep that only makes sense on the day, like "uniform on" before Cubs.
+  if (req.prepDueBy !== undefined) {
+    if (req.prepDueBy === null || req.prepDueBy === '') {
+      next.prepDueBy = null;
+    } else {
+      const prepDueBy = parseIso(req.prepDueBy);
+      if (!prepDueBy) return { ok: false, error: 'prepDueBy must be an ISO datetime' };
+      next.prepDueBy = prepDueBy;
+    }
   }
 
   if (req.externalRef !== undefined) {
@@ -1094,6 +1108,28 @@ async function uncomplete(req) {
     await completions.item(req.completionId, HOUSEHOLD_ID).delete();
   }
   return getState();
+}
+
+// Parent-gated fresh start: wipe the activity history - completions (chore
+// ticks, misses, prep confirmations) and reward redemptions - without
+// touching who exists, the chores themselves, the calendar or the shop.
+// Points balances derive entirely from those rows, so this zeroes everyone.
+// Exists because test data otherwise lives forever: nothing else can delete
+// a completion, deliberately.
+async function clearActivity(req) {
+  await requireParent(req.parentId, req.parentPin);
+  const completions = await queryHousehold('completions');
+  for (const row of completions) {
+    await container('completions').item(row.id, HOUSEHOLD_ID).delete().catch(() => {});
+  }
+  const rewardRows = await queryHousehold('rewards');
+  let redemptions = 0;
+  for (const row of rewardRows) {
+    if (row.type !== 'redemption') continue;
+    await container('rewards').item(row.id, HOUSEHOLD_ID).delete().catch(() => {});
+    redemptions += 1;
+  }
+  return { ok: true, cleared: { completions: completions.length, redemptions } };
 }
 
 async function addExtra(req) {
@@ -1866,6 +1902,7 @@ const ROUTES = {
   reorderTasks,
   tickPrepItem,
   confirmPrep,
+  clearActivity,
 };
 
 app.http('hero', {

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2104,6 +2104,49 @@ async function main() {
   assert.strictEqual(soccerMissed, false, 'a confirmed list is never swept as missed');
   console.log('\u2713 confirming in time keeps the list off the miss sweep');
 
+  // -------------------------------------------------------------------------
+  // clearActivity: the parent-gated fresh start. Wipes completions and
+  // redemptions - balances derive from those rows, so everyone drops to zero -
+  // while people, chores, the shop and the calendar survive.
+  const beforeClear = await R.state();
+  assert.ok(beforeClear.completions.length > 0, 'there is history to clear, or this proves nothing');
+  let kidRefused = false;
+  try {
+    await R.clearActivity({ parentId: 'toby', parentPin: '1234' });
+  } catch (err) {
+    kidRefused = err && err.status === 401;
+  }
+  assert.ok(kidRefused, 'a kid cannot wipe the history');
+  const wiped = await R.clearActivity({ parentId: 'peter', parentPin: '1234' });
+  assert.strictEqual(wiped.ok, true);
+  assert.ok(wiped.cleared.completions > 0, 'it reports what it removed');
+  const afterClear = await R.state();
+  assert.strictEqual(afterClear.completions.length, 0, 'no completions survive');
+  assert.strictEqual(afterClear.redemptions.length, 0, 'no redemptions survive');
+  Object.values(afterClear.stats).forEach((kidStats) => {
+    assert.strictEqual(kidStats.balance, 0, 'every balance is zero');
+  });
+  assert.ok(afterClear.people.length >= 4, 'people survive');
+  assert.ok(afterClear.rewards.length > 0, 'the reward shop survives');
+  console.log('\u2713 clearActivity wipes history and balances, leaves people and the shop');
+
+  // prepDueBy override: "uniform on" prep is due at the event itself, not the
+  // night before - so a same-day tick works right up to the start.
+  const cubsStart = new Date(at('17:30').getTime() + 3 * 3600000); // later today
+  const cubs2 = await R.addPlanningItem({
+    parentId: 'peter', parentPin: '1234', type: 'event', title: 'Cubs tonight',
+    personId: null, startAt: cubsStart.toISOString(), prepDueBy: cubsStart.toISOString(),
+    prepLists: [{ personId: 'toby', points: 3, items: [{ text: 'Cubs uniform on' }] }],
+  });
+  assert.strictEqual(cubs2.ok, true);
+  assert.ok(cubs2.item.prepDueBy, 'the override is stored');
+  const sameDayTick = await R.tickPrepItem({
+    personId: 'toby', pin: '1234', planningItemId: cubs2.item.id, itemIndex: 0, done: true,
+  });
+  assert.strictEqual(sameDayTick.ok, true,
+    'with the override, same-day prep is open - the night-before rule would have refused this');
+  console.log('\u2713 prepDueBy overrides the night-before default for same-day prep');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -1,0 +1,119 @@
+// One-shot demo seed for the LIVE app, run from a GitHub Actions runner
+// (the dev container's egress policy cannot reach azurewebsites.net).
+//
+// What it does, in order:
+//   1. clearActivity     - wipes completions and redemptions (points to zero)
+//   2. deletes every chore and every calendar item
+//   3. seeds the real family schedule Pete described, exercising every
+//      feature shipped this week: windows, weekday chores, prep lists with
+//      points, the night-before deadline and the per-event override.
+//
+// Times are written in UTC but MEAN Perth (UTC+8): 17:30 Perth = 09:30Z.
+const API = process.env.API_URL || 'https://herotasks-func-dev.azurewebsites.net/api/hero';
+const PIN = process.env.PARENT_PIN || '1234';
+const parent = { parentId: 'peter', parentPin: PIN };
+
+const post = async (body) => {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  if (json && json.ok === false) throw new Error(`${body.action}: ${json.error}`);
+  return json;
+};
+
+// Next occurrence of a Perth weekday/time, at least `graceHours` away so we
+// never seed an event whose prep deadline has already shut.
+function nextPerth(weekday, hh, mm, graceHours = 12) {
+  const now = Date.now();
+  for (let d = 0; d < 15; d += 1) {
+    const probe = new Date(now + d * 86400000);
+    const perth = new Date(probe.getTime() + 8 * 3600000);
+    if (perth.getUTCDay() !== weekday) continue;
+    const at = Date.UTC(perth.getUTCFullYear(), perth.getUTCMonth(), perth.getUTCDate(), hh - 8, mm);
+    if (at - now > graceHours * 3600000) return new Date(at);
+  }
+  throw new Error('no slot found');
+}
+
+// ---- 1. wipe ----
+const cleared = await post({ action: 'clearActivity', ...parent });
+console.log('cleared:', JSON.stringify(cleared.cleared));
+
+const state = await post({ action: 'state' });
+for (const task of state.tasks || []) {
+  await post({ action: 'deleteTask', ...parent, taskId: task.id });
+  console.log('deleted chore:', task.title);
+}
+const from = new Date(Date.now() - 400 * 86400000).toISOString();
+const to = new Date(Date.now() + 400 * 86400000).toISOString();
+const cal = await post({ action: 'calendar', ...parent, start: from, end: to });
+const seen = new Set();
+for (const item of cal.items || []) {
+  if (item.kind === 'chore' || !item.id || seen.has(item.id)) continue;
+  seen.add(item.id);
+  await post({ action: 'deletePlanningItem', ...parent, planningItemId: item.id });
+  console.log('deleted calendar item:', item.title);
+}
+
+// ---- 2. chores: school lunches, Mon-Fri, evening window ----
+for (const kid of ['toby', 'ollie']) {
+  await post({
+    action: 'addTask', ...parent, kidId: kid,
+    title: 'Make school lunches', points: 5,
+    cycle: 'weekly', days: [1, 2, 3, 4, 5], windowId: 'evening',
+  });
+  console.log(`chore: Make school lunches (${kid}, Mon-Fri, evening)`);
+}
+
+// ---- 3. events with prep ----
+// Soccer: Sunday 09:00 Perth, Ollie. Prep worth 10, due the NIGHT BEFORE
+// (the default rule - nothing to override).
+const soccer = nextPerth(0, 9, 0, 20);
+await post({
+  action: 'addPlanningItem', ...parent, type: 'event',
+  title: 'Soccer', personId: 'ollie', startAt: soccer.toISOString(),
+  prepLists: [{ personId: 'ollie', points: 10, items: [
+    { text: 'Boots' }, { text: 'Shin pads' }, { text: 'Water bottle' },
+    { text: 'Kit' }, { text: 'Club socks' },
+  ] }],
+});
+console.log('event: Soccer', soccer.toISOString(), '(prep due the night before)');
+
+// Cubs: Monday 17:30 Perth, whole family (Toby AND Ollie both go), a prep
+// list each. "Uniform on" is same-evening prep, so prepDueBy overrides the
+// night-before default to the event start itself.
+// Scouts: Thursday 18:00-20:00 Perth, Toby only, same override.
+// Calendar items do not recur yet, so seed the next two weeks of each.
+for (let week = 0; week < 2; week += 1) {
+  const cubs = new Date(nextPerth(1, 17, 30).getTime() + week * 7 * 86400000);
+  await post({
+    action: 'addPlanningItem', ...parent, type: 'event',
+    title: 'Cubs', personId: null, startAt: cubs.toISOString(),
+    prepDueBy: cubs.toISOString(),
+    prepLists: [
+      { personId: 'toby',  points: 3, items: [{ text: 'Cubs uniform on' }] },
+      { personId: 'ollie', points: 3, items: [{ text: 'Cubs uniform on' }] },
+    ],
+  });
+  console.log('event: Cubs', cubs.toISOString());
+
+  const scouts = new Date(nextPerth(4, 18, 0).getTime() + week * 7 * 86400000);
+  await post({
+    action: 'addPlanningItem', ...parent, type: 'event',
+    title: 'Scouts', personId: 'toby',
+    startAt: scouts.toISOString(),
+    endAt: new Date(scouts.getTime() + 2 * 3600000).toISOString(),
+    prepDueBy: scouts.toISOString(),
+    prepLists: [{ personId: 'toby', points: 3, items: [{ text: 'Scouts uniform on' }] }],
+  });
+  console.log('event: Scouts', scouts.toISOString());
+}
+
+const finalState = await post({ action: 'state' });
+console.log('\nfinal: tasks =', (finalState.tasks || []).length,
+  '| balances =', JSON.stringify(Object.fromEntries(
+    Object.entries(finalState.stats || {}).map(([k, v]) => [k, v.balance]))));
+console.log('SEED COMPLETE');


### PR DESCRIPTION
Pete asked for the test data gone and the family's real schedule in its place.

## `clearActivity` (parent-gated)

Wipes completions and redemptions — balances derive from those rows, so everyone drops to zero — while **people, chores, the shop and the calendar survive**. Exists because nothing else can delete a completion, deliberately, and test history otherwise lives forever.

## `prepDueBy` accepted on planning items — a real bug fix

The deadline check has *read* `prepDueBy` since the prep-lists PR, but nothing ever accepted it on input — so the per-event override the plan decided on ("overridable per event") **silently could not be set**. Found while writing the seed: "uniform on" prep is due at the event itself, not the night before, and without the override the seed would have quietly seeded the wrong rule.

## The seed itself

`scripts/seed-demo.mjs` plus a **`workflow_dispatch`-only** workflow (never runs on its own). It runs from a GitHub runner because the dev container's egress policy cannot reach `azurewebsites.net`. In order: `clearActivity` → delete every chore and calendar item → seed:

| What | Detail |
|---|---|
| Make school lunches ×2 | Both kids, Mon–Fri, evening window, 5 pts |
| Soccer (Sunday 9:00 Perth) | Ollie; 5-item prep list worth 10 pts, **night-before default** |
| Cubs ×2 weeks (Mon 17:30 Perth) | Whole family; a "Cubs uniform on" list per kid, 3 pts, **`prepDueBy` = event start** |
| Scouts ×2 weeks (Thu 18:00–20:00 Perth) | Toby; "Scouts uniform on", 3 pts, same override |

Events don't recur yet, hence two explicit weeks of each.

## Tests

`clearActivity` refuses a kid, reports what it removed, zeroes every balance, leaves people and the shop. The override keeps same-day prep open where the night-before rule would have refused it.

## Checks

API logic tests (2 new), `check-design.js`, `check-frontend.js`, smoke 66/66.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_