### PR TITLE
The Today header prints the real date, and a submitted chore reads as done

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1255,6 +1255,16 @@ button.parent-list-row:active { transform: scale(0.99); }
 }
 .prep-missed { color: var(--danger); font-weight: var(--weight-medium); }
 .btn[disabled] { opacity: 0.45; cursor: not-allowed; }
+/* A submitted chore must read as dealt-with at a glance. Struck through in
+   both states - the sub line carries the difference (waiting vs banked). */
+.task.done-pending .title,
+.task.done-queued .title,
+.task.done-approved .title { text-decoration: line-through; color: var(--ink-muted); }
+.section-date {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--ink-muted);
+}
 /* My List - a kid's own notes, plans and reminders. */
 .mylist-head {
   display: flex; align-items: center; justify-content: space-between;
@@ -1570,7 +1580,7 @@ button.parent-list-row:active { transform: scale(0.99); }
       <div class="home-content-sheet">
         <div class="home-glance-grid">
           <section>
-            <h2 class="section-title">📅 Today</h2>
+            <h2 class="section-title">🗓️ Today <span class="section-date" id="k-today-date"></span></h2>
             <div id="k-glance-today"></div>
           </section>
           <section>
@@ -1626,7 +1636,7 @@ button.parent-list-row:active { transform: scale(0.99); }
     <!-- CALENDAR TAB -->
     <div id="tab-calendar" class="tab-panel hidden">
       <div class="tab-content">
-        <h2 class="section-title">📅 Calendar</h2>
+        <h2 class="section-title">🗓️ Calendar</h2>
         <div class="calendar-controls" role="tablist" aria-label="Calendar view">
           <button id="calendar-view-day" class="calendar-chip" onclick="switchCalendarView('day')">Day</button>
           <button id="calendar-view-week" class="calendar-chip active" onclick="switchCalendarView('week')">Week</button>
@@ -1653,7 +1663,7 @@ button.parent-list-row:active { transform: scale(0.99); }
       <span class="tab-icon">🏆</span><span>Leaders</span>
     </button>
     <button class="tab-btn"        id="tabbtn-calendar" onclick="switchTab('calendar')" aria-label="Calendar">
-      <span class="tab-icon">📅</span><span>Calendar</span>
+      <span class="tab-icon">🗓️</span><span>Calendar</span>
     </button>
   </nav>
 
@@ -2628,6 +2638,15 @@ function glanceEventCard(item, kidId) {
     + '</div>';
 }
 
+function todayHeaderLabel() {
+  return new Date().toLocaleDateString([], { weekday: 'short', day: 'numeric', month: 'short' });
+}
+
+function setTodayHeaderDate() {
+  var el = document.getElementById('k-today-date');
+  if (el) el.textContent = todayHeaderLabel();
+}
+
 function prepDueLabel(item) {
   if (!item.prepDueDate || !item.prepDueTime) return '';
   var parts = item.prepDueTime.split(':');
@@ -2686,6 +2705,7 @@ function glanceCard(item, kidId) {
 }
 
 function renderKidGlance(kid) {
+  setTodayHeaderDate();
   var todayEl = document.getElementById('k-glance-today');
   var weekEl = document.getElementById('k-glance-week');
   if (!todayEl || !weekEl) return;
@@ -3051,7 +3071,7 @@ function renderParentApprovalsGlance() {
   el.innerHTML = (nothingScheduled
       ? buildEmptyPill('Nothing scheduled')
       : '<div class="card parent-card">'
-        + '<h3 class="parent-section-title">Today</h3>'
+        + '<h3 class="parent-section-title">Today <span class="section-date">' + esc(todayHeaderLabel()) + '</span></h3>'
         + renderParentGlanceRows(todayItems, 'Nothing today.')
         + '</div>'
         + '<div class="card parent-card">'

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -274,7 +274,7 @@ test('the rewards shop is not empty', async ({ page }) => {
 test('the kid Home screen shows a Today and a This Week section', async ({ page }) => {
   await pickPerson(page, 'Ollie');
 
-  await expect(page.getByRole('heading', { name: /^📅 Today$/ })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /🗓️ Today/ })).toBeVisible();
   await expect(page.getByRole('heading', { name: /This Week/ })).toBeVisible();
 
   // Both must resolve to real content or a real empty state - never a permanent
@@ -932,6 +932,39 @@ test('a missed chore shows on the parent\u2019s today view', async ({ page }) =>
 // it, and Packed only unlocks when everything is ticked. This is the surface
 // the original prepLists[kidId] lookup bug kept blank - that code had never
 // once run.
+// Pete's screenshot: the flat calendar emoji hardcodes "JUL 17" in its
+// artwork on Samsung/Apple, and with no real date anywhere the app appeared
+// to claim the wrong day. The header now prints the actual date, and a
+// submitted chore reads as dealt-with - struck through - rather than
+// looking indistinguishable from still-to-do.
+test('the Today header shows the real date, and a submitted chore is struck through', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: 'Sweep the porch', points: 2, cycle: 'daily',
+    });
+  });
+  await page.reload();
+  await pickPerson(page, 'Toby');
+
+  const expected = new Date().toLocaleDateString([], { weekday: 'short', day: 'numeric', month: 'short' });
+  await expect(page.locator('#k-today-date')).toHaveText(expected);
+
+  const row = page.locator('.task', { hasText: 'Sweep the porch' }).first();
+  await expect(row).toBeVisible();
+  const before = await row.locator('.title').evaluate((el) => getComputedStyle(el).textDecorationLine);
+  expect(before).not.toContain('line-through');
+  await row.locator('.tick').click();
+  await expect(row).toContainText(/waiting for a grown-up/i);
+  const after = await row.locator('.title').evaluate((el) => getComputedStyle(el).textDecorationLine);
+  expect(after, 'a submitted chore should be struck through').toContain('line-through');
+});
+
 test('a kid can tick their prep list and confirm packed', async ({ page }) => {
   const eventId = await page.evaluate(async () => {
     const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {


### PR DESCRIPTION
Two findings from Pete's phone.

## "It's Tuesday 25th August, not 17th"

The app never printed a date — that's the flat calendar emoji's own artwork, which hardcodes **JUL 17** (World Emoji Day) on Samsung and Apple fonts. With no real date anywhere on screen, the icon read as the app claiming the wrong day.

- Section headers and the Calendar tab now use the **spiral calendar**, which carries no number
- The Today header prints the actual device date — **"Today · Tue 25 Aug"**
- Parent HQ's Today panel gets the same

## A ticked chore looked identical to a still-to-do one

Bar the sub line, nothing changed visually on submit. Submitted rows (pending, queued or approved) now **strike the title through**; the sub line carries the difference — "Waiting for a grown-up ⏳" vs "Done — points banked! 💰". On approval the row stays struck through for the rest of the day and resets with the new day — the existing lifecycle, now legible.

## Tests

Smoke: the header shows today's real formatted date; a chore's title is not struck before ticking and is after. One existing test had pinned the exact old header text (`/^📅 Today$/`) and was updated with the change.

## Checks

`check-design.js`, `check-frontend.js`, smoke 67/67.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_