### PR TITLE
A one-off event can be promoted to weekly from the edit flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5266,6 +5266,16 @@ async function parentEditPlanningItem(itemId) {
     return;
   }
   var personId = whoIndex === 0 ? null : kidsOnly()[whoIndex - 1].id;
+  // Same control the add form has - a one-off must be promotable to weekly
+  // after the fact (Soccer was seeded one-off; the season is not).
+  var recurrence = null;
+  if (type === 'event') {
+    var repeatInput = prompt('Repeats?\n1) Just once  2) Every week', item.recurrence === 'weekly' ? '2' : '1');
+    if (repeatInput === null) return;
+    var repeatChoice = String(repeatInput).trim();
+    if (repeatChoice !== '1' && repeatChoice !== '2') { toast('Choose 1 or 2 for repeats.'); return; }
+    recurrence = repeatChoice === '2' ? 'weekly' : null;
+  }
   var notesInput = prompt('Notes (optional)', item.notes || '');
   if (notesInput === null) return;
   await parentUpdatePlanningItem(itemId, function(payload) {
@@ -5275,6 +5285,7 @@ async function parentEditPlanningItem(itemId) {
     payload.endAt = type === 'event' ? endAt : null;
     payload.personId = personId;
     payload.notes = notesInput.trim() || null;
+    payload.recurrence = recurrence;
     if (type === 'reminder') {
       payload.prepLists = [];
       payload.adultActions = [];

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -937,6 +937,60 @@ test('a missed chore shows on the parent\u2019s today view', async ({ page }) =>
 // to claim the wrong day. The header now prints the actual date, and a
 // submitted chore reads as dealt-with - struck through - rather than
 // looking indistinguishable from still-to-do.
+// The add form could make an event weekly; the edit flow could not - so a
+// one-off could never be promoted once created. Drives the real prompt
+// sequence and asserts the server ends up with recurrence set.
+test('editing a one-off event can make it weekly', async ({ page }) => {
+  const eventId = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const made = await post({
+      action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
+      type: 'event', title: 'Winter season opener', personId: 'ollie',
+      startAt: new Date(Date.now() + 3 * 86400000).toISOString(),
+    });
+    return made.item.id;
+  });
+
+  await page.reload();
+  await pickPerson(page, 'Peter');
+  await page.getByRole('button', { name: /calendar/i }).first().click();
+
+  // The edit flow is a prompt sequence; answer each by its question text,
+  // changing only the Repeats step.
+  await page.evaluate(() => {
+    window.prompt = (message, fallback) => /Repeats\?/.test(String(message)) ? '2' : String(fallback == null ? '' : fallback);
+  });
+  await page.evaluate((id) => window.parentEditPlanningItem(id), eventId);
+
+  await expect.poll(async () => page.evaluate(async (id) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const cal = await post({
+      action: 'calendar', parentId: 'peter', parentPin: '1234',
+      start: new Date(Date.now() - 86400000).toISOString(),
+      end: new Date(Date.now() + 20 * 86400000).toISOString(),
+    });
+    const rows = (cal.items || []).filter((i) => i.id === id);
+    return rows.length ? rows[0].recurrence + ':' + rows.length : null;
+  }, eventId)).toBe('weekly:3');
+
+  await page.evaluate(async (id) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({ action: 'deletePlanningItem', planningItemId: id, parentId: 'peter', parentPin: '1234' });
+  }, eventId);
+});
+
 test('the Today header shows the real date, and a submitted chore is struck through', async ({ page }) => {
   await page.evaluate(async () => {
     const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {


### PR DESCRIPTION
Pete: *"the recurring weekly option is already there when I'm initially creating an item, but what I don't have is the ability to make an item recurring that is currently a one-off — is that right?"* It was right. The add form has had "Repeats weekly" since #201; the edit flow didn't, so a one-off could never be promoted. Soccer is the live case: seeded as a single game, and the season is not.

## Change

The edit sequence gains a **Repeats?** step (events only — "1) Just once 2) Every week"), defaulting to the item's current setting. `planningUpdatePayload` already round-trips `recurrence` and the server has accepted it on update since #201 — this was purely a missing control.

## Tests

Smoke drives the real prompt sequence, changing only the Repeats answer, and asserts the calendar then expands the event weekly — three occurrences across a twenty-day range.

## Checks

`check-design.js`, `check-frontend.js`, smoke 68/68.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_