### PR TITLE
Email proposals: ingest, kid interest, parent decision (#41)

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -1,5 +1,5 @@
 const { app } = require('@azure/functions');
-const { randomUUID } = require('crypto');
+const { randomUUID, createHash } = require('crypto');
 const { container } = require('../lib/cosmos');
 const { ensureSeeded, HOUSEHOLD_ID } = require('../lib/seed');
 const { sendPush } = require('../lib/push');
@@ -191,6 +191,13 @@ async function getState() {
   const rewardDocs = (await queryHousehold('rewards')).filter((r) => r.type === 'reward' && r.active !== false);
   const allRewardRows = await queryHousehold('rewards');
   const redemptionDocs = allRewardRows.filter((r) => r.type === 'redemption');
+  // Email proposals still waiting on someone. Approved ones are ordinary
+  // active planning items and travel via the calendar; declined ones are done.
+  const proposalDocs = (await queryHousehold('planningItems')).filter((p) => (
+    p.source === 'email'
+    && p.active === false
+    && ['proposed', 'kid-interested'].includes(p.proposalState)
+  ));
 
   const windows = await getHouseholdWindows();
 
@@ -262,6 +269,28 @@ async function getState() {
       decidedAt: c.decidedAt || null,
     })),
     stats,
+    proposals: proposalDocs
+      .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
+      .map((p) => ({
+        id: p.id,
+        type: p.type,
+        title: p.title,
+        startAt: p.startAt,
+        endAt: p.endAt || null,
+        allDay: !!p.allDay,
+        personId: p.personId ?? null,
+        classification: p.classification,
+        proposalState: p.proposalState,
+        summary: p.summary || null,
+        payments: p.payments || [],
+        prepLists: p.prepLists || [],
+        adultActions: p.adultActions || [],
+        proposedPrepDueBy: p.proposedPrepDueBy || null,
+        sourceMeta: p.sourceMeta || null,
+        kidResponse: p.kidResponse || null,
+        notes: p.notes || null,
+        createdAt: p.createdAt,
+      })),
     quietHours: household && household.quietHours ? household.quietHours : null,
     today: todayStr(),
   };
@@ -1048,6 +1077,208 @@ async function deletePlanningItem(req) {
   planningItem.active = false;
   await planningItems.item(req.planningItemId, HOUSEHOLD_ID).replace(planningItem);
   return { ok: true };
+}
+
+// ---- Email proposals (#41) -------------------------------------------------
+// Items the email pipeline found live in the same planningItems container but
+// start with active:false, which keeps them invisible to the calendar, kids'
+// lists and the miss sweep until a parent approves. proposalState tracks the
+// approval conversation; classification decides who gets asked.
+
+const PROPOSAL_CLASSIFICATIONS = ['kid-choice', 'parent-direct', 'informational'];
+
+function validatePayments(payments) {
+  if (payments === undefined || payments === null) return { ok: true, payments: [] };
+  if (!Array.isArray(payments)) return { ok: false, error: 'payments must be an array' };
+  const normalized = [];
+  for (const pay of payments) {
+    if (!pay || typeof pay !== 'object') return { ok: false, error: 'payments entries must be objects' };
+    const description = String(pay.description || '').trim();
+    const amount = String(pay.amount || '').trim();
+    if (!description || !amount) return { ok: false, error: 'payments need description and amount' };
+    normalized.push({
+      description,
+      amount,
+      bank: String(pay.bank || '').trim() || null,
+      accountName: String(pay.accountName || '').trim() || null,
+      bsb: String(pay.bsb || '').trim() || null,
+      account: String(pay.account || '').trim() || null,
+      reference: String(pay.reference || '').trim() || null,
+    });
+  }
+  return { ok: true, payments: normalized };
+}
+
+// The ingest Function calls this with EMAIL_INGEST_KEY, not a parent PIN - it
+// runs on a timer with nobody logged in. Refusing when the env var is unset
+// means a misconfigured deploy fails closed rather than accepting anything.
+async function ingestEmailItem(req) {
+  const key = process.env.EMAIL_INGEST_KEY;
+  if (!key || String(req.ingestKey || '') !== key) {
+    throw Object.assign(new Error('Bad ingest key'), { status: 401 });
+  }
+  const classification = String(req.classification || '').trim();
+  if (!PROPOSAL_CLASSIFICATIONS.includes(classification)) {
+    return { ok: false, error: `classification must be one of ${PROPOSAL_CLASSIFICATIONS.join(', ')}` };
+  }
+  const externalRef = String(req.externalRef || '').trim();
+  if (!externalRef) return { ok: false, error: 'externalRef is required' };
+  const paymentCheck = validatePayments(req.payments);
+  if (!paymentCheck.ok) return paymentCheck;
+
+  const validated = await validatePlanningPayload({ ...req, externalRef, source: 'email' });
+  if (!validated.ok) return validated;
+  if (validated.duplicate) return { ok: true, item: validated.duplicate, duplicate: true };
+
+  const item = validated.item;
+  // Same email + same event = same id, so re-reading a message the watermark
+  // missed becomes a 409 instead of a second card.
+  item.id = 'email-' + createHash('sha1').update(`${externalRef}|${item.title}`).digest('hex').slice(0, 24);
+  item.source = 'email';
+  item.classification = classification;
+  item.summary = String(req.summary || '').trim() || null;
+  item.payments = paymentCheck.payments;
+  item.proposedPrepDueBy = parseIso(req.proposedPrepDueBy);
+  item.sourceMeta = {
+    from: String(req.from || '').trim() || null,
+    subject: String(req.subject || '').trim() || null,
+    receivedAt: parseIso(req.receivedAt),
+  };
+  item.kidResponse = null;
+  // Informational items (newsletters, date announcements) skip the approval
+  // queue: they go straight onto the calendar as read-only context.
+  if (classification === 'informational') {
+    item.active = true;
+    item.proposalState = 'approved';
+  } else {
+    item.active = false;
+    item.proposalState = 'proposed';
+  }
+
+  try {
+    await container('planningItems').items.create(item);
+  } catch (err) {
+    if (err && err.code === 409) {
+      const { resource: existing } = await container('planningItems')
+        .item(item.id, HOUSEHOLD_ID)
+        .read()
+        .catch(() => ({ resource: null }));
+      return { ok: true, item: existing || item, duplicate: true };
+    }
+    throw err;
+  }
+
+  const quietHours = await getHouseholdQuietHours();
+  const people = await queryHousehold('people');
+  const parents = people.filter((p) => p.role === 'parent');
+  const notify = [];
+  if (classification === 'kid-choice') {
+    if (item.personId) {
+      notify.push(sendPushIfAllowed(item.personId, {
+        title: 'Something came up! 📧',
+        body: `${item.title} — want to go? Tap to have a look.`,
+        url: '/',
+      }, quietHours));
+    }
+    parents.forEach((parent) => notify.push(sendPushIfAllowed(parent.id, {
+      title: 'New from email 📧',
+      body: `${item.title} — waiting on ${item.personId ? 'a yes from the kids' : 'a decision'}`,
+      url: '/',
+    }, quietHours)));
+  } else if (classification === 'parent-direct') {
+    parents.forEach((parent) => notify.push(sendPushIfAllowed(parent.id, {
+      title: 'Needs a parent 📧',
+      body: item.title,
+      url: '/',
+    }, quietHours)));
+  } else if (item.personId) {
+    notify.push(sendPushIfAllowed(item.personId, {
+      title: 'On your calendar 📧',
+      body: item.title,
+      url: '/',
+    }, quietHours));
+  }
+  await Promise.all(notify);
+  return { ok: true, item };
+}
+
+// A kid saying "I want to go" (or not). Interest never publishes anything -
+// it flips the proposal to kid-interested so the parents' queue shows who's
+// keen, and the parents still make the call.
+async function respondProposal(req) {
+  const personId = String(req.personId || '').trim();
+  await requireSelf(personId, req.pin, personId);
+  const planningItems = container('planningItems');
+  const { resource: item } = await planningItems
+    .item(req.proposalId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!item || item.source !== 'email' || !['proposed', 'kid-interested'].includes(item.proposalState)) {
+    return { ok: false, error: 'Proposal not found' };
+  }
+  if (item.classification !== 'kid-choice') return { ok: false, error: 'This one is not up to the kids' };
+  if (item.personId && item.personId !== personId) return { ok: false, error: 'Not allowed' };
+
+  const wants = !!req.wants;
+  item.kidResponse = { personId, wants, at: new Date().toISOString() };
+  if (wants) item.proposalState = 'kid-interested';
+  await planningItems.item(item.id, HOUSEHOLD_ID).replace(item);
+
+  if (wants) {
+    const quietHours = await getHouseholdQuietHours();
+    const people = await queryHousehold('people');
+    const kid = people.find((p) => p.id === personId);
+    await Promise.all(people
+      .filter((p) => p.role === 'parent')
+      .map((parent) => sendPushIfAllowed(parent.id, {
+        title: 'Wants to go! 🙋',
+        body: `${kid ? kid.name : 'A kid'} wants to go to ${item.title}`,
+        url: '/',
+      }, quietHours)));
+  }
+  return getState();
+}
+
+// The parent decision. Approval is the moment the proposal becomes a real
+// calendar item: active flips true and everything downstream (calendar, prep
+// deadlines, miss sweep) starts treating it exactly like a hand-entered event.
+async function decideProposal(req) {
+  await requireParent(req.parentId, req.parentPin);
+  const planningItems = container('planningItems');
+  const { resource: item } = await planningItems
+    .item(req.proposalId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!item || item.source !== 'email' || !['proposed', 'kid-interested'].includes(item.proposalState)) {
+    return { ok: false, error: 'Proposal not found' };
+  }
+
+  if (!req.approve) {
+    item.proposalState = 'declined';
+    item.decidedAt = new Date().toISOString();
+    await planningItems.item(item.id, HOUSEHOLD_ID).replace(item);
+    return { ok: true, item };
+  }
+
+  item.proposalState = 'approved';
+  item.decidedAt = new Date().toISOString();
+  item.active = true;
+  // The deadline the extractor proposed from the event's scale is only ever a
+  // default; the approving parent's value wins.
+  const prepDueBy = parseIso(req.prepDueBy) || item.proposedPrepDueBy || null;
+  if (prepDueBy) item.prepDueBy = prepDueBy;
+  await planningItems.item(item.id, HOUSEHOLD_ID).replace(item);
+
+  const { conflicts, suggestedTimes } = await getConflictsForItem(item);
+  if (item.personId) {
+    const quietHours = await getHouseholdQuietHours();
+    await sendPushIfAllowed(item.personId, {
+      title: "It's on! 🎉",
+      body: `${item.title} is on your calendar`,
+      url: '/',
+    }, quietHours);
+  }
+  return { ok: true, item, conflicts, suggestedTimes };
 }
 
 function startOfUtcDay(date) {
@@ -2047,6 +2278,9 @@ const ROUTES = {
   addPlanningItem,
   updatePlanningItem,
   deletePlanningItem,
+  ingestEmailItem,
+  respondProposal,
+  decideProposal,
   calendar,
   completeTask,
   uncomplete,

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2274,7 +2274,196 @@ async function main() {
   });
   assert.strictEqual(recurringReminder.ok, true, 'reminder save: ' + JSON.stringify(recurringReminder));
   assert.strictEqual(recurringReminder.item.recurrence, null, 'recurrence is cleared on reminders');
-  console.log('\u2713 reminders cannot recur');
+  console.log('✓ reminders cannot recur');
+
+  // -------------------------------------------------------------------------
+  // Email proposals (#41). The ingest Function drops items in as inactive
+  // proposals; kids raise a hand, parents decide, and only approval makes the
+  // thing real on the calendar.
+
+  // No key configured = fail closed, whatever the caller sends.
+  delete process.env.EMAIL_INGEST_KEY;
+  await assert.rejects(
+    () => R.ingestEmailItem({ ingestKey: 'anything', classification: 'kid-choice' }),
+    (err) => err.status === 401,
+    'ingest must refuse when EMAIL_INGEST_KEY is unset'
+  );
+  process.env.EMAIL_INGEST_KEY = 'test-ingest-key';
+  await assert.rejects(
+    () => R.ingestEmailItem({ ingestKey: 'wrong-key', classification: 'kid-choice' }),
+    (err) => err.status === 401,
+    'ingest must refuse a wrong key'
+  );
+  console.log('✓ ingestEmailItem fails closed without the right key');
+
+  const hikeStart = new Date(at('09:00').getTime() + 5 * 86400000);
+  pushCalls.length = 0;
+  const hike = await R.ingestEmailItem({
+    ingestKey: 'test-ingest-key',
+    classification: 'kid-choice',
+    externalRef: 'gmail-thread-hike-1',
+    type: 'event',
+    title: 'Bibbulmun Track Hike',
+    personId: 'ollie',
+    startAt: hikeStart.toISOString(),
+    endAt: new Date(hikeStart.getTime() + 6 * 3600000).toISOString(),
+    summary: 'Overnight hike with the unit. $5, packing list attached.',
+    payments: [{
+      description: 'Hike fee', amount: '$5', bank: 'Westpac',
+      accountName: 'Willetton Scout Unit', bsb: '036-022', account: '624871',
+      reference: 'Ollie',
+    }],
+    prepLists: [{ personId: 'ollie', items: [{ text: 'Pack sleeping bag' }, { text: 'Fill water bottles' }], points: 10 }],
+    adultActions: [{ text: 'Pay $5 hike fee' }],
+    proposedPrepDueBy: new Date(hikeStart.getTime() - 2 * 86400000).toISOString(),
+    from: 'leader@scouts.example',
+    subject: 'Term 3 hikes',
+    receivedAt: new Date().toISOString(),
+  });
+  assert.strictEqual(hike.ok, true, 'ingest: ' + JSON.stringify(hike));
+  assert.ok(hike.item.id.startsWith('email-'), 'proposal ids are deterministic email- ids');
+  assert.strictEqual(hike.item.active, false, 'a kid-choice proposal starts inactive');
+  assert.strictEqual(hike.item.proposalState, 'proposed');
+  assert.strictEqual(hike.item.payments[0].bsb, '036-022', 'payment details survive normalisation');
+  assert.strictEqual(hike.item.prepLists[0].points, 10, 'prep list points survive');
+
+  let proposalsState = await getState();
+  assert.ok(proposalsState.proposals.some((p) => p.id === hike.item.id), 'state lists the pending proposal');
+  const hikeCal = await R.calendar({
+    parentId: 'peter', parentPin: '1234',
+    start: new Date(hikeStart.getTime() - 86400000).toISOString(),
+    end: new Date(hikeStart.getTime() + 86400000).toISOString(),
+  });
+  assert.ok(!hikeCal.items.some((row) => row.id === hike.item.id),
+    'an unapproved proposal never reaches the calendar');
+  console.log('✓ ingested kid-choice proposal is pending, visible in state, off the calendar');
+
+  const kidChoicePushes = pushCalls
+    .filter((call) => call.type === 'send')
+    .map((call) => JSON.parse(call.payload));
+  assert.ok(kidChoicePushes.some((p) => p.title === 'Something came up! 📧'),
+    'the kid hears about a kid-choice proposal');
+  assert.ok(kidChoicePushes.some((p) => p.title === 'New from email 📧'),
+    'parents hear about it too');
+
+  const rerun = await R.ingestEmailItem({
+    ingestKey: 'test-ingest-key',
+    classification: 'kid-choice',
+    externalRef: 'gmail-thread-hike-1',
+    type: 'event',
+    title: 'Bibbulmun Track Hike',
+    personId: 'ollie',
+    startAt: hikeStart.toISOString(),
+  });
+  assert.strictEqual(rerun.ok, true);
+  assert.strictEqual(rerun.duplicate, true, 'same email + title is a duplicate, not a second card');
+  assert.strictEqual(rerun.item.id, hike.item.id);
+  assert.strictEqual((await getState()).proposals.filter((p) => p.id === hike.item.id).length, 1);
+  console.log('✓ re-ingesting the same email is idempotent');
+
+  const wrongKidRespond = await R.respondProposal({
+    personId: 'toby', pin: '1234', proposalId: hike.item.id, wants: true,
+  });
+  assert.strictEqual(wrongKidRespond.ok, false, "another kid can't answer for Ollie");
+
+  pushCalls.length = 0;
+  const ollieWants = await R.respondProposal({
+    personId: 'ollie', pin: '1234', proposalId: hike.item.id, wants: true,
+  });
+  assert.strictEqual(ollieWants.ok, true);
+  const hikeAfterRespond = (await getState()).proposals.find((p) => p.id === hike.item.id);
+  assert.strictEqual(hikeAfterRespond.proposalState, 'kid-interested');
+  assert.strictEqual(hikeAfterRespond.kidResponse.wants, true);
+  const interestPushes = pushCalls
+    .filter((call) => call.type === 'send')
+    .map((call) => JSON.parse(call.payload))
+    .filter((p) => p.title === 'Wants to go! 🙋');
+  assert.ok(interestPushes.length >= 1, 'parents are told Ollie wants to go');
+  assert.ok(/Ollie wants to go to Bibbulmun Track Hike/.test(interestPushes[0].body));
+  console.log('✓ kid interest flips the proposal to kid-interested and pings parents');
+
+  const parentDeadline = new Date(hikeStart.getTime() - 86400000).toISOString();
+  pushCalls.length = 0;
+  const hikeApproved = await R.decideProposal({
+    parentId: 'peter', parentPin: '1234', proposalId: hike.item.id,
+    approve: true, prepDueBy: parentDeadline,
+  });
+  assert.strictEqual(hikeApproved.ok, true, 'approve: ' + JSON.stringify(hikeApproved));
+  assert.strictEqual(hikeApproved.item.active, true, 'approval publishes the item');
+  assert.strictEqual(hikeApproved.item.proposalState, 'approved');
+  assert.strictEqual(hikeApproved.item.prepDueBy, parentDeadline, "the parent's deadline beats the proposed one");
+  assert.ok(Array.isArray(hikeApproved.conflicts), 'approval reports conflicts like any calendar add');
+  assert.ok(!(await getState()).proposals.some((p) => p.id === hike.item.id),
+    'an approved proposal leaves the pending list');
+  const hikeCal2 = await R.calendar({
+    parentId: 'peter', parentPin: '1234',
+    start: new Date(hikeStart.getTime() - 86400000).toISOString(),
+    end: new Date(hikeStart.getTime() + 86400000).toISOString(),
+  });
+  assert.ok(hikeCal2.items.some((row) => row.id === hike.item.id && row.source === 'email'),
+    'the approved item now appears on the calendar');
+  assert.ok(pushCalls.some((call) => call.type === 'send'
+    && JSON.parse(call.payload).title === "It's on! 🎉"), 'the kid hears the yes');
+  const decideAgain = await R.decideProposal({
+    parentId: 'peter', parentPin: '1234', proposalId: hike.item.id, approve: true,
+  });
+  assert.strictEqual(decideAgain.ok, false, 'a decided proposal cannot be decided twice');
+  console.log('✓ parent approval publishes the item with the chosen prep deadline');
+
+  // Parent-direct: kids cannot answer; declining archives without publishing.
+  const ipadStart = new Date(at('09:00').getTime() + 8 * 86400000);
+  const ipad = await R.ingestEmailItem({
+    ingestKey: 'test-ingest-key',
+    classification: 'parent-direct',
+    externalRef: 'gmail-thread-ipad-1',
+    type: 'event',
+    title: 'School iPad payment due',
+    personId: 'toby',
+    startAt: ipadStart.toISOString(),
+  });
+  assert.strictEqual(ipad.ok, true);
+  const kidOnParentDirect = await R.respondProposal({
+    personId: 'toby', pin: '1234', proposalId: ipad.item.id, wants: true,
+  });
+  assert.strictEqual(kidOnParentDirect.ok, false, 'parent-direct is not up to the kids');
+  const declined = await R.decideProposal({
+    parentId: 'peter', parentPin: '1234', proposalId: ipad.item.id, approve: false,
+  });
+  assert.strictEqual(declined.ok, true);
+  assert.strictEqual(declined.item.proposalState, 'declined');
+  assert.strictEqual(declined.item.active, false, 'a declined proposal never publishes');
+  assert.ok(!(await getState()).proposals.some((p) => p.id === ipad.item.id));
+  console.log('✓ parent-direct proposals skip the kids and can be declined away');
+
+  // Informational goes straight to the calendar, no approval step at all.
+  const clubStart = new Date(at('09:00').getTime() + 3 * 86400000);
+  const club = await R.ingestEmailItem({
+    ingestKey: 'test-ingest-key',
+    classification: 'informational',
+    externalRef: 'gmail-thread-aviation-1',
+    type: 'event',
+    title: 'Aviation Club meeting',
+    personId: 'toby',
+    startAt: clubStart.toISOString(),
+  });
+  assert.strictEqual(club.ok, true);
+  assert.strictEqual(club.item.active, true, 'informational items are live immediately');
+  assert.strictEqual(club.item.proposalState, 'approved');
+  assert.ok(!(await getState()).proposals.some((p) => p.id === club.item.id),
+    'and never sit in the pending queue');
+  const clubCal = await R.calendar({
+    parentId: 'peter', parentPin: '1234',
+    start: new Date(clubStart.getTime() - 86400000).toISOString(),
+    end: new Date(clubStart.getTime() + 86400000).toISOString(),
+  });
+  assert.ok(clubCal.items.some((row) => row.id === club.item.id));
+  console.log('✓ informational emails land straight on the calendar');
+
+  const ghostRespond = await R.respondProposal({ personId: 'ollie', pin: '1234', proposalId: 'nope', wants: true });
+  assert.strictEqual(ghostRespond.ok, false);
+  const ghostDecide = await R.decideProposal({ parentId: 'peter', parentPin: '1234', proposalId: 'nope', approve: true });
+  assert.strictEqual(ghostDecide.ok, false);
+  console.log('✓ responding/deciding on a missing proposal fails cleanly');
 
   console.log('\nALL LOGIC TESTS PASSED');
 }


### PR DESCRIPTION
Part 1 of 3 for #41 (Gmail import). This is the API half: everything the email pipeline finds lands as an **inactive proposal** in the planningItems container, invisible to the calendar, kids' lists and the miss sweep until a parent approves it.

## New routes

- **ingestEmailItem** — called by the upcoming email Function with `EMAIL_INGEST_KEY` (never a PIN); fails closed when the env var is unset. Deterministic `email-<sha1>` ids make re-reading the same message idempotent. Carries classification, summary, structured payment details (bank/BSB/account/reference — displayed, never paid automatically), prep lists, adult actions and a proposed prep deadline.
  - `kid-choice` → pings the kid ("want to go?") and the parents
  - `parent-direct` → pings the parents only
  - `informational` → publishes straight to the calendar, no approval step
- **respondProposal** — a kid's "I want to go" flips the proposal to kid-interested and pings the parents. Interest never publishes anything; parents always decide.
- **decideProposal** — parent approval flips `active: true`; from that moment it's an ordinary calendar item with conflicts reported, and the parent's prep deadline wins over the proposed one. Decline archives without publishing.
- `state` now returns a `proposals` array (pending only).

## Tests

Logic tests cover: fail-closed ingest auth, idempotent re-ingest, all three classification behaviours, the wrong-kid refusal, the respond→decide lifecycle, deadline override, decline, and missing-proposal errors. Full logic suite and all 75 smoke tests pass locally.

Next: PR B (proposal cards + kid "want to go" UI), PR C (the Gmail-reading timer Function). #41 stays open until all three land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_