### PR TITLE
Approvals and reward-request counts become side-by-side stat tiles

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -764,6 +764,17 @@ Same tokens, different register:
 - Density over generosity — a parent scanning approvals wants to see more at once
 - **No celebration animations.** Approving is administration, not achievement.
 
+### Stat tiles
+
+The counts waiting on the parent (approvals, reward requests) are two rounded
+tiles side by side at the top of the Approvals tab — `.stat-row` / `.stat-tile` —
+a big number over a small muted label. Zero is stated once, on the tile; the
+card containers below stay empty rather than repeating it as a pill or a
+sentence. A non-zero tile takes `.attention` (`--warning-wash` background,
+`--warning` number) because it is work waiting on the parent, and the decision
+cards render below the row. One exception to the type rule above: the tile
+number uses `--text-2xl` — the count is the point of the tile.
+
 ---
 
 ## The one thing that separates an app from a web page

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -999,6 +999,39 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   font-weight: var(--weight-bold);
   margin-bottom: var(--space-3);
 }
+.stat-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+.stat-tile {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-1);
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  text-align: center;
+}
+.stat-num {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  line-height: 1;
+}
+.stat-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--ink-muted);
+}
+/* A non-zero count is work waiting on the parent, so the tile warms up. */
+.stat-tile.attention { background: var(--warning-wash); }
+.stat-tile.attention .stat-num { color: var(--warning); }
+/* The decision cards only exist when a tile is non-zero; give them room
+   from the tile row without spending it when the containers are empty. */
+#p-pending:not(:empty),
+#p-reward-requests:not(:empty) { margin-top: var(--space-3); }
 .parent-card,
 .parent-list-card {
   background: var(--surface);
@@ -1703,11 +1736,21 @@ button.parent-list-row:active { transform: scale(0.99); }
       <!-- Work waiting on the parent comes first. This is the tab they land on,
            and everything below is context for a decision, not a decision. -->
       <section class="parent-section">
-        <h2 class="parent-section-title">Awaiting your approval</h2>
+        <!-- The two waiting-on-you counts sit side by side as tiles, so the
+             numbers read at a glance instead of two stacked sections spending
+             half a screen saying nothing is here. Cards render below the row
+             only when there is actually something to decide. -->
+        <div class="stat-row">
+          <div class="stat-tile" id="p-stat-approvals">
+            <span class="stat-num">0</span>
+            <span class="stat-label">Awaiting approval</span>
+          </div>
+          <div class="stat-tile" id="p-stat-rewards">
+            <span class="stat-num">0</span>
+            <span class="stat-label">Reward requests</span>
+          </div>
+        </div>
         <div id="p-pending"></div>
-      </section>
-      <section class="parent-section">
-        <h2 class="parent-section-title">Reward requests</h2>
         <div id="p-reward-requests"></div>
       </section>
       <section class="parent-section">
@@ -2314,6 +2357,14 @@ function cycleCompletion(task) {
 // same information as one pill.
 function buildEmptyPill(text) {
   return '<div class="pill-row pill-row-start"><span class="pill neutral">' + esc(text) + '</span></div>';
+}
+
+// The count tiles at the top of Approvals.
+function setStatTile(id, count) {
+  var tile = document.getElementById(id);
+  if (!tile) return;
+  tile.querySelector('.stat-num').textContent = count;
+  tile.classList.toggle('attention', count > 0);
 }
 
 function buildEmptyState(emoji, line1, line2) {
@@ -4135,8 +4186,9 @@ function renderParent(person) {
   renderParentApprovalsSummary();
 
   var el = document.getElementById('p-pending');
+  setStatTile('p-stat-approvals', pending.length);
   if (pending.length === 0) {
-    el.innerHTML = buildEmptyPill('All caught up');
+    el.innerHTML = '';
   } else {
     el.innerHTML = pending.map(function(c) {
       var kid = state.people.find(function(k) { return k.id === c.kidId; }) || { name: '?', emoji: '❓' };
@@ -4218,8 +4270,9 @@ function renderParent(person) {
       + '</div>';
   }).join('') || buildEmptyState('👧', 'Add a kid to start assigning tasks.', 'Once a kid is added, you can assign chores from this tab.');
 
+  setStatTile('p-stat-rewards', pendingRedemptions.length);
   document.getElementById('p-reward-requests').innerHTML = pendingRedemptions.length === 0
-    ? buildEmptyPill('0 requests')
+    ? ''
     : pendingRedemptions.map(function(r) {
         var kid = state.people.find(function(k) { return k.id === r.kidId; }) || { name: '?', emoji: '❓' };
         return '<div class="card parent-card">'

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -453,14 +453,21 @@ test('Parent HQ task rows have no reorder controls', async ({ page }) => {
 });
 
 // Approvals is the tab a parent lands on. What is waiting on them has to be at
-// the top of it, not below two sections of context.
+// the top of it, not below two sections of context. The two counts are tiles
+// side by side, not stacked sections - the row must actually be a row.
 test('Approvals opens with what is waiting on the parent, at the top', async ({ page }) => {
   await pickPerson(page, 'Peter');
 
+  const tiles = page.locator('#p-tab-approvals .parent-section').first().locator('.stat-tile');
+  await expect(tiles).toHaveCount(2);
+  await expect(tiles.first()).toContainText('Awaiting approval');
+  await expect(tiles.nth(1)).toContainText('Reward requests');
+  const a = await tiles.first().boundingBox();
+  const b = await tiles.nth(1).boundingBox();
+  expect(Math.abs(a.y - b.y)).toBeLessThan(4);
+
   const headings = await page.locator('#p-tab-approvals .parent-section-title').allTextContents();
-  expect(headings[0]).toMatch(/Awaiting your approval/);
-  expect(headings[1]).toMatch(/Reward requests/);
-  expect(headings.slice(2).join(' ')).toMatch(/Today, by kid/);
+  expect(headings[0]).toMatch(/Today, by kid/);
 });
 
 // A "Waiting on you" row was a plain div - it looked actionable and did
@@ -1389,10 +1396,13 @@ test('a kid with nothing on gets one pill, not an empty state', async ({ page })
   await expect(ollie.locator('.empty')).toHaveCount(0);
 });
 
-test('empty parent sections are a pill, not a paragraph', async ({ page }) => {
+// Zero is stated once, on the tile - the card containers below stay empty
+// rather than adding a pill or a paragraph to repeat it.
+test('empty waiting sections are a zero on the tile, not filler text', async ({ page }) => {
   await pickPerson(page, 'Peter');
-  await expect(page.locator('#p-reward-requests .pill')).toContainText('0 requests');
-  await expect(page.locator('#p-reward-requests')).not.toContainText('will show up here');
+  await expect(page.locator('#p-stat-rewards .stat-num')).toHaveText('0');
+  await expect(page.locator('#p-reward-requests')).toBeEmpty();
+  await expect(page.locator('#p-tab-approvals')).not.toContainText('will show up here');
 });
 
 // The kids have photos now; the approval card was still drawing the emoji


### PR DESCRIPTION
Pete circled "Awaiting your approval / All caught up" and "Reward requests / 0 requests" — two stacked sections spending half a screen to say nothing is waiting.

They are now two rounded stat tiles side by side at the top of the Approvals tab, each a big count over a small muted label. Applies to every parent login (it's the shared Parent HQ render).

- Zero is stated once, on the tile — the "All caught up" / "0 requests" filler pills are gone and the card containers stay empty
- A non-zero tile takes the warning wash with the count in the warning colour, because it's work waiting on the parent
- Approval and reward cards render below the tile row only when they exist; jump-to-approval and all card behaviour unchanged
- Smoke: the top-of-tab test now asserts the two tiles exist, carry their labels, and sit on the same row (bounding-box y within 4px); the empty-section test asserts zero on the tile and an empty container
- Docs: design-system.md gains a "Stat tiles" section under Parent HQ

All 68 smoke tests pass; design and parse checks green. Frontend-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_