### PR TITLE
Home's This Week survives the Calendar tab being in Day view

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3536,15 +3536,25 @@ async function loadKidCalendar(kid) {
   kidCalendarLoading = true;
   renderKidCalendar(kid);
   renderKidGlance(kid);
+  // The Home glance renders from this same fetch, and its promise is "today
+  // and the next seven days" whatever view the Calendar tab is in - a Day
+  // view must not empty the Home screen's This Week. Fetch the union of the
+  // calendar view's range and the glance's.
   var bounds = kidCalendarBounds();
+  var glanceStart = new Date();
+  glanceStart.setHours(0, 0, 0, 0);
+  var glanceEnd = addDays(glanceStart, 7);
+  glanceEnd.setHours(23, 59, 59, 999);
+  var fetchStart = bounds.start < glanceStart ? bounds.start : glanceStart;
+  var fetchEnd = bounds.end > glanceEnd ? bounds.end : glanceEnd;
   var result;
   try {
     result = await api({
       action: 'calendar',
       personId: session.personId,
       pin: session.pin,
-      start: bounds.start.toISOString(),
-      end: bounds.end.toISOString(),
+      start: fetchStart.toISOString(),
+      end: fetchEnd.toISOString(),
     });
   } catch (e) {
     kidCalendarLoading = false;

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -285,6 +285,46 @@ test('the kid Home screen shows a Today and a This Week section', async ({ page 
   await expect(page.locator('#k-glance-week .glance-skel')).toHaveCount(0);
 });
 
+// The Home glance shares one fetch with the Calendar tab, but its promise is
+// "today and the next seven days" whatever view that tab is in. Before the
+// fetch was widened, switching the calendar to Day silently emptied Home's
+// This Week - Thursday's Scouts vanished from a Tuesday Home screen.
+test('Home’s This Week survives the Calendar tab being in Day view', async ({ page }) => {
+  const eventId = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const state = await post({ action: 'state' });
+    const start = new Date(new Date(state.today + 'T12:00:00Z').getTime() + 2 * 86400000);
+    const made = await post({
+      action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
+      type: 'event', title: 'Glance range probe', personId: 'toby',
+      startAt: start.toISOString(),
+    });
+    return made.item.id;
+  });
+
+  await page.reload();
+  await pickPerson(page, 'Toby');
+  await expect(page.locator('#k-glance-week')).toContainText('Glance range probe');
+
+  await page.locator('#tabbtn-calendar').click();
+  await page.locator('#calendar-view-day').click();
+  await page.locator('#tabbtn-home').click();
+  await expect(page.locator('#k-glance-week')).toContainText('Glance range probe');
+
+  await page.evaluate(async (id) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({ action: 'deletePlanningItem', planningItemId: id, parentId: 'peter', parentPin: '1234' });
+  }, eventId);
+});
+
 test('the old daily-only Missions section is gone from Home', async ({ page }) => {
   await pickPerson(page, 'Ollie');
   await expect(page.locator('#tab-home')).not.toContainText("Today's Missions");


### PR DESCRIPTION
Closes #228.

Pete: "there's scouts on Thursday which doesn't show on 'this week'?"

Root cause: the Home glance deliberately shares one fetch with the Calendar tab (one loader, one truth — #158), but the fetch range followed the calendar's *current view*. With the calendar switched to Day, the shared data only spanned today — so Home's "This Week" silently emptied and Thursday's Scouts vanished from a Tuesday Home screen.

Fix: the fetch now covers the union of the calendar view's range and the glance's own promise of today + 7 days, so the Home screen holds whatever view the Calendar tab is in. Bonus: near a weekend, "This Week" now shows early-next-week items instead of stopping at Sunday.

Smoke: new test seeds an event two days out, flips the kid calendar to Day view, returns Home, and asserts the event is still on "This Week". Suite green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_