### PR TITLE
The active kid tab wears a pill behind its icon

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -816,6 +816,10 @@ Concretely, in this app:
   meta, never for something a kid needs to read or act on.
 - **Round icon buttons in the tab bar**, at least 44px, well spaced. Icons alone
   are fine there; everywhere else an icon needs a label.
+- **The active tab wears a pill behind its icon** (`--brand-wash` on
+  `.tab-icon`, the Material bottom-nav convention) with the label in
+  `--brand`, bold. Colour alone cannot mark these tabs — the icons are emoji,
+  which never tint.
 
 ### Calibrating the age
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -661,8 +661,18 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   padding: var(--space-2) var(--space-1);
 }
 .tab-btn:active { transform: scale(0.97); }
-.tab-btn .tab-icon { font-size: 1.4rem; line-height: 1; }
-.tab-btn.active { color: var(--brand); }
+/* The active indicator is a pill behind the icon (the Material bottom-nav
+   convention). Colour alone cannot mark these tabs: the icons are emoji,
+   which never tint, so without the pill only the tiny label changed. */
+.tab-btn .tab-icon {
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  transition: background var(--dur-fast) var(--ease-out);
+}
+.tab-btn.active { color: var(--brand); font-weight: var(--weight-bold); }
+.tab-btn.active .tab-icon { background: var(--brand-wash); }
 
 /* ─── Section titles ──────────────────────────────────────────────────── */
 .section-title {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -627,6 +627,29 @@ for (const bp of BREAKPOINTS) {
   });
 }
 
+// Emoji icons never tint, so colour alone cannot say which tab you are on:
+// the active tab carries a pill behind its icon (the Material bottom-nav
+// convention), and it must follow a tab switch.
+test('the active tab wears a pill behind its icon, and it moves on switch', async ({ page }) => {
+  await pickPerson(page, 'Toby');
+
+  // The pill fades via a CSS transition, so poll on its settled alpha
+  // rather than reading mid-fade: > 0.5 is worn, < 0.05 is bare.
+  const iconAlpha = (tab) => page.locator(`#tabbtn-${tab} .tab-icon`)
+    .evaluate((el) => {
+      const bg = getComputedStyle(el).backgroundColor;
+      const m = bg.match(/rgba?\([\d\s,]+?(?:,\s*([\d.]+))?\)/);
+      return m && m[1] !== undefined ? Number(m[1]) : (bg === 'rgba(0, 0, 0, 0)' ? 0 : 1);
+    });
+
+  await expect.poll(() => iconAlpha('home')).toBeGreaterThan(0.5);
+  await expect.poll(() => iconAlpha('missions')).toBeLessThan(0.05);
+
+  await page.locator('#tabbtn-missions').click();
+  await expect.poll(() => iconAlpha('missions')).toBeGreaterThan(0.5);
+  await expect.poll(() => iconAlpha('home')).toBeLessThan(0.05);
+});
+
 test('content is capped and centred on a wide screen, not stretched', async ({ page }) => {
   await page.setViewportSize({ width: 1920, height: 1080 });
   await pickPerson(page, 'Ollie');


### PR DESCRIPTION
Closes #224.

Pete asked which is the standard way to show which tab you're on: per-screen headers, an underline, or a pill behind the active icon. The pill is the standard — Material Design's bottom navigation uses exactly that (iOS tints the active icon instead, but our icons are emoji, which never tint — which is why the current active state was invisible: only the tiny label turned purple).

- The active kid tab's icon now sits on a rounded `--brand-wash` pill, with the label in brand purple and bold; the pill fades between tabs with the existing fast transition
- No new headers — the tab bar itself now says where you are
- Parent HQ is unchanged: its filled choice-pills already are this convention
- Smoke: new test asserts the pill sits behind the active icon and moves on a tab switch, polling the settled transition alpha rather than reading mid-fade; suite is now 70, all green
- Docs: design-system.md tab-bar rules gain the active-pill convention

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_