### PR TITLE
A sent-back elective sits with the kid, points on offer

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -960,8 +960,50 @@ async function confirmPrep(req) {
     });
   } catch (err) {
     if (!err || err.code !== 409) throw err;
-    // Already confirmed - not an error worth showing a kid.
+    // Already a row under this occurrence id. Confirmed or still pending:
+    // idempotent, nothing to do. But a REJECTED one silently eating the
+    // resubmit was a dead end - packing again after a send-back must put it
+    // back in front of the parent.
+    const completions = container('completions');
+    const rowId = `prep-${item.id}-${occ.date}-${personId}`;
+    const { resource: existing } = await completions
+      .item(rowId, HOUSEHOLD_ID)
+      .read()
+      .catch(() => ({ resource: null }));
+    if (existing && existing.status === 'rejected') {
+      existing.status = 'pending';
+      existing.date = todayStr();
+      existing.resubmittedAt = new Date().toISOString();
+      await completions.item(rowId, HOUSEHOLD_ID).replace(existing);
+    }
   }
+  return getState();
+}
+
+// A sent-back elective stays on offer: the kid redoes it and this puts the
+// same row back in front of the parent, points intact. giveUp withdraws it
+// instead - off the kid's Home, out of everyone's history lists.
+async function redoExtra(req) {
+  const personId = String(req.personId || '').trim();
+  await requireSelf(personId, req.pin, personId);
+  const completions = container('completions');
+  const { resource: completion } = await completions
+    .item(req.completionId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!completion || completion.kidId !== personId || completion.taskId || completion.planningItemId) {
+    return { ok: false, error: 'Not found' };
+  }
+  if (completion.status !== 'rejected') return { ok: false, error: 'Nothing to redo' };
+  if (req.giveUp) {
+    completion.status = 'withdrawn';
+    completion.decidedAt = new Date().toISOString();
+  } else {
+    completion.status = 'pending';
+    completion.date = todayStr();
+    completion.resubmittedAt = new Date().toISOString();
+  }
+  await completions.item(req.completionId, HOUSEHOLD_ID).replace(completion);
   return getState();
 }
 
@@ -1340,6 +1382,13 @@ async function reject(req) {
     completion.status = 'rejected';
     completion.comment = comment;
     completion.decidedAt = new Date().toISOString();
+    // Pricing a sent-back ELECTIVE keeps the offer alive: the points sit on
+    // the rejected row so the kid's Try-again card can show what redoing it
+    // is worth. Chores carry their points on the task, so this is extras-only.
+    if (!completion.taskId && req.points !== undefined && req.points !== null && req.points !== '') {
+      const offered = Number(req.points);
+      if (Number.isFinite(offered) && offered >= 0) completion.points = offered;
+    }
     await completions.item(req.completionId, HOUSEHOLD_ID).replace(completion);
     const quietHours = await getHouseholdQuietHours();
     await sendPushIfAllowed(completion.kidId, {
@@ -2022,6 +2071,7 @@ const ROUTES = {
   reorderMyItems,
   reorderTasks,
   tickPrepItem,
+  redoExtra,
   confirmPrep,
   clearActivity,
 };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2074,6 +2074,48 @@ async function main() {
   assert.strictEqual(prepRows.length, 1, 'and creates nothing new');
   console.log('\u2713 confirming twice cannot double the reward');
 
+  // -------------------------------------------------------------------------
+  // Sent-back electives stay on offer. Rejecting an extra can price the redo;
+  // the kid puts the same row back in front of the parent, points intact, or
+  // withdraws it. A rejected prep confirmation can be resubmitted too - the
+  // idempotency 409 used to eat that silently.
+  const extraState = await R.addExtra({ kidId: 'toby', personId: 'toby', pin: '1234', title: 'Washed the car' });
+  const extraRow = extraState.completions.find((c) => c.title === 'Washed the car');
+  const pricedReject = await R.reject({
+    parentId: 'peter', parentPin: '1234', completionId: extraRow.id,
+    comment: 'Still soapy - rinse it.', points: 15,
+  });
+  assert.strictEqual(pricedReject.ok, undefined === pricedReject.ok ? pricedReject.ok : pricedReject.ok, 'reject ran');
+  const afterReject = (await R.state()).completions.find((c) => c.id === extraRow.id);
+  assert.strictEqual(afterReject.status, 'rejected');
+  assert.strictEqual(afterReject.points, 15, 'the offer is stored on the sent-back elective');
+
+  const wrongRedo = await R.redoExtra({ personId: 'ollie', pin: '1234', completionId: extraRow.id });
+  assert.strictEqual(wrongRedo.ok, false, "another kid cannot redo someone else's elective");
+
+  await R.redoExtra({ personId: 'toby', pin: '1234', completionId: extraRow.id });
+  const resub = (await R.state()).completions.find((c) => c.id === extraRow.id);
+  assert.strictEqual(resub.status, 'pending', 'redo puts the same row back in front of the parent');
+  assert.strictEqual(resub.points, 15, 'with the offer intact');
+  console.log('\u2713 a priced send-back stays on offer and resubmits with its points');
+
+  const extraState2 = await R.addExtra({ kidId: 'toby', personId: 'toby', pin: '1234', title: 'Weeded the path' });
+  const extraRow2 = extraState2.completions.find((c) => c.title === 'Weeded the path');
+  await R.reject({ parentId: 'peter', parentPin: '1234', completionId: extraRow2.id, comment: 'Half done.', points: 4 });
+  await R.redoExtra({ personId: 'toby', pin: '1234', completionId: extraRow2.id, giveUp: true });
+  const withdrawn = (await R.state()).completions.find((c) => c.id === extraRow2.id);
+  assert.strictEqual(withdrawn.status, 'withdrawn', 'bowing out withdraws the row');
+  console.log('\u2713 a kid can bow out of a sent-back elective');
+
+  // Rejected prep, packed again: the 409 path must flip it back to pending.
+  const soccerPrepId = `prep-${soccerEvent.item.id}-${soccerOccDate}-ollie`;
+  await R.reject({ parentId: 'peter', parentPin: '1234', completionId: soccerPrepId, comment: 'Boots are muddy.' });
+  const rePacked = await R.confirmPrep({ personId: 'ollie', pin: '1234', planningItemId: soccerEvent.item.id });
+  assert.strictEqual(rePacked.ok, undefined === rePacked.ok ? rePacked.ok : rePacked.ok, 'confirm ran');
+  const prepAgain = (await R.state()).completions.find((c) => c.id === soccerPrepId);
+  assert.strictEqual(prepAgain.status, 'pending', 'packing again after a send-back re-pends the same row');
+  console.log('\u2713 a rejected prep confirmation can be resubmitted');
+
   // Prep opens on the day it is due. Thursday Scouts' "uniform on" is not a
   // Tuesday tick: with the default night-before deadline, an event two days
   // out is due tomorrow, so today is too early - refused as such, not as

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -768,6 +768,19 @@ Same tokens, different register:
 - Density over generosity — a parent scanning approvals wants to see more at once
 - **No celebration animations.** Approving is administration, not achievement.
 
+### Sent-back electives stay on offer
+
+Rejecting a kid-added extra asks what redoing it is worth (after the note);
+the points sit on the rejected row. The kid's Home shows it as a Try-again
+card — name, the offer, the parent's note — with one tap to resubmit the
+same row (points intact, `redoExtra`) or bow out (`giveUp` → withdrawn,
+which drops it from every history list). No expiry: electives have no
+window, so the card stays until acted on. Approving a priced extra prefills
+the points prompt with the offer. Must-do chores keep their behaviour:
+points on the task, bounce back under the existing window rules. A rejected
+prep confirmation resubmits through `confirmPrep` — the idempotency 409
+flips a rejected row back to pending instead of silently eating the redo.
+
 ### Decision notes
 
 Each pending approval card carries one optional note box (`.approve-note`)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1649,6 +1649,9 @@ button.parent-list-row:active { transform: scale(0.99); }
             <div id="k-glance-week"></div>
           </section>
         </div>
+        <!-- Sent-back electives: the offer stays open, no window, until the
+             kid redoes it or bows out. -->
+        <div id="k-redo"></div>
         <div class="kid-home-actions">
           <button class="btn ghost" onclick="addExtraPrompt()">➕ I did something extra!</button>
           <button class="btn voice-trigger" id="k-voice-reminder-btn" onclick="openVoiceReminderFlow()">🎤 Add a voice reminder</button>
@@ -2518,6 +2521,7 @@ function renderKid(kid) {
   renderRewardShop(kid, balance);
   renderRewardProgress(balance);
   renderRedemptions(kid);
+  renderRedoExtras(kid);
   renderRecentActivity(kid);
   renderKidCalendar(kid);
   renderKidGlance(kid);
@@ -4146,7 +4150,10 @@ function renderParent(person) {
         + '<div class="parent-copy">'
         + '<strong>' + esc(kid.name) + '</strong>'
         + '<div>' + esc(c.title) + (isExtra ? ' <span class="tag extra">kid-added</span>' : '') + '</div>'
-        + '<div class="sub">' + c.date + (isExtra ? '' : ' · worth ' + c.points + ' pts') + '</div>'
+        + '<div class="sub">' + c.date
+        + (isExtra
+            ? (c.points ? ' · offered ' + c.points + ' pts' : '')
+            : ' · worth ' + c.points + ' pts') + '</div>'
         + '</div>'
         + '</div>'
         + '<input class="approve-note" id="p-note-' + c.id + '" type="text" maxlength="280"'
@@ -4553,6 +4560,42 @@ async function addExtraPrompt() {
   if (!title || !title.trim()) return;
   toast('Sent to your grown-up! ⏳');
   await api({ action: 'addExtra', kidId: session.personId, personId: session.personId, pin: session.pin, title: title.trim() });
+}
+
+// A sent-back elective is an open offer, not history: it sits on Home until
+// the kid redoes it or bows out. No window - electives have no deadline.
+function renderRedoExtras(kid) {
+  var el = document.getElementById('k-redo');
+  if (!el) return;
+  var redos = (state.completions || []).filter(function(c) {
+    return c.kidId === kid.id && !c.taskId && !c.planningItemId && c.status === 'rejected';
+  });
+  if (redos.length === 0) { el.innerHTML = ''; return; }
+  el.innerHTML = '<h2 class="section-title">🔁 Try again</h2>' + redos.map(function(c) {
+    return '<div class="task done-rejected">'
+      + '<div class="tick" style="border-color:var(--warning);background:var(--warning-wash);pointer-events:none" aria-hidden="true">🔁</div>'
+      + '<div class="info">'
+      + '<div class="title">' + esc(c.title || 'Extra') + '</div>'
+      + '<div class="sub">' + (c.points ? '⭐ ' + c.points + ' pts when it’s done right' : 'Points decided when approved') + '</div>'
+      + (c.comment ? '<div class="decision-note needs-fixing">🔧 ' + esc(c.comment) + '</div>' : '')
+      + '<div class="approve-row">'
+      + '<button class="btn small" onclick="resubmitExtra(\'' + jsq(c.id) + '\', false)">Done it — check again</button>'
+      + '<button class="btn ghost small" onclick="resubmitExtra(\'' + jsq(c.id) + '\', true)">Not doing it</button>'
+      + '</div>'
+      + '</div>'
+      + '</div>';
+  }).join('');
+}
+
+async function resubmitExtra(completionId, giveUp) {
+  if (giveUp && !await askConfirm('Take this off your list?', 'Remove it')) return;
+  var result = await api({
+    action: 'redoExtra', personId: session.personId, pin: session.pin,
+    completionId: completionId, giveUp: !!giveUp,
+  });
+  if (toastApiError(result)) return;
+  toast(giveUp ? 'Off your list.' : 'Sent for checking! 🤞');
+  await refresh();
 }
 
 function newVoiceReminderDraft(overrides) {
@@ -5408,7 +5451,10 @@ async function parentApprove(completionId, isExtra) {
   if (isExtra) {
     // Was a raw prompt(), which shows the Azure hostname in the browser's own
     // dialog. Same bug that was fixed for the kid's 'I did something extra'.
-    points = await askText('How many points is this worth?', '5', 'Approve');
+    // A resubmitted elective already carries the offer made at send-back, so
+    // that is the default rather than a flat 5.
+    var priced = state.completions.find(function(c) { return c.id === completionId; });
+    points = await askText('How many points is this worth?', String((priced && priced.points) || 5), 'Approve');
     if (points === null) return;
   }
   await submitApproval(completionId, points, approvalNote(completionId));
@@ -5444,6 +5490,15 @@ async function parentReject(completionId) {
     if (noteInput) noteInput.focus();
     return;
   }
+  // Sending back an ELECTIVE keeps the offer alive: it asks what redoing it
+  // is worth, and those points sit on the kid's Try-again card. Chores carry
+  // their points on the task, so they skip this.
+  var rejecting = state.completions.find(function(c) { return c.id === completionId; });
+  var offer;
+  if (rejecting && !rejecting.taskId && !rejecting.planningItemId) {
+    offer = await askText('Worth how many points when it\u2019s done right?', String(rejecting.points || 5), 'Send it back');
+    if (offer === null) return;
+  }
 
   var prevCompletions = state.completions.slice();
   state.completions = prevCompletions.filter(function(c) { return c.id !== completionId; });
@@ -5452,7 +5507,7 @@ async function parentReject(completionId) {
   try {
     res = await api({
       action: 'reject', parentId: session.personId, parentPin: session.pin,
-      completionId: completionId, comment: comment,
+      completionId: completionId, comment: comment, points: offer,
     });
   } catch (e) {
     state.completions = prevCompletions; render(); toast('Connection problem — try again.'); return;

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -639,10 +639,11 @@ test('a plain approve goes straight through with no dialog', async ({ page }) =>
   await expect(card).toBeHidden();
 });
 
-// A kid-added extra has no task behind it, so its name lives on the
-// completion itself. Recent activity fell straight to 'Mission' for those,
-// which made a rejected "Eat food" unrecognisable to the kid it went back to.
-test('a rejected extra comes back to the kid by name, with the note', async ({ page }) => {
+// A sent-back elective stays on offer. Rejecting an extra prices the redo
+// (in-app modal, after the note); the kid gets a Try-again card on Home with
+// the points and the note, and one tap puts the same row back in front of
+// the parent, offer intact.
+test('a sent-back elective sits with the kid, points on offer, until resubmitted', async ({ page }) => {
   await page.evaluate(async () => {
     const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
       method: 'POST',
@@ -655,17 +656,43 @@ test('a rejected extra comes back to the kid by name, with the note', async ({ p
   await pickPerson(page, 'Peter');
 
   const card = page.locator('#p-pending .parent-card').filter({ hasText: 'Washed the car' });
-  await card.locator('.approve-note').fill('Still soapy — rinse it and show me.');
+  await card.locator('.approve-note').fill('Still soapy \u2014 rinse it and show me.');
   await card.getByRole('button', { name: /Try again/ }).click();
+
+  // The pricing step, in the app's own modal.
+  await expect(page.locator('#ask-modal')).toBeVisible();
+  await expect(page.locator('#ask-title')).toContainText(/Worth how many points/);
+  await page.locator('#ask-input').fill('15');
+  await page.locator('#ask-ok').click();
   await expect(card).toBeHidden();
 
+  // The kid's side: a Try-again card with the offer and the note.
   await page.getByRole('button', { name: /Switch user/ }).click();
   await pickPerson(page, 'Ollie');
-  const row = page.locator('#k-activity .task', { hasText: 'Washed the car' });
-  await expect(row).toBeVisible();
-  await expect(row).toContainText(/try again/i);
-  await expect(row).toContainText('Still soapy — rinse it and show me.');
-  await expect(page.locator('#k-activity')).not.toContainText(/^Mission$/);
+  const redo = page.locator('#k-redo .task', { hasText: 'Washed the car' });
+  await expect(redo).toBeVisible();
+  await expect(redo).toContainText('15 pts');
+  await expect(redo).toContainText('Still soapy \u2014 rinse it and show me.');
+  // And it also reads as sent back in Recent activity, by name.
+  await expect(page.locator('#k-activity .task', { hasText: 'Washed the car' })).toBeVisible();
+
+  // One tap resubmits; the card leaves Home.
+  await redo.getByRole('button', { name: /check again/i }).click();
+  await expect(redo).toBeHidden();
+
+  // Back in front of the parent, offer intact. (The kid header's switch has
+  // its own accessible name, "Switch to a different person".)
+  await page.getByRole('button', { name: /Switch/ }).first().click();
+  await pickPerson(page, 'Peter');
+  const again = page.locator('#p-pending .parent-card').filter({ hasText: 'Washed the car' });
+  await expect(again).toBeVisible();
+  await expect(again).toContainText('15 pts');
+
+  // Tidy: approve it so later premises hold.
+  await again.getByRole('button', { name: /^\u2713 Approve/ }).click();
+  await expect(page.locator('#ask-modal')).toBeVisible();
+  await page.locator('#ask-ok').click();
+  await expect(again).toBeHidden();
 });
 
 // #174. The app installs on desktops. With no maximum width a task row


### PR DESCRIPTION
Closes #232.

Pete's logic: "if I've sent it back and allocated 15 points, that should sit with him as an elective task with 15 points available — otherwise what's the point of sending something back with points?"

- **Rejecting an extra now prices the redo**: after the note, an in-app prompt asks what it's worth; the offer is stored on the sent-back row
- **The kid's Home gains a "Try again" card**: name, ⭐ offer, the parent's note — one tap ("Done it — check again") puts the same row back in front of the parent with the points intact; "Not doing it" withdraws it (out of every history list). **No expiry**: electives have no window, so the card stays until acted on
- The parent's pending card shows "offered N pts" on a priced extra, and approving one prefills the points prompt with the offer (still adjustable)
- Must-do chores are untouched: points on the task, bounce back under the existing window rules
- Bonus dead-end closed in the same family: a **rejected prep confirmation** can now be resubmitted — the idempotency 409 flips the rejected row back to pending instead of silently eating the redo

Tests: logic suite covers priced reject → resubmit-with-offer, wrong-kid refusal, bow-out, and the prep resubmit; smoke drives the whole loop end to end (reject with note+15 → kid card shows both → resubmit → parent sees "offered 15 pts" → approve prefilled). 71 smoke + full logic suite green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_