### PR TITLE
The prep card names its deadline, and a disabled Packed looks disabled

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -824,6 +824,31 @@ function currentOccurrence(item, now = new Date()) {
   return { ...last, date: todayStr(new Date(last.startAt)) };
 }
 
+function localHHMM(date) {
+  const parts = LOCAL_TIME_FORMAT.formatToParts(date);
+  return `${parts.find((part) => part.type === 'hour').value}:${parts.find((part) => part.type === 'minute').value}`;
+}
+
+// When an occurrence's prep is due, as household-local display parts - the
+// client shows these verbatim, so no timezone maths ever happens in the
+// browser. Mirrors prepDeadlinePassed: the override wins; otherwise the last
+// window's close on the day before.
+async function prepDueParts(occ, windows) {
+  if (occ.prepDueBy) {
+    const when = new Date(occ.prepDueBy);
+    if (!Number.isNaN(when.getTime())) {
+      return { prepDueDate: todayStr(when), prepDueTime: localHHMM(when) };
+    }
+  }
+  const dayBefore = new Date(new Date(`${occ.date}T12:00:00Z`).getTime() - 86400000)
+    .toISOString().slice(0, 10);
+  const closes = (windows || await getHouseholdWindows())
+    .filter((w) => HHMM_RE.test(w.closesAt || ''))
+    .map((w) => w.closesAt)
+    .sort();
+  return { prepDueDate: dayBefore, prepDueTime: closes[closes.length - 1] || '21:00' };
+}
+
 // When prep for an event is due: the close of the LAST window on the day
 // before the event - "packed for Sunday soccer by Saturday 9pm". Being ready
 // the night before is the thing being rewarded, which is why the deadline is
@@ -1015,6 +1040,7 @@ async function calendar(req) {
   ]);
 
   const schedule = [];
+  const householdWindows = await getHouseholdWindows();
 
   for (const item of planningItems) {
     if (item.active === false) continue;
@@ -1040,6 +1066,10 @@ async function calendar(req) {
         occurrenceDate: todayStr(occStart),
         prepOpenDate: liveOcc ? liveOcc.date : null,
       };
+      if (item.type === 'event' && (item.prepLists || []).some((l) => l.items && l.items.length)) {
+        Object.assign(row, await prepDueParts(
+          { ...occ, date: row.occurrenceDate }, householdWindows));
+      }
       if (callerRole === 'kid') delete row.adultActions;
       schedule.push(row);
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1254,6 +1254,7 @@ button.parent-list-row:active { transform: scale(0.99); }
   margin-top: var(--space-1);
 }
 .prep-missed { color: var(--danger); font-weight: var(--weight-medium); }
+.btn[disabled] { opacity: 0.45; cursor: not-allowed; }
 /* My List - a kid's own notes, plans and reminders. */
 .mylist-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -2602,13 +2603,14 @@ function glanceEventCard(item, kidId) {
     if (confirmed) {
       footer = '<div class="sub">Packed and confirmed ✅' + (list.points ? ' · ' + list.points + ' pts pending' : '') + '</div>';
     } else if (missed) {
-      footer = '<div class="sub prep-missed">Missed — packing closed the night before'
+      footer = '<div class="sub prep-missed">Missed — packing closed'
         + (list.points ? ' · ' + list.points + ' pts were up for grabs' : '') + '</div>';
     } else if (!isLive) {
       footer = '<div class="sub">Opens after this week\u2019s' + (list.points ? ' · ' + list.points + ' pts' : '') + '</div>';
     } else {
+      var dueLabel = prepDueLabel(item);
       footer = '<div class="prep-footer">'
-        + '<span class="sub">Pack in time' + (list.points ? ' · ' + list.points + ' pts' : '') + '</span>'
+        + '<span class="sub">' + (dueLabel ? 'Pack by <strong>' + esc(dueLabel) + '</strong>' : 'Pack in time') + (list.points ? ' · ' + list.points + ' pts' : '') + '</span>'
         + '<button class="btn small" ' + (allTicked ? '' : 'disabled ')
         + 'onclick="confirmPrepPacked(\'' + jsq(item.id) + '\')">Packed ✔</button>'
         + '</div>';
@@ -2624,6 +2626,24 @@ function glanceEventCard(item, kidId) {
     + prep
     + '</div>'
     + '</div>';
+}
+
+function prepDueLabel(item) {
+  if (!item.prepDueDate || !item.prepDueTime) return '';
+  var parts = item.prepDueTime.split(':');
+  var hour = Number(parts[0]);
+  var suffix = hour >= 12 ? 'pm' : 'am';
+  var displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  var time = displayHour + (parts[1] === '00' ? '' : ':' + parts[1]) + suffix;
+  var today = todayStr();
+  var tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  var tomorrowStr = tomorrow.getFullYear() + '-' + String(tomorrow.getMonth() + 1).padStart(2, '0') + '-' + String(tomorrow.getDate()).padStart(2, '0');
+  var day;
+  if (item.prepDueDate === today) day = 'today';
+  else if (item.prepDueDate === tomorrowStr) day = 'tomorrow';
+  else day = new Date(item.prepDueDate + 'T12:00:00').toLocaleDateString([], { weekday: 'short' });
+  return day + ' ' + time;
 }
 
 async function tickPrep(planningItemId, itemIndex, done) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -959,8 +959,18 @@ test('a kid can tick their prep list and confirm packed', async ({ page }) => {
   await expect(card).toBeVisible();
   await expect(card.locator('.prep-item')).toHaveCount(2);
 
+  // The card must say WHEN packing closes, not just that it must be "in
+  // time" - the match time and the packing deadline are different days and
+  // the kid only sees the former otherwise.
+  await expect(card).toContainText(/Pack by/);
+  await expect(card).not.toContainText(/Pack in time/);
+
   const packed = card.getByRole('button', { name: /packed/i });
   await expect(packed).toBeDisabled();
+  // And a disabled Packed must look disabled - it rendered fully opaque and
+  // pressable with nothing ticked.
+  const dimmed = await packed.evaluate((el) => Number(getComputedStyle(el).opacity) < 0.7);
+  expect(dimmed, 'disabled Packed should be visibly dimmed').toBe(true);
 
   await card.locator('.prep-item input').nth(0).check();
   await card.locator('.prep-item input').nth(1).check();


### PR DESCRIPTION
From Pete's first real test pass, on his phone: the Soccer card said **"Sun 9:00"** and **"Pack in time · 10 pts"** — the *match* time was visible, the *packing* deadline never was, and those are different days. And the Packed ✔ button rendered fully opaque with nothing ticked — actually disabled, but looking pressable.

## Changes

- `calendar()` stamps every prep-carrying occurrence with `prepDueDate` / `prepDueTime`, computed **server-side in household-local parts** (the `prepDueBy` override wins; otherwise the last window's close on the day before) — the browser does no timezone maths, it prints what it's given. The card now reads **"Pack by Sat 9pm · 10 pts"**, with "today 5:30pm" / "tomorrow" when nearer.
- `.btn[disabled]` is dimmed with a `not-allowed` cursor.
- The missed line drops "the night before", which is untrue for same-evening overrides like Cubs.

## Tests

Smoke asserts the card says "Pack by" and never "Pack in time", and that a disabled Packed is visibly dimmed.

## Checks

API logic tests, `check-design.js`, `check-frontend.js`, smoke 66/66.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_