### PR TITLE
A rejected extra comes back to the kid by name, not as "Mission"

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4072,7 +4072,10 @@ function renderRecentActivity(kid) {
   }
   el.innerHTML = decided.map(function(c) {
     var task = state.tasks.find(function(t) { return t.id === c.taskId; });
-    var title = task ? esc(task.title) : esc(c.taskTitle || 'Mission');
+    // A kid-added extra or a prep confirmation has no task behind it - its
+    // name lives on the completion itself. Falling straight to 'Mission'
+    // made a rejected "Eat food" unrecognisable to the kid it went back to.
+    var title = task ? esc(task.title) : esc(c.title || c.taskTitle || 'Mission');
     var pts   = task ? task.points : (c.points || 0);
     var isApproved = c.status === 'approved';
     var isMissed = c.status === 'missed';

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -639,6 +639,35 @@ test('a plain approve goes straight through with no dialog', async ({ page }) =>
   await expect(card).toBeHidden();
 });
 
+// A kid-added extra has no task behind it, so its name lives on the
+// completion itself. Recent activity fell straight to 'Mission' for those,
+// which made a rejected "Eat food" unrecognisable to the kid it went back to.
+test('a rejected extra comes back to the kid by name, with the note', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({ action: 'addExtra', kidId: 'ollie', personId: 'ollie', pin: '1234', title: 'Washed the car' });
+  });
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-pending .parent-card').filter({ hasText: 'Washed the car' });
+  await card.locator('.approve-note').fill('Still soapy — rinse it and show me.');
+  await card.getByRole('button', { name: /Try again/ }).click();
+  await expect(card).toBeHidden();
+
+  await page.getByRole('button', { name: /Switch user/ }).click();
+  await pickPerson(page, 'Ollie');
+  const row = page.locator('#k-activity .task', { hasText: 'Washed the car' });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(/try again/i);
+  await expect(row).toContainText('Still soapy — rinse it and show me.');
+  await expect(page.locator('#k-activity')).not.toContainText(/^Mission$/);
+});
+
 // #174. The app installs on desktops. With no maximum width a task row
 // stretched to ~1900px to hold thirty characters, at phone type scale.
 //


### PR DESCRIPTION
Closes #230.

Pete rejected Ollie's kid-added "Eat food" with a try-again note and it seemed to never reach Ollie. It did reach him — in Home's Recent activity — but labelled **"Mission"**: extras (and prep confirmations) have no task behind them, their name lives on the completion itself (`title`), and the renderer only read `taskTitle`, which just offline-queued chores carry.

The title now falls through `c.title` → `c.taskTitle` → "Mission". Real chores sent back were already working: the chore reappears on the kid's list to redo, with the note in Recent activity.

Smoke: new test creates an extra as Ollie, rejects it as Peter with a note via the card's note box, switches to Ollie, and asserts Recent activity names "Washed the car" with the try-again line and the note. Suite is 71, all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_