### PR TITLE
Drop the redundant total pill from the per-kid day summary

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3184,15 +3184,18 @@ function renderParentApprovalsTodayByKid() {
     // green "All caught up" meant only "nothing pending on you", so it sat
     // beside a "Not started" row and contradicted it - a kid who had done
     // nothing at all read as caught up.
-    var pills = todayItems.length === 0
-      ? '<span class="pill neutral">Nothing on today</span>'
-      : '<span class="pill neutral">' + todayItems.length + ' chore'
-        + (todayItems.length === 1 ? '' : 's') + '</span>'
-        + (missedCount > 0 ? '<span class="pill bad">' + missedCount + ' missed</span>' : '')
+    // No "N chores" total pill: the breakdown sums to it, and with a single
+    // chore "1 chore · 1 to do" read as the same thing counted twice.
+    var pills;
+    if (todayItems.length === 0) {
+      pills = '<span class="pill neutral">Nothing on today</span>';
+    } else if (toDo === 0 && waiting === 0 && missedCount === 0) {
+      pills = '<span class="pill good">' + (todayItems.length === 1 ? 'Done ✅' : 'All ' + todayItems.length + ' done ✅') + '</span>';
+    } else {
+      pills = (missedCount > 0 ? '<span class="pill bad">' + missedCount + ' missed</span>' : '')
         + (waiting > 0 ? '<span class="pill warn">' + waiting + ' pending</span>' : '')
-        + (toDo > 0 ? '<span class="pill neutral">' + toDo + ' to do</span>' : '')
-        + (toDo === 0 && waiting === 0 && missedCount === 0
-            ? '<span class="pill good">All done ✅</span>' : '');
+        + (toDo > 0 ? '<span class="pill neutral">' + toDo + ' to do</span>' : '');
+    }
 
     return '<div class="card parent-card">'
       + '<div class="parent-item-head">'

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -1364,7 +1364,9 @@ test('a kid card reports status as pills, not paragraphs', async ({ page }) => {
   const cards = page.locator('#p-approvals-today-by-kid .parent-card');
   const toby = cards.filter({ hasText: 'Toby' });
   await expect(toby.locator('.pill.warn')).toContainText(/\d+ pending/);
-  await expect(toby.locator('.pill.neutral').first()).toContainText(/chore/);
+  // No "N chores" total pill: with a single chore it read as the same thing
+  // counted twice. The breakdown pills carry the whole story.
+  await expect(toby.locator('.pill', { hasText: /chore/ })).toHaveCount(0);
 
   // The pill describes the kid's day, not the parent's inbox: with a chore
   // pending there is no green pill, and a kid with an untouched chore says


### PR DESCRIPTION
Pete asked: "why does toby have 1 chore and 1 to do?" — because the pill row showed a "N chores" total pill *and* the breakdown, which with a single chore reads as the same thing counted twice.

The breakdown (missed / pending / to do) already sums to the total, so the total pill is dropped:

- Nothing scheduled → neutral "Nothing on today"
- Everything approved → green "Done ✅" (or "All N done ✅")
- Otherwise → only the non-zero breakdown pills: red "N missed", amber "N pending", neutral "N to do"

Smoke updated to assert no pill matching /chore/ appears in the per-kid row. All 68 smoke tests pass locally; API logic tests untouched (frontend-only change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_