### PR TITLE
Pull down to refresh, on both shells

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -196,6 +196,16 @@ Every decorative animation sits behind:
 - View transition: the outgoing view fades to 0 and the incoming fades in with
   `translateY(8px) → 0`, `--dur-base`, `--ease-out`.
 
+### Pull to refresh
+
+Both scroll areas (`.kid-main`, `.parent-main`) carry the app's own
+pull-to-refresh (`attachPullToRefresh`): the pinned shell suppresses the
+browser's native one, so a `.ptr-pill` (surface, `--shadow-2`, 🔄) follows a
+damped pull from the top and a release past ~70px runs `refresh()`. Touch
+events only — desktop has reload — with a guarded `preventDefault` that
+fires only mid-pull from the top, so scrolling is untouched and older iOS
+without `overscroll-behavior` support still behaves. Transform/opacity only.
+
 ### Cards
 
 `--surface`, `--radius-lg`, `--shadow-1`, padding `--space-4`, gap `--space-3`

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1007,6 +1007,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
   flex: 1;
   overflow-y: auto;
   overscroll-behavior: contain;
+  position: relative; /* anchors the pull-to-refresh pill, like .kid-main */
 }
 .parent-panel {
   min-height: 100%;
@@ -1524,6 +1525,32 @@ button.parent-list-row:active { transform: scale(0.99); }
 @media (min-width: 80rem) {
   html { font-size: 112.5%; }
 }
+
+/* ─── Pull to refresh ─────────────────────────────────────────────────── */
+.ptr-pill {
+  position: absolute;
+  top: var(--space-2);
+  left: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-left: -1.25rem;
+  border-radius: var(--radius-full);
+  background: var(--surface);
+  box-shadow: var(--shadow-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-lg);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 5;
+  transition: opacity var(--dur-fast) var(--ease-out), transform var(--dur-base) var(--ease-out);
+}
+.ptr-pill.refreshing .ptr-icon {
+  display: inline-block;
+  animation: ptr-spin 800ms linear infinite;
+}
+@keyframes ptr-spin { to { transform: rotate(360deg); } }
 
 /* ─── Confetti canvas ─────────────────────────────────────────────────── */
 #confetti-canvas { position: fixed; inset: 0; pointer-events: none; z-index: 99; }
@@ -5861,6 +5888,73 @@ window.addEventListener('online',  function() { setOfflineIndicator(false); drai
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() { navigator.serviceWorker.register('sw.js').catch(function() {}); });
 }
+
+// ─── Pull to refresh ──────────────────────────────────────────────────────
+// The shell pins the page (body overflow hidden, overscroll contained), so
+// the browser's own pull-to-refresh never fires - this is the app's own.
+// Touch events only: it is a phone gesture, and desktop has reload. The
+// guarded preventDefault also covers older iOS that ignores
+// overscroll-behavior, and only fires while actually pulling from the top,
+// so normal scrolling is never touched.
+var PTR_THRESHOLD = 70;
+var PTR_DAMPING = 0.45;
+
+function attachPullToRefresh(container) {
+  if (!container) return;
+  var pill = document.createElement('div');
+  pill.className = 'ptr-pill';
+  pill.innerHTML = '<span class="ptr-icon">🔄</span>';
+  container.appendChild(pill);
+  var startY = null;
+  var pull = 0;
+  var busy = false;
+
+  function reset() {
+    pill.style.transition = '';
+    pill.style.opacity = '0';
+    pill.style.transform = '';
+  }
+
+  container.addEventListener('touchstart', function(e) {
+    if (busy || container.scrollTop > 0) { startY = null; return; }
+    startY = e.touches[0].clientY;
+    pull = 0;
+  }, { passive: true });
+
+  container.addEventListener('touchmove', function(e) {
+    if (busy || startY === null) return;
+    var dy = e.touches[0].clientY - startY;
+    if (dy <= 0 || container.scrollTop > 0) { pull = 0; reset(); return; }
+    pull = dy * PTR_DAMPING;
+    var shown = Math.min(pull, PTR_THRESHOLD + 20);
+    pill.style.transition = 'none'; // follow the finger, no lag
+    pill.style.opacity = String(Math.min(1, pull / PTR_THRESHOLD));
+    pill.style.transform = 'translateY(' + shown + 'px) rotate(' + Math.round(pull * 3) + 'deg)';
+    if (e.cancelable) e.preventDefault();
+  }, { passive: false });
+
+  async function finish() {
+    if (busy || startY === null) return;
+    startY = null;
+    if (pull < PTR_THRESHOLD) { reset(); return; }
+    busy = true;
+    pill.style.transition = '';
+    pill.classList.add('refreshing');
+    pill.style.transform = 'translateY(' + PTR_THRESHOLD + 'px)';
+    try {
+      await refresh();
+    } finally {
+      pill.classList.remove('refreshing');
+      reset();
+      busy = false;
+    }
+  }
+  container.addEventListener('touchend', finish);
+  container.addEventListener('touchcancel', finish);
+}
+
+attachPullToRefresh(document.querySelector('.kid-main'));
+attachPullToRefresh(document.querySelector('.parent-main'));
 </script>
 </body>
 </html>

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -695,6 +695,50 @@ test('a sent-back elective sits with the kid, points on offer, until resubmitted
   await expect(again).toBeHidden();
 });
 
+// The pinned shell suppresses the browser's own pull-to-refresh, so the app
+// provides its own: pull from the top of a scroll area, release past the
+// threshold, and it refreshes. A short pull snaps back and does nothing.
+test('pull down far enough refreshes; a short pull does not', async ({ page }) => {
+  await pickPerson(page, 'Toby');
+  await expect(page.locator('.kid-main .ptr-pill')).toHaveCount(1);
+  await expect(page.locator('.parent-main .ptr-pill')).toHaveCount(1);
+
+  const pullResult = await page.evaluate(async () => {
+    const main = document.querySelector('.kid-main');
+    const results = {};
+    const orig = window.refresh;
+    let hit = false;
+    window.refresh = async () => { hit = true; };
+    const send = (type, y) => {
+      const t = new Touch({ identifier: 1, target: main, clientX: 100, clientY: y });
+      main.dispatchEvent(new TouchEvent(type, {
+        touches: type === 'touchend' ? [] : [t],
+        changedTouches: [t],
+        bubbles: true,
+        cancelable: true,
+      }));
+    };
+    // Long pull: past the threshold.
+    send('touchstart', 100);
+    send('touchmove', 160);
+    send('touchmove', 320);
+    send('touchend', 320);
+    await new Promise((r) => setTimeout(r, 80));
+    results.longPull = hit;
+    // Short pull: under the threshold.
+    hit = false;
+    send('touchstart', 100);
+    send('touchmove', 140);
+    send('touchend', 140);
+    await new Promise((r) => setTimeout(r, 80));
+    results.shortPull = hit;
+    window.refresh = orig;
+    return results;
+  });
+  expect(pullResult.longPull, 'a long pull must refresh').toBe(true);
+  expect(pullResult.shortPull, 'a short pull must not refresh').toBe(false);
+});
+
 // #174. The app installs on desktops. With no maximum width a task row
 // stretched to ~1900px to hold thirty characters, at phone type scale.
 //


### PR DESCRIPTION
Closes #234.

Pete: "add a bounce screen down like you would in most apps to make it refresh — needs to work on Android, iOS, whatever."

The pinned shell (fixed header/tab bar, contained overscroll) is what makes this feel like an app — and it also suppresses the browser's own pull-to-refresh. So the app now provides its own:

- Pull from the top of either scroll area (kid screens and Parent HQ) and a spinner pill follows the pull, rotating as it comes down
- Release past the threshold (~70px damped) → it spins and runs a full refresh; a short pull snaps back and does nothing
- Plain touch events, no libraries — identical on Android and iOS. Older iOS that ignores `overscroll-behavior` is covered by a guarded `preventDefault` that only fires mid-pull from the very top, so normal scrolling is never affected
- Design-system pill (surface, `--shadow-2`, full radius), transform/opacity animation only

Smoke: synthetic touch sequences assert a long pull triggers `refresh()` and a short pull doesn't, and the pill exists in both shells. Suite is 72, all green; static checks pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_