### PR TITLE
Prep opens on the day it is due, not days ahead

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -875,6 +875,15 @@ async function prepDeadlinePassed(item, now = new Date(), occ = null) {
   return Number.isFinite(lastClose) && localMinutes(now) >= lastClose;
 }
 
+// Prep opens at the start of the day it is due - "uniform on" for Thursday
+// Scouts is a Thursday action, not a Tuesday one. The deadline stays the only
+// knob: move it earlier and the open day moves with it.
+async function prepNotYetOpen(item, now = new Date(), occ = null) {
+  const occurrence = occ || currentOccurrence(item, now);
+  const { prepDueDate } = await prepDueParts(occurrence);
+  return todayStr(now) < prepDueDate;
+}
+
 // A kid ticking one item on their own prep list. requireSelf plus a check the
 // list is actually theirs - the parent-only updatePlanningItem stays the only
 // way to touch anyone else's.
@@ -894,6 +903,9 @@ async function tickPrepItem(req) {
     return { ok: false, error: 'No such item' };
   }
   const occ = currentOccurrence(item);
+  if (await prepNotYetOpen(item, new Date(), occ)) {
+    return { ok: false, error: 'Too early — this opens on the day it’s due.', notOpenYet: true };
+  }
   if (await prepDeadlinePassed(item, new Date(), occ)) {
     return { ok: false, error: 'Too late — packing closed.', windowClosed: true };
   }
@@ -926,6 +938,9 @@ async function confirmPrep(req) {
   const occ = currentOccurrence(item);
   if (list.tickedFor !== occ.date || !list.items.length || !list.items.every((entry) => entry.done)) {
     return { ok: false, error: 'Tick everything off first.' };
+  }
+  if (await prepNotYetOpen(item, new Date(), occ)) {
+    return { ok: false, error: 'Too early — this opens on the day it’s due.', notOpenYet: true };
   }
   if (await prepDeadlinePassed(item, new Date(), occ)) {
     return { ok: false, error: 'Too late — packing closed.', windowClosed: true };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2029,13 +2029,15 @@ async function main() {
   // points are gone but the event stays.
   const { ROUTES: R } = require('./src/functions/hero.js');
 
-  // Sunday soccer: two local days ahead, so tonight is not yet the night
-  // before and nothing can close it.
+  // Sunday soccer, two local days ahead - with the deadline overridden to
+  // tonight, which is also what OPENS it today: prep is tickable only on the
+  // day it is due, and the pinned clock reads ~noon.
   const inTwoDays = new Date(at('09:00').getTime() + 2 * 86400000);
   const soccerEvent = await R.addPlanningItem({
     parentId: 'peter', parentPin: '1234',
     type: 'event', title: 'Soccer', personId: 'ollie',
     startAt: inTwoDays.toISOString(),
+    prepDueBy: at('22:00').toISOString(),
     prepLists: [{ personId: 'ollie', points: 10, items: [
       { text: 'boots' }, { text: 'water bottle' },
     ] }],
@@ -2071,6 +2073,23 @@ async function main() {
   const prepRows = twice.completions.filter((c) => c.id === `prep-${soccerEvent.item.id}-${soccerOccDate}-ollie`);
   assert.strictEqual(prepRows.length, 1, 'and creates nothing new');
   console.log('\u2713 confirming twice cannot double the reward');
+
+  // Prep opens on the day it is due. Thursday Scouts' "uniform on" is not a
+  // Tuesday tick: with the default night-before deadline, an event two days
+  // out is due tomorrow, so today is too early - refused as such, not as
+  // "too late".
+  const scoutsSoon = await R.addPlanningItem({
+    parentId: 'peter', parentPin: '1234', type: 'event', title: 'Scouts night',
+    personId: 'toby', startAt: inTwoDays.toISOString(),
+    prepLists: [{ personId: 'toby', points: 3, items: [{ text: 'Uniform on' }] }],
+  });
+  assert.strictEqual(scoutsSoon.ok, true);
+  const tooEarlyTick = await R.tickPrepItem({
+    personId: 'toby', pin: '1234', planningItemId: scoutsSoon.item.id, itemIndex: 0, done: true,
+  });
+  assert.strictEqual(tooEarlyTick.ok, false, 'a tick before the due day is refused');
+  assert.strictEqual(tooEarlyTick.notOpenYet, true, 'and flagged too early, not too late');
+  console.log('\u2713 prep cannot be ticked before the day it is due');
 
   // The night before, after the last window: too late to tick or confirm,
   // and the sweep records the miss. Event TOMORROW, "now" tonight at 21:30.
@@ -2155,7 +2174,8 @@ async function main() {
   // separately each week, and last week's ticks never carry over.
   const { currentOccurrence } = require('./src/functions/hero.js');
 
-  const cubsStart2 = new Date(at('17:30').getTime() + 26 * 3600000); // tomorrow 19:30ish local? no: +26h from 17:30 today
+  // Tonight, so week one's prep is due (and therefore open) today.
+  const cubsStart2 = new Date(at('17:30').getTime() + 3 * 3600000);
   const weekly = await R.addPlanningItem({
     parentId: 'peter', parentPin: '1234', type: 'event', title: 'Weekly Cubs',
     personId: null, startAt: cubsStart2.toISOString(), recurrence: 'weekly',

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -403,6 +403,12 @@ night is the thing rewarded** — not attending. The rules, all settled:
   (`prepDeadlinePassed`), with an optional per-event `prepDueBy` ISO override
   winning when set. After it: ticking and confirming are refused with
   `windowClosed: true`, and the sweep records `prep-miss-<itemId>-<kidId>`.
+- **Prep opens on the day it is due** (`prepNotYetOpen`): Thursday's "uniform
+  on" is a Thursday action, not a Tuesday tick. Before the due day, ticking
+  and confirming are refused with `notOpenYet: true`, and the kid card
+  renders the checklist locked under a neutral "🔒 Opens Thu · by 5:30pm"
+  chip. The deadline stays the only knob — set it earlier and the open day
+  moves with it.
 - **A kid ticks only their own list** — `tickPrepItem` is `requireSelf` plus
   a personId match; the parent-only `updatePlanningItem` remains the only way
   to touch anyone else's.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2672,11 +2672,15 @@ function glanceEventCard(item, kidId) {
     var missed = (state.completions || []).some(function(c) {
       return c.id === 'prep-miss-' + item.id + '-' + occDate + '-' + kidId;
     });
+    // Prep opens on the day it is due - Thursday's "uniform on" is a
+    // Thursday action, not a Tuesday one. The server refuses early ticks
+    // too; this just stops the card offering them.
+    var notYetOpen = !!item.prepDueDate && item.prepDueDate > todayStr();
     // Ticks belong to one occurrence; a stale tickedFor means an untouched
     // week however the flags look.
     var ticksCount = list.tickedFor === occDate;
     var allTicked = ticksCount && list.items.every(function(entry) { return entry.done; });
-    var locked = missed || confirmed || !isLive;
+    var locked = missed || confirmed || !isLive || notYetOpen;
     var rows = list.items.map(function(entry, index) {
       var ticked = ticksCount && entry.done;
       return '<label class="prep-item' + (ticked ? ' done' : '') + (locked ? ' locked' : '') + '">'
@@ -2694,6 +2698,10 @@ function glanceEventCard(item, kidId) {
       chips.push('<span class="pill bad">⏳ Closed' + (dueLabel ? ' ' + esc(dueLabel) : '') + (list.points ? ' · ' + list.points + ' pts gone' : '') + '</span>');
     } else if (!isLive) {
       chips.push('<span class="pill neutral">Opens after this week\u2019s</span>');
+      if (list.points) chips.push('<span class="pill neutral">⭐ ' + list.points + '</span>');
+    } else if (notYetOpen) {
+      chips.push('<span class="pill neutral">🔒 Opens ' + esc(prepDueDayLabel(item))
+        + (item.prepDueTime ? ' · by ' + esc(prepDueTimeLabel(item)) : '') + '</span>');
       if (list.points) chips.push('<span class="pill neutral">⭐ ' + list.points + '</span>');
     } else {
       chips.push('<span class="pill warn">⏳ by ' + esc(dueLabel || 'the deadline') + '</span>');
@@ -2729,22 +2737,29 @@ function setTodayHeaderDate() {
   if (el) el.textContent = todayHeaderLabel();
 }
 
-function prepDueLabel(item) {
-  if (!item.prepDueDate || !item.prepDueTime) return '';
+function prepDueTimeLabel(item) {
+  if (!item.prepDueTime) return '';
   var parts = item.prepDueTime.split(':');
   var hour = Number(parts[0]);
   var suffix = hour >= 12 ? 'pm' : 'am';
   var displayHour = hour % 12 === 0 ? 12 : hour % 12;
-  var time = displayHour + (parts[1] === '00' ? '' : ':' + parts[1]) + suffix;
+  return displayHour + (parts[1] === '00' ? '' : ':' + parts[1]) + suffix;
+}
+
+function prepDueDayLabel(item) {
+  if (!item.prepDueDate) return '';
   var today = todayStr();
+  if (item.prepDueDate === today) return 'today';
   var tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
   var tomorrowStr = tomorrow.getFullYear() + '-' + String(tomorrow.getMonth() + 1).padStart(2, '0') + '-' + String(tomorrow.getDate()).padStart(2, '0');
-  var day;
-  if (item.prepDueDate === today) day = 'today';
-  else if (item.prepDueDate === tomorrowStr) day = 'tomorrow';
-  else day = new Date(item.prepDueDate + 'T12:00:00').toLocaleDateString([], { weekday: 'short' });
-  return day + ' ' + time;
+  if (item.prepDueDate === tomorrowStr) return 'tomorrow';
+  return new Date(item.prepDueDate + 'T12:00:00').toLocaleDateString([], { weekday: 'short' });
+}
+
+function prepDueLabel(item) {
+  if (!item.prepDueDate || !item.prepDueTime) return '';
+  return prepDueDayLabel(item) + ' ' + prepDueTimeLabel(item);
 }
 
 async function tickPrep(planningItemId, itemIndex, done) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -1039,13 +1039,15 @@ test('a kid can tick their prep list and confirm packed', async ({ page }) => {
       body: JSON.stringify(body),
     }).then((r) => r.json());
     const state = await post({ action: 'state' });
-    // Two local days ahead, so the night-before deadline cannot be shut
-    // whatever hour this runs.
+    // Two local days ahead, with the deadline overridden to tonight: prep
+    // only opens on the day it is due, and the harness pins local time to
+    // ~noon, so now+8h is this evening - open, not yet closed.
     const start = new Date(new Date(state.today + 'T12:00:00Z').getTime() + 2 * 86400000);
     const made = await post({
       action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
       type: 'event', title: 'Soccer match', personId: 'ollie',
       startAt: start.toISOString(),
+      prepDueBy: new Date(Date.now() + 8 * 3600000).toISOString(),
       prepLists: [{ personId: 'ollie', points: 10, items: [{ text: 'boots' }, { text: 'shin pads' }] }],
     });
     return made.item.id;
@@ -1104,6 +1106,47 @@ test('a kid can tick their prep list and confirm packed', async ({ page }) => {
       body: JSON.stringify(body),
     }).then((r) => r.json());
     await real({ action: 'deletePlanningItem', planningItemId: id, parentId: 'peter', parentPin: '1234' });
+  }, eventId);
+});
+
+// Thursday's "uniform on" is a Thursday action, not a Tuesday one: prep only
+// opens on the day it is due. An event two days out (default night-before
+// deadline: due tomorrow) must render locked today, saying when it opens.
+test('prep days away is locked until its due day', async ({ page }) => {
+  const eventId = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const state = await post({ action: 'state' });
+    const start = new Date(new Date(state.today + 'T12:00:00Z').getTime() + 2 * 86400000);
+    const made = await post({
+      action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
+      type: 'event', title: 'Scouts night', personId: 'toby',
+      startAt: start.toISOString(),
+      prepLists: [{ personId: 'toby', points: 3, items: [{ text: 'Uniform on' }] }],
+    });
+    return made.item.id;
+  });
+
+  await page.reload();
+  await pickPerson(page, 'Toby');
+
+  const card = page.locator('.task', { hasText: 'Scouts night' }).first();
+  await expect(card).toBeVisible();
+  await expect(card.locator('.event-chips .pill', { hasText: /🔒 Opens/ })).toHaveCount(1);
+  await expect(card.locator('.event-chips .pill.warn')).toHaveCount(0);
+  await expect(card.locator('.prep-item input').first()).toBeDisabled();
+  await expect(card.getByRole('button', { name: /packed/i })).toHaveCount(0);
+
+  await page.evaluate(async (id) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({ action: 'deletePlanningItem', planningItemId: id, parentId: 'peter', parentPin: '1234' });
   }, eventId);
 });
 


### PR DESCRIPTION
Closes #222.

Pete's screenshot: Tuesday, and Thursday's "Scouts uniform on" was tickable now. Prep had a deadline but no opening time.

**One rule, no new settings: prep opens at the start of the day it's due, and closes at its deadline.**

- Scouts (due Thu 5:30pm) → tickable Thursday only, until 5:30pm
- Soccer (due Sat 9pm, the night before Sunday's game) → tickable all Saturday
- Cubs (due Mon 5:30pm) → tickable Monday
- Want an earlier packing window? Set the deadline earlier — the open day moves with it. `prepDueBy` stays the only knob.

Changes:

- API: `prepNotYetOpen` mirrors `prepDeadlinePassed`; `tickPrepItem` and `confirmPrep` refuse early ticks with `notOpenYet: true`
- Kid card: before the due day the checklist renders locked under a neutral "🔒 Opens Thu · by 5:30pm" chip (future weeks of a repeating event keep their "Opens after this week's" chip); on the due day it behaves exactly as today
- The miss sweep is untouched — it was already deadline-based
- The seeded examples already do the right thing under the new rule: Scouts opens Thursday, Cubs Monday, soccer Saturday

Tests: logic suite gains the too-early refusal (and the weekly/soccer fixtures move their deadlines onto the pinned-clock day so they're open when ticked); smoke gains a locked-state case and now runs 69. All green locally, design/frontend checks pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_