### PR TITLE
Scouts prep is due 5:30, half an hour before the 6pm start

### DIFF
--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -106,7 +106,8 @@ for (let week = 0; week < 2; week += 1) {
     title: 'Scouts', personId: 'toby',
     startAt: scouts.toISOString(),
     endAt: new Date(scouts.getTime() + 2 * 3600000).toISOString(),
-    prepDueBy: scouts.toISOString(),
+    // Pete's rule: uniform on by 5:30, half an hour before the 6pm start.
+    prepDueBy: new Date(scouts.getTime() - 30 * 60000).toISOString(),
     prepLists: [{ personId: 'toby', points: 3, items: [{ text: 'Scouts uniform on' }] }],
   });
   console.log('event: Scouts', scouts.toISOString());


### PR DESCRIPTION
Pete's correction to the seed: Scouts uniform must be on by **17:30 Perth**, not by the 18:00 start. One line — `prepDueBy` moves to start minus 30 minutes.

The seed wipes before it writes, so re-running it replaces the two Scouts events with the corrected deadline. Cubs is unchanged (starts 17:30, prep due at start, which already matches "by 5:30").

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_