### PR TITLE
Approvals tab drops Yesterday and Today &amp; this week

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -370,20 +370,18 @@ grabs."*
 
 ### The family view
 
-Parent HQ's Approvals tab is the family's one screen, in this order: what's
-waiting on you, reward requests, **Today by kid**, **Yesterday**, today &
-this week, recently decided.
+Parent HQ's Approvals tab is decisions plus today's state, in this order:
+the stat tiles, what's waiting on you, reward requests, **Today by kid**
+(with a View calendar action), recently decided. There is deliberately no
+Yesterday and no This-week section here — the Calendar tab owns the wider
+view, and a day's agenda is one tap on it.
 
 - **Today by kid** counts misses as their own pill (`.pill.bad`, "2 missed")
   alongside pending, and "All caught up" only appears when there are neither.
   A row whose window shut on it is tagged **Missed** (`.tag.missed`), not
   "Not started" — which would understate a door that has already closed.
-- **Yesterday** renders per kid from the completion records alone: done,
-  sent back, missed, each with the points that were at stake. This panel is
-  what the whole windows-and-misses build exists to feed — until misses were
-  recorded there was nothing truthful it could have said. Yesterday's date is
-  derived from `state.today` (the API's local day), minus one day at UTC
-  noon, so no timezone can shift it.
+  Misses still reach the parent here and in the evening summary push; the
+  per-day history lives on the Calendar tab.
 
 Smoke-testing note: the suite's store is shared across the whole run, so a
 test that seeds chores for a kid must retire them (`deleteTask`) before

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1775,17 +1775,15 @@ button.parent-list-row:active { transform: scale(0.99); }
         <div id="p-pending"></div>
         <div id="p-reward-requests"></div>
       </section>
+      <!-- No Yesterday or This-week sections here: the Calendar tab owns the
+           wider view, and a day's agenda is one tap on it. This tab is the
+           decisions and today's state, nothing else. -->
       <section class="parent-section">
         <h2 class="parent-section-title">Today, by kid</h2>
         <div id="p-approvals-today-by-kid"></div>
-      </section>
-      <section class="parent-section">
-        <h2 class="parent-section-title">Yesterday</h2>
-        <div id="p-yesterday"></div>
-      </section>
-      <section class="parent-section">
-        <h2 class="parent-section-title">Today &amp; this week</h2>
-        <div id="p-approvals-glance"></div>
+        <div class="parent-actions">
+          <button class="btn ghost small" onclick="switchParentTab('calendar')">View calendar</button>
+        </div>
       </section>
       <section class="parent-section">
         <h2 class="parent-section-title">Recently decided</h2>
@@ -3139,113 +3137,6 @@ function parentCalendarOverviewStatus(item) {
   return { className: 'waiting', label: 'Waiting on you' };
 }
 
-function renderParentGlanceRows(items, emptyText) {
-  if (!items.length) return '<div class="sub">' + esc(emptyText) + '</div>';
-  return '<div class="parent-list">' + items.map(function(item) {
-    var notes = item.notes ? '<div class="sub">📝 ' + esc(item.notes) + '</div>' : '';
-    return '<div class="parent-list-row">'
-      + '<div class="parent-copy">'
-      + '<span class="parent-list-title">' + esc(item.title || 'Untitled') + '</span>'
-      + '<div class="sub"><span class="tag parent-calendar-kind">' + esc(item.kind || 'item') + '</span>'
-      + ' · ' + esc(parentCalendarItemTime(item))
-      + ' · ' + esc(parentCalendarWho(item))
-      + (item.kind === 'chore' && item.points ? ' · ' + item.points + ' pts' : '')
-      + '</div>'
-      + notes
-      + '</div>'
-      + '</div>';
-  }).join('') + '</div>';
-}
-
-function renderParentApprovalsGlance() {
-  var el = document.getElementById('p-approvals-glance');
-  if (!el) return;
-  if (parentApprovalsGlanceLoading || !parentApprovalsGlanceLoaded) {
-    el.innerHTML = parentCalendarSkeletonHtml();
-    return;
-  }
-  var todayKey = todayStr();
-  var undecided = (parentApprovalsGlanceItems || []).filter(function(item) {
-    return item.kind !== 'chore' || !parentCalendarIsComplete(item);
-  });
-  var todayItems = undecided
-    .filter(function(item) { return parentCalendarDayKey(item) === todayKey; })
-    .sort(parentCalendarSortWhen);
-  var weekItems = undecided
-    .filter(function(item) { return parentCalendarDayKey(item) !== todayKey; })
-    .sort(parentCalendarSortWhen);
-  var nothingScheduled = todayItems.length === 0 && weekItems.length === 0;
-  el.innerHTML = (nothingScheduled
-      ? buildEmptyPill('Nothing scheduled')
-      : '<div class="card parent-card">'
-        + '<h3 class="parent-section-title">Today <span class="section-date">' + esc(todayHeaderLabel()) + '</span></h3>'
-        + renderParentGlanceRows(todayItems, 'Nothing today.')
-        + '</div>'
-        + '<div class="card parent-card">'
-        + '<h3 class="parent-section-title">This week</h3>'
-        + renderParentGlanceRows(weekItems, 'Nothing else this week.')
-        + '</div>')
-    + '<div class="parent-actions">'
-    + '<button class="btn ghost small" onclick="switchParentTab(\'calendar\')">View calendar</button>'
-    + '</div>';
-}
-
-// Yesterday, per kid: done and missed, from the completion records alone.
-// This is the panel the whole windows-and-misses build exists to feed - until
-// misses were recorded, every morning looked identical however the day before
-// went, and there was nothing truthful this panel could have said.
-function renderParentYesterday() {
-  var el = document.getElementById('p-yesterday');
-  if (!el) return;
-  // The API's own idea of today, minus one day at UTC noon so no timezone can
-  // shift it across midnight. Falls back to the browser only if state is old
-  // enough to predate the field.
-  var todayKey = (state && state.today) || todayStr();
-  var yesterdayKey = new Date(new Date(todayKey + 'T12:00:00Z').getTime() - 86400000)
-    .toISOString().slice(0, 10);
-  var rows = (state.completions || []).filter(function(c) {
-    return c.date === yesterdayKey && c.taskId;
-  });
-  if (rows.length === 0) {
-    el.innerHTML = buildEmptyPill('Nothing recorded yesterday');
-    return;
-  }
-  var kids = kidsOnly();
-  el.innerHTML = kids.map(function(kid) {
-    var mine = rows.filter(function(c) { return c.kidId === kid.id; });
-    if (mine.length === 0) return '';
-    var done = mine.filter(function(c) { return c.status === 'approved' || c.status === 'pending' || c.status === 'queued'; }).length;
-    var missed = mine.filter(function(c) { return c.status === 'missed'; }).length;
-    var pills = (done > 0 ? '<span class="pill good">' + done + ' done</span>' : '')
-      + (missed > 0 ? '<span class="pill bad">' + missed + ' missed</span>' : '');
-    return '<div class="card parent-card">'
-      + '<div class="parent-item-head">'
-      + '<div class="parent-copy parent-kid-line">'
-      + '<span class="parent-kid-face">' + renderAvatarHtml(kid.emoji, 'var(--brand)', 'head') + '</span>'
-      + '<strong>' + esc(kid.name) + '</strong>'
-      + '</div>'
-      + '<div class="pill-row">' + pills + '</div>'
-      + '</div>'
-      + '<div class="parent-list">' + mine.map(function(c) {
-          var tag = c.status === 'missed'
-            ? { className: 'missed', label: 'Missed' }
-            : c.status === 'approved'
-              ? { className: 'approved', label: 'Done' }
-              : c.status === 'rejected'
-                ? { className: 'rejected', label: 'Sent back' }
-                : { className: 'waiting', label: 'Waiting on you' };
-          return '<div class="parent-list-row">'
-            + '<div class="parent-copy">'
-            + '<span class="parent-list-title">' + esc(c.title || 'Untitled') + '</span>'
-            + (c.points ? '<div class="sub">' + c.points + ' pts</div>' : '')
-            + '</div>'
-            + '<span class="tag ' + tag.className + '">' + tag.label + '</span>'
-            + '</div>';
-        }).join('') + '</div>'
-      + '</div>';
-  }).join('') || buildEmptyPill('Nothing recorded yesterday');
-}
-
 function renderParentApprovalsTodayByKid() {
   var el = document.getElementById('p-approvals-today-by-kid');
   if (!el) return;
@@ -3336,9 +3227,7 @@ function jumpToApproval(completionId) {
 }
 
 function renderParentApprovalsSummary() {
-  renderParentApprovalsGlance();
   renderParentApprovalsTodayByKid();
-  renderParentYesterday();
 }
 
 function renderParentCalendarChecklists(item) {

--- a/scripts/check-frontend.js
+++ b/scripts/check-frontend.js
@@ -109,11 +109,12 @@ check(/action:\s*'addPlanningItem'/.test(html), 'parent calendar form calls addP
 check(/action:\s*'updatePlanningItem'/.test(html), 'parent calendar edit calls updatePlanningItem');
 check(/action:\s*'deletePlanningItem'/.test(html), 'parent calendar delete calls deletePlanningItem');
 check(/id="p-approvals-badge"/.test(html), 'approvals badge exists');
-check(/id="p-approvals-glance"/.test(html), 'approvals tab includes at-a-glance container');
-check(/Today &amp; this week/.test(html), 'approvals tab includes Today & this week title');
+// The Approvals tab is decisions plus today's state, nothing else: no
+// Yesterday and no This-week sections - the Calendar tab owns those.
+check(!/id="p-approvals-glance"/.test(html), 'approvals tab has no at-a-glance section (Calendar owns the week)');
+check(!/id="p-yesterday"/.test(html), 'approvals tab has no Yesterday section (Calendar owns the past)');
 check(/id="p-approvals-today-by-kid"/.test(html), 'approvals tab includes today-by-kid container');
 check(/Today, by kid/.test(html), 'approvals tab includes Today, by kid title');
-const approvalsGlanceIndex = html.indexOf('id="p-approvals-glance"');
 const approvalsTodayByKidIndex = html.indexOf('id="p-approvals-today-by-kid"');
 const approvalsPendingIndex = html.indexOf('id="p-pending"');
 // Work waiting on the parent comes first on the tab they land on. These
@@ -121,21 +122,18 @@ const approvalsPendingIndex = html.indexOf('id="p-pending"');
 // were updated rather than dropped - the point is that the order is deliberate.
 const approvalsRewardReqIndex = html.indexOf('id="p-reward-requests"');
 check(approvalsPendingIndex !== -1 && approvalsTodayByKidIndex !== -1 && approvalsPendingIndex < approvalsTodayByKidIndex, 'pending approvals list appears before today-by-kid section');
-check(approvalsPendingIndex !== -1 && approvalsGlanceIndex !== -1 && approvalsPendingIndex < approvalsGlanceIndex, 'pending approvals list appears before at-a-glance section');
 check(approvalsRewardReqIndex !== -1 && approvalsTodayByKidIndex !== -1 && approvalsRewardReqIndex < approvalsTodayByKidIndex, 'reward requests appear before today-by-kid section');
-check(approvalsTodayByKidIndex !== -1 && approvalsGlanceIndex !== -1 && approvalsTodayByKidIndex < approvalsGlanceIndex, 'today-by-kid section appears before at-a-glance section');
 check(/onclick="jumpToApproval\(/.test(html), 'waiting-on-you rows link through to their approval');
 check(/id="p-pending-' \+ c\.id \+ '"/.test(html), 'pending approval cards carry an id to jump to');
-check(/function loadParentApprovalsGlance\(\)/.test(html), 'approvals at-a-glance loader exists');
-check(/action:\s*'calendar'[\s\S]*parentId:\s*session\.personId[\s\S]*parentPin:\s*session\.pin/.test(html), 'approvals at-a-glance reuses calendar action with parent credentials');
-check(/function renderParentApprovalsGlance\(\)/.test(html), 'approvals at-a-glance renderer exists');
+check(/function loadParentApprovalsGlance\(\)/.test(html), 'calendar-backed approvals loader exists (feeds today-by-kid)');
+check(/action:\s*'calendar'[\s\S]*parentId:\s*session\.personId[\s\S]*parentPin:\s*session\.pin/.test(html), 'approvals loader reuses calendar action with parent credentials');
 check(/function parentCalendarLiveCompletion\(item\)/.test(html), 'calendar live completion matcher exists');
 check(/function parentCalendarOverviewStatus\(item\)/.test(html), 'calendar overview status helper exists');
 check(/function renderParentApprovalsTodayByKid\(\)/.test(html), 'approvals today-by-kid renderer exists');
 check(/function renderParentApprovalsSummary\(\)/.test(html), 'approvals summary renderer exists');
 check(/\.tag\.waiting\s*\{\s*background:\s*var\(--warning-wash\);\s*color:\s*var\(--warning\);\s*\}/.test(html), 'waiting tag uses warning tokens');
 check(/item\.kind === 'chore' && item\.kidId === kid\.id && parentCalendarDayKey\(item\) === todayKey/.test(html), 'today-by-kid renderer filters today chore occurrences per kid');
-check(/switchParentTab\('calendar'\)|switchParentTab\\\('calendar'\\\)/.test(html), 'approvals at-a-glance includes View calendar action');
+check(/switchParentTab\('calendar'\)|switchParentTab\\\('calendar'\\\)/.test(html), 'today-by-kid offers a View calendar action');
 check(/parentEditTask\(\\'/.test(html), 'task rows wire an Edit button');
 check(/id="k-voice-reminder-btn"/.test(html), 'kid Home tab includes a voice reminder button');
 check(/id="voice-reminder-modal"/.test(html), 'voice reminder confirmation modal exists');

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -894,34 +894,6 @@ test('a shut window refuses the completion at the API', async ({ page }) => {
   expect(verdict.error).toMatch(/window closed/i);
 });
 
-// The family view: yesterday, per kid, from the recorded facts. Until misses
-// were recorded there was nothing truthful this panel could have said - every
-// morning looked identical however the day before went. Yesterday-dated rows
-// cannot be created through the real routes (the API stamps today), so this
-// drives the real renderer over planted records - the same lexical `state`
-// the page itself renders from.
-test('yesterday shows each kid\u2019s done and missed, from the records', async ({ page }) => {
-  await pickPerson(page, 'Peter');
-  await page.evaluate(() => {
-    const y = new Date(new Date(state.today + 'T12:00:00Z').getTime() - 86400000)
-      .toISOString().slice(0, 10);
-    state.completions.push(
-      { id: 'y1', taskId: 't-veg', kidId: 'toby', title: 'Water the veggies', points: 3, date: y, status: 'approved' },
-      { id: 'y2', taskId: 't-bins', kidId: 'toby', title: 'Bins out', points: 5, date: y, status: 'missed' },
-    );
-    renderParentYesterday();
-  });
-
-  const tobyCard = page.locator('#p-yesterday .parent-card', { hasText: 'Toby' });
-  await expect(tobyCard).toBeVisible();
-  await expect(tobyCard.locator('.pill.good')).toContainText('1 done');
-  await expect(tobyCard.locator('.pill.bad')).toContainText('1 missed');
-  await expect(tobyCard.locator('.parent-list-row', { hasText: 'Bins out' }).locator('.tag.missed'))
-    .toContainText(/missed/i);
-  await expect(tobyCard.locator('.parent-list-row', { hasText: 'Water the veggies' }).locator('.tag.approved'))
-    .toContainText(/done/i);
-});
-
 // A miss reaches the parent's Today view as a pill and a tag, not silence.
 test('a missed chore shows on the parent\u2019s today view', async ({ page }) => {
   await page.evaluate(async () => {


### PR DESCRIPTION
Closes #226.

Pete: "the yesterday, today and this week isn't needed as that's on the calendar tab which is a really nice view of the day if you click on it."

The Approvals tab is now decisions plus today's state, nothing else:

- **Removed:** the "Yesterday" and "Today &amp; this week" sections and their renderers (~150 lines)
- **Kept:** stat tiles, pending approval cards, reward requests, "Today, by kid", "Recently decided"
- The **View calendar** shortcut moves under "Today, by kid", so the day view Pete likes stays one tap away
- The calendar-backed loader stays — "Today, by kid" is fed by it
- Misses still reach the parent via the Today-by-kid pills and the evening summary push; per-day history lives on the Calendar tab

Checks updated to enforce the new shape: `check-frontend.js` now asserts the sections are *absent*, and the Yesterday panel's smoke test goes with the panel (suite is 69, all green). Docs' family-view section updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_