### PR TITLE
The kid pill describes the kid's day, not the parent's inbox

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3179,12 +3179,20 @@ function renderParentApprovalsTodayByKid() {
     var statuses = todayItems.map(function(item) { return parentCalendarOverviewStatus(item).className; });
     var waiting = statuses.filter(function(name) { return name === 'waiting'; }).length;
     var missedCount = statuses.filter(function(name) { return name === 'missed'; }).length;
-    var pills = '<span class="pill neutral">' + todayItems.length + ' chore'
-      + (todayItems.length === 1 ? '' : 's') + '</span>'
-      + (missedCount > 0 ? '<span class="pill bad">' + missedCount + ' missed</span>' : '')
-      + (waiting > 0
-          ? '<span class="pill warn">' + waiting + ' pending</span>'
-          : (missedCount === 0 ? '<span class="pill good">All caught up</span>' : ''));
+    var toDo = statuses.filter(function(name) { return name === 'not-started'; }).length;
+    // The pill describes the KID's day, not the parent's inbox. The old
+    // green "All caught up" meant only "nothing pending on you", so it sat
+    // beside a "Not started" row and contradicted it - a kid who had done
+    // nothing at all read as caught up.
+    var pills = todayItems.length === 0
+      ? '<span class="pill neutral">Nothing on today</span>'
+      : '<span class="pill neutral">' + todayItems.length + ' chore'
+        + (todayItems.length === 1 ? '' : 's') + '</span>'
+        + (missedCount > 0 ? '<span class="pill bad">' + missedCount + ' missed</span>' : '')
+        + (waiting > 0 ? '<span class="pill warn">' + waiting + ' pending</span>' : '')
+        + (toDo > 0 ? '<span class="pill neutral">' + toDo + ' to do</span>' : '')
+        + (toDo === 0 && waiting === 0 && missedCount === 0
+            ? '<span class="pill good">All done ✅</span>' : '');
 
     return '<div class="card parent-card">'
       + '<div class="parent-item-head">'

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -756,12 +756,21 @@ test('a chore can be set to particular weekdays, and lands on exactly those', as
       start: from.toISOString(), end: to.toISOString(),
     });
     const mine = (cal.items || []).filter((i) => i.taskId === task.id);
+    // The expectation the server enforces: matching weekdays within the
+    // range, but never before the chore's creation day (its anchor). The
+    // old hardcoded 6 was only right when this ran on a Monday.
+    let expected = 0;
+    const anchor = new Date(`${task.createdAt}T00:00:00Z`);
+    for (let day = new Date(from); day.getTime() <= to.getTime(); day.setUTCDate(day.getUTCDate() + 1)) {
+      if (day.getTime() >= anchor.getTime() && [1, 3, 5].includes(day.getUTCDay())) expected += 1;
+    }
     return {
       days: task.days,
       error: cal.error || null,
       ok: cal.ok === true,
       weekdays: [...new Set(mine.map((i) => new Date(i.occurrenceAt).getUTCDay()))].sort(),
       count: mine.length,
+      expected,
     };
   });
 
@@ -769,7 +778,8 @@ test('a chore can be set to particular weekdays, and lands on exactly those', as
   expect(result.ok, 'the calendar call should succeed').toBe(true);
   expect(result.days, 'the chosen days come back on the task').toEqual([1, 3, 5]);
   expect(result.weekdays, 'it lands on Mon, Wed and Fri and nothing else').toEqual([1, 3, 5]);
-  expect(result.count, 'three days a week, across two weeks').toBe(6);
+  expect(result.expected, 'the range holds at least a week of them').toBeGreaterThanOrEqual(3);
+  expect(result.count, 'exactly the anchored occurrences in range').toBe(result.expected);
 });
 
 // A chore on Mon/Wed/Fri is due on each of them. Matching completions by week -
@@ -1354,7 +1364,15 @@ test('a kid card reports status as pills, not paragraphs', async ({ page }) => {
   const cards = page.locator('#p-approvals-today-by-kid .parent-card');
   const toby = cards.filter({ hasText: 'Toby' });
   await expect(toby.locator('.pill.warn')).toContainText(/\d+ pending/);
-  await expect(toby.locator('.pill.neutral')).toContainText(/chore/);
+  await expect(toby.locator('.pill.neutral').first()).toContainText(/chore/);
+
+  // The pill describes the kid's day, not the parent's inbox: with a chore
+  // pending there is no green pill, and a kid with an untouched chore says
+  // "to do" rather than "All caught up" beside a Not started row.
+  await expect(toby.locator('.pill.good')).toHaveCount(0);
+  const ollie = cards.filter({ hasText: 'Ollie' });
+  const ollieText = await ollie.textContent();
+  expect(/All caught up/.test(ollieText || '')).toBe(false);
 
   // The filler subtitle is gone from every card.
   await expect(page.locator('#p-approvals-today-by-kid')).not.toContainText('chores overview');
@@ -1363,8 +1381,9 @@ test('a kid card reports status as pills, not paragraphs', async ({ page }) => {
 test('a kid with nothing on gets one pill, not an empty state', async ({ page }) => {
   await pickPerson(page, 'Peter');
   const ollie = page.locator('#p-approvals-today-by-kid .parent-card').filter({ hasText: 'Ollie' });
-  await expect(ollie.locator('.pill.good')).toContainText('All caught up');
-  // No emoji-and-two-sentences block explaining that zero means zero.
+  // "Nothing on today", stated once - not a green "caught up" claim, and not
+  // an emoji-and-two-sentences block explaining that zero means zero.
+  await expect(ollie.locator('.pill.neutral')).toContainText('Nothing on today');
   await expect(ollie.locator('.empty')).toHaveCount(0);
 });
 


### PR DESCRIPTION
Pete, on the Approvals screen: Toby's card said **"Not started"** and **"All caught up"** at once. The green pill meant only *"nothing pending on you and nothing missed"* — it said nothing about whether the kid had done anything, so a kid who had done nothing at all read as caught up.

## The pill row now states the kid's actual day

- `N chores` · red `N missed` · amber `N pending` · neutral `N to do`
- **Green is earned:** `All done ✅` only when every chore is submitted or approved and nothing missed
- A kid with nothing scheduled says `Nothing on today`, once, in neutral — not a green claim about work that never existed

The page-top "All caught up" under *Awaiting your approval* keeps its meaning — that one genuinely is about the parent's inbox.

## Also: a pre-existing time-bomb test, defused

This run exposed it: the weekday-chore smoke test hardcoded **6** expected occurrences, which is only correct when the chore is created on a Monday — a chore anchors at its creation day, so a Tuesday run finds 5 and the test fails through no fault of the diff. It now computes the expectation from the same anchor rule the server enforces, so it means the same thing on every day of the week.

## Checks

`check-design.js`, `check-frontend.js`, smoke 68/68.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_