### PR TITLE
Wire the prep-list controls into the calendar agenda

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1241,6 +1241,12 @@ button.parent-list-row:active { transform: scale(0.99); }
   flex-wrap: wrap;
 }
 .parent-calendar-inline-actions .btn.small { min-height: 2.5rem; }
+.cal-checklist-wrap {
+  background: var(--surface-sunken);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  margin: var(--space-2) 0 var(--space-3);
+}
 .parent-calendar-loading {
   display: flex;
   flex-direction: column;
@@ -2247,6 +2253,9 @@ var goalCarouselSignature = '';
 let parentCalendarMonth = null;
 let parentCalendarWeekStart = null;
 let parentCalendarSelectedDay = null;
+// Which event's checklist is expanded in the agenda - by item id, so it
+// survives the re-render every prep mutation triggers.
+let parentCalendarChecklistOpenId = null;
 let parentCalendarItems = [];
 let parentCalendarLoading = false;
 let parentApprovalsGlanceItems = [];
@@ -3389,12 +3398,23 @@ function renderParentCalendar() {
               + '</div>'
               + (canManage
                   ? '<div class="parent-actions">'
+                    + (item.kind === 'event'
+                        ? '<button class="btn ghost small" onclick="parentToggleChecklist(\'' + jsq(item.id) + '\')">🎒 Checklist</button>'
+                        : '')
                     + '<button class="btn ghost small" onclick="parentEditPlanningItem(\'' + jsq(item.id) + '\')">Edit</button>'
                     + '<button class="btn red-ghost small" onclick="parentDeletePlanningItem(\'' + jsq(item.id) + '\')">Delete</button>'
                     + '</div>'
                   : '')
-              + '</div>';
+              + '</div>'
+              + (item.kind === 'event' && parentCalendarChecklistOpenId === item.id
+                  ? '<div class="cal-checklist-wrap">' + renderParentCalendarChecklists(item) + '</div>'
+                  : '');
           }).join('') + '</div>');
+}
+
+function parentToggleChecklist(itemId) {
+  parentCalendarChecklistOpenId = parentCalendarChecklistOpenId === itemId ? null : itemId;
+  renderParentCalendar();
 }
 
 async function loadParentCalendar() {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -1670,6 +1670,42 @@ test('dots are coloured per person, and there is no legend', async ({ page }) =>
   await expect(page.locator('#p-tab-calendar')).not.toContainText(/legend/i);
 });
 
+// The prep-list controls were defined but never rendered - every checklist
+// in production had been created by the seed, and a parent had no way to
+// build one in the app. Event rows in the agenda now carry a Checklist
+// toggle that opens the lists and the add/set-points controls.
+test('a parent can open an event checklist and add a prep item', async ({ page }) => {
+  await seedCalendar(page);
+
+  page.on('dialog', (dialog) => {
+    if (/Which kid prep list/.test(dialog.message())) return dialog.accept('2');
+    if (/Prep item\?/.test(dialog.message())) return dialog.accept('Bring a hat');
+    return dialog.dismiss();
+  });
+
+  await openParentCalendar(page);
+  // Select the seeded day directly: in the full suite, earlier tests leave
+  // chores dotting today, so "first busy cell" can land on a day with no
+  // events at all. Day-tapping itself is covered by the agenda test below.
+  await page.evaluate(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 2);
+    parentCalendarSelectedDay = d.getFullYear() + '-'
+      + String(d.getMonth() + 1).padStart(2, '0') + '-'
+      + String(d.getDate()).padStart(2, '0');
+    renderParentCalendar();
+  });
+
+  const agenda = page.locator('#p-calendar-agenda');
+  await agenda.getByRole('button', { name: /Checklist/ }).first().click();
+  await expect(agenda.getByRole('button', { name: /\+ Prep item/ })).toBeVisible();
+
+  await agenda.getByRole('button', { name: /\+ Prep item/ }).click();
+  await expect(agenda.locator('.parent-calendar-checklist').first()).toBeVisible();
+  await expect(agenda.locator('.cal-checklist-wrap')).toContainText('Bring a hat');
+  await expect(agenda.getByRole('button', { name: /Set pts/ }).first()).toBeVisible();
+});
+
 test('tapping a day expands its agenda inline, without leaving the screen', async ({ page }) => {
   await seedCalendar(page);
   await openParentCalendar(page);


### PR DESCRIPTION
Closes #236.

Pete: "the prep items and set points options don't appear."

They couldn't — `renderParentCalendarChecklists` (the whole "+ Prep item" / "+ Adult action" / "Set pts" block, with its handlers and CSS) was defined but **never called**, orphaned in a calendar rework. Every prep list in production was created by the seed through the API; the app had no path to build one.

Now: expand a day in the Parent HQ calendar and each **event** row carries a **🎒 Checklist** button. Tapping it opens the event's prep lists inline — per-kid lists with their items, "Set pts" on each, and "+ Prep item" / "+ Adult action" to build them. The expansion stays open across the re-render each mutation triggers.

Smoke: seeds an event, opens its checklist from the agenda (selecting the seeded day directly — in the full suite earlier tests dot today with chores, so "first busy cell" is not reliably an event day), adds "Bring a hat" through the real prompt flow, and asserts it renders with the Set pts control. Suite is 73, all green.

Known follow-up (Pete's next screenshot): the editor prompts themselves are still raw browser dialogs with ISO dates — being replaced with a real form next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_