### PR TITLE
Proposal cards, kid hand-up, and email badges (#41)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -791,6 +791,37 @@ points on the task, bounce back under the existing window rules. A rejected
 prep confirmation resubmits through `confirmPrep` — the idempotency 409
 flips a rejected row back to pending instead of silently eating the redo.
 
+### Email proposals (#41)
+
+Things the email pipeline finds arrive as **proposals**, not calendar items.
+Until a parent approves, they are invisible everywhere except the two places
+that ask for a decision:
+
+- **Parent HQ · Approvals** gets a third stat tile (**From email**) and a
+  card per pending proposal: title with a 📧 mark, classification tag
+  (`kids choose` / `needs a parent`), when and who, the extracted summary,
+  any payment details in a bordered `.proposal-payment` block (bank, BSB,
+  account, reference — displayed for the parent to act on, never paid
+  automatically), a one-line prep preview, and a `datetime-local` input
+  prefilled with the proposed prep deadline. The parent's value wins on
+  approve. Kid-choice cards carry a waiting tag: `waiting on <kid>`,
+  `🙋 wants to go`, or `said not this time` — a parent can approve over the
+  top of any of them. Decline goes through the in-app confirm and archives
+  without publishing. Half-edited deadline inputs survive background
+  re-renders, same as approval notes.
+- **Kid Home** shows kid-choice proposals for that kid (or the whole family)
+  as a "📧 Coming up — want to go?" card with **🙋 I want to go!** /
+  **Not for me**. Answering changes only who is waiting — nothing publishes
+  until a parent approves. After a yes the card reads
+  "waiting on your grown-ups".
+
+Approved items are ordinary calendar items from that moment — prep
+deadlines, miss sweep, conflicts — and carry a small **📧 from email**
+marker on kid event cards and parent agenda rows. Informational emails
+(newsletters with dates) skip the queue entirely and land straight on the
+calendar with the same marker. The approvals badge at the top counts
+pending proposals along with approvals and reward requests.
+
 ### Decision notes
 
 Each pending approval card carries one optional note box (`.approve-note`)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -900,6 +900,14 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .tag { font-size: var(--text-xs); font-weight: var(--weight-bold); border-radius: var(--radius-full); padding: var(--space-1) var(--space-2); }
 .tag.extra { background: var(--brand-wash); color: var(--brand); }
+.proposal-payment {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+  font-size: var(--text-sm);
+}
 
 /* ─── Parent screen ───────────────────────────────────────────────────── */
 .parent-header {
@@ -1024,7 +1032,7 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .stat-row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--space-3);
 }
 .stat-tile {
@@ -1682,6 +1690,9 @@ button.parent-list-row:active { transform: scale(0.99); }
             <div id="k-glance-week"></div>
           </section>
         </div>
+        <!-- Things found in email a kid can put their hand up for. Saying yes
+             tells the parents; nothing lands on the calendar until they approve. -->
+        <div id="k-proposals"></div>
         <!-- Sent-back electives: the offer stays open, no window, until the
              kid redoes it or bows out. -->
         <div id="k-redo"></div>
@@ -1807,9 +1818,14 @@ button.parent-list-row:active { transform: scale(0.99); }
             <span class="stat-num">0</span>
             <span class="stat-label">Reward requests</span>
           </div>
+          <div class="stat-tile" id="p-stat-proposals">
+            <span class="stat-num">0</span>
+            <span class="stat-label">From email</span>
+          </div>
         </div>
         <div id="p-pending"></div>
         <div id="p-reward-requests"></div>
+        <div id="p-proposals"></div>
       </section>
       <!-- No Yesterday or This-week sections here: the Calendar tab owns the
            wider view, and a day's agenda is one tap on it. This tab is the
@@ -2566,6 +2582,7 @@ function renderKid(kid) {
   renderRewardShop(kid, balance);
   renderRewardProgress(balance);
   renderRedemptions(kid);
+  renderKidProposals(kid);
   renderRedoExtras(kid);
   renderRecentActivity(kid);
   renderKidCalendar(kid);
@@ -2774,6 +2791,7 @@ function glanceEventCard(item, kidId) {
   if (when) {
     headChips.push('<span class="pill neutral">🗓️ ' + esc(when) + (item.recurrence === 'weekly' ? ' · weekly' : '') + '</span>');
   }
+  if (item.source === 'email') headChips.push('<span class="pill neutral">📧 from email</span>');
   return '<div class="task">'
     + '<button class="tick" disabled>' + (item.kind === 'reminder' ? '🔔' : '📌') + '</button>'
     + '<div class="info">'
@@ -3411,7 +3429,8 @@ function renderParentCalendar() {
               + '<span class="parent-list-title">' + esc(item.title || 'Untitled') + '</span>'
               + '<div class="sub">' + esc(parentCalendarItemTime(item))
               + ' · ' + esc(parentCalendarWho(item))
-              + (item.kind === 'chore' && item.points ? ' · ' + item.points + ' pts' : '') + '</div>'
+              + (item.kind === 'chore' && item.points ? ' · ' + item.points + ' pts' : '')
+              + (item.source === 'email' ? ' · 📧 from email' : '') + '</div>'
               + notes
               + '</div>'
               + (canManage
@@ -4181,7 +4200,7 @@ function renderParent(person) {
     + esc(person.name) + '\u2019s HQ';
   var pending = state.completions.filter(function(c) { return c.status === 'pending'; });
   var pendingRedemptions = (state.redemptions || []).filter(function(r) { return r.status === 'pending'; });
-  var approvalCount = pending.length + pendingRedemptions.length;
+  var approvalCount = pending.length + pendingRedemptions.length + (state.proposals || []).length;
   var approvalBadge = document.getElementById('p-approvals-badge');
   approvalBadge.textContent = approvalCount;
   approvalBadge.classList.toggle('hidden', approvalCount === 0);
@@ -4300,6 +4319,8 @@ function renderParent(person) {
             }).join('') + '</div>')
       + '</div>';
   }).join('') || buildEmptyState('👧', 'Add a kid to start assigning tasks.', 'Once a kid is added, you can assign chores from this tab.');
+
+  renderParentProposals();
 
   setStatTile('p-stat-rewards', pendingRedemptions.length);
   document.getElementById('p-reward-requests').innerHTML = pendingRedemptions.length === 0
@@ -4660,6 +4681,160 @@ async function resubmitExtra(completionId, giveUp) {
   });
   if (toastApiError(result)) return;
   toast(giveUp ? 'Off your list.' : 'Sent for checking! 🤞');
+  await refresh();
+}
+
+function proposalWhenLabel(p) {
+  var d = new Date(p.startAt);
+  if (Number.isNaN(d.getTime())) return '';
+  var label = d.toLocaleDateString([], { weekday: 'short', day: 'numeric', month: 'short' });
+  if (!p.allDay) label += ' · ' + d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return label;
+}
+
+// Email finds a kid-choice item; the kid's answer here changes who is waiting,
+// never what is published - only a parent's approval does that.
+function renderKidProposals(kid) {
+  var el = document.getElementById('k-proposals');
+  if (!el) return;
+  var mine = (state.proposals || []).filter(function(p) {
+    return p.classification === 'kid-choice'
+      && (p.personId === kid.id || p.personId === null);
+  });
+  if (mine.length === 0) { el.innerHTML = ''; return; }
+  el.innerHTML = '<h2 class="section-title">📧 Coming up — want to go?</h2>' + mine.map(function(p) {
+    var answered = p.kidResponse && p.kidResponse.personId === kid.id;
+    var footer;
+    if (answered && p.kidResponse.wants) {
+      footer = '<div class="sub">🙋 You said yes — waiting on your grown-ups</div>';
+    } else if (answered) {
+      footer = '<div class="sub">You said not this time</div>';
+    } else {
+      footer = '<div class="approve-row">'
+        + '<button class="btn small" onclick="kidRespondProposal(\'' + jsq(p.id) + '\', true)">🙋 I want to go!</button>'
+        + '<button class="btn ghost small" onclick="kidRespondProposal(\'' + jsq(p.id) + '\', false)">Not for me</button>'
+        + '</div>';
+    }
+    var when = proposalWhenLabel(p);
+    return '<div class="task">'
+      + '<button class="tick" disabled>📧</button>'
+      + '<div class="info">'
+      + '<div class="title">' + esc(p.title) + '</div>'
+      + (when ? '<div class="sub">🗓️ ' + esc(when) + '</div>' : '')
+      + (p.summary ? '<div class="sub">' + esc(p.summary) + '</div>' : '')
+      + footer
+      + '</div>'
+      + '</div>';
+  }).join('');
+}
+
+async function kidRespondProposal(proposalId, wants) {
+  var result = await api({
+    action: 'respondProposal', personId: session.personId, pin: session.pin,
+    proposalId: proposalId, wants: !!wants,
+  });
+  if (toastApiError(result)) return;
+  toast(wants ? 'Told your grown-ups you want to go! 🙋' : 'Okay — passed that on.');
+}
+
+// The parent's queue shows every pending proposal whatever its classification:
+// kid-choice ones carry a waiting-on tag, and a parent can always approve over
+// the top without the kid having answered.
+function renderParentProposals() {
+  var el = document.getElementById('p-proposals');
+  if (!el) return;
+  var pendingProposals = state.proposals || [];
+  setStatTile('p-stat-proposals', pendingProposals.length);
+  if (pendingProposals.length === 0) { el.innerHTML = ''; return; }
+  // A background refresh redraws this list; carry a half-edited deadline over,
+  // same as the approval note boxes.
+  var draftDues = {};
+  Array.prototype.forEach.call(el.querySelectorAll('.proposal-due'), function(input) {
+    if (input.value) draftDues[input.id] = input.value;
+  });
+  el.innerHTML = pendingProposals.map(function(p) {
+    var kid = p.personId ? state.people.find(function(k) { return k.id === p.personId; }) : null;
+    var who = kid ? kid.name : 'Whole family';
+    var classTag = p.classification === 'kid-choice' ? 'kids choose' : 'needs a parent';
+    var waitTag = '';
+    if (p.classification === 'kid-choice') {
+      if (p.proposalState === 'kid-interested') {
+        waitTag = ' <span class="tag extra">🙋 wants to go</span>';
+      } else if (p.kidResponse && !p.kidResponse.wants) {
+        waitTag = ' <span class="tag">said not this time</span>';
+      } else {
+        waitTag = ' <span class="tag">waiting on ' + esc(who) + '</span>';
+      }
+    }
+    var payments = (p.payments || []).map(function(pay) {
+      var lines = [];
+      if (pay.bank) lines.push('Bank: ' + esc(pay.bank));
+      if (pay.accountName) lines.push('Name: ' + esc(pay.accountName));
+      if (pay.bsb) lines.push('BSB: ' + esc(pay.bsb));
+      if (pay.account) lines.push('Account: ' + esc(pay.account));
+      if (pay.reference) lines.push('Ref: ' + esc(pay.reference));
+      return '<div class="proposal-payment">'
+        + '<strong>💳 ' + esc(pay.description) + ' — ' + esc(pay.amount) + '</strong>'
+        + (lines.length ? '<div class="sub">' + lines.join(' · ') + '</div>' : '')
+        + '</div>';
+    }).join('');
+    var prepBits = (p.prepLists || []).map(function(list) {
+      var prepKid = state.people.find(function(k) { return k.id === list.personId; });
+      return (prepKid ? esc(prepKid.name) : '?') + ': ' + list.items.length
+        + ' item' + (list.items.length === 1 ? '' : 's')
+        + (list.points ? ' · ⭐ ' + list.points : '');
+    });
+    var adultBits = (p.adultActions || []).map(function(a) { return esc(a.text); });
+    var when = proposalWhenLabel(p);
+    return '<div class="card parent-card" id="p-proposal-' + esc(p.id) + '">'
+      + '<div class="parent-copy">'
+      + '<strong>📧 ' + esc(p.title) + '</strong> <span class="tag">' + classTag + '</span>' + waitTag
+      + '<div class="sub">' + esc(when) + ' · ' + esc(who) + '</div>'
+      + (p.summary ? '<div class="sub">' + esc(p.summary) + '</div>' : '')
+      + (p.sourceMeta && p.sourceMeta.from
+          ? '<div class="sub">From ' + esc(p.sourceMeta.from)
+            + (p.sourceMeta.subject ? ' — ' + esc(p.sourceMeta.subject) : '') + '</div>'
+          : '')
+      + payments
+      + (prepBits.length ? '<div class="sub">🎒 ' + prepBits.join(' · ') + '</div>' : '')
+      + (adultBits.length ? '<div class="sub">👤 ' + adultBits.join(' · ') + '</div>' : '')
+      + '</div>'
+      + '<div class="field"><label>Prep due</label>'
+      + '<input type="datetime-local" class="proposal-due" id="p-prop-due-' + esc(p.id) + '"'
+      + ' value="' + planningDateToLocalInput(p.proposedPrepDueBy) + '" aria-label="Prep deadline for ' + esc(p.title) + '">'
+      + '</div>'
+      + '<div class="approve-row">'
+      + '<button class="btn green small" onclick="parentDecideProposal(\'' + jsq(p.id) + '\', true)">✓ Approve</button>'
+      + '<button class="btn red-ghost small" onclick="parentDecideProposal(\'' + jsq(p.id) + '\', false)">✗ Decline</button>'
+      + '</div>'
+      + '</div>';
+  }).join('');
+  Object.keys(draftDues).forEach(function(id) {
+    var input = document.getElementById(id);
+    if (input) input.value = draftDues[id];
+  });
+}
+
+async function parentDecideProposal(proposalId, approve) {
+  if (!approve && !await askConfirm('Decline this? It won’t go on anyone’s calendar.', 'Decline')) return;
+  var prepDueBy = null;
+  if (approve) {
+    var dueInput = document.getElementById('p-prop-due-' + proposalId);
+    if (dueInput && dueInput.value) {
+      var due = new Date(dueInput.value);
+      if (!Number.isNaN(due.getTime())) prepDueBy = due.toISOString();
+    }
+  }
+  var result = await api({
+    action: 'decideProposal', parentId: session.personId, parentPin: session.pin,
+    proposalId: proposalId, approve: !!approve, prepDueBy: prepDueBy,
+  });
+  if (toastApiError(result)) return;
+  toast(approve
+    ? (result.conflicts && result.conflicts.length
+        ? 'Approved — heads up, it clashes with something that day.'
+        : 'Approved — it’s on the calendar.')
+    : 'Declined.');
   await refresh();
 }
 

--- a/tests/smoke/server.js
+++ b/tests/smoke/server.js
@@ -94,6 +94,8 @@ stub(path.join(API_ROOT, 'node_modules/web-push'), {
 
 process.env.VAPID_PUBLIC_KEY = 'smoke-public';
 process.env.VAPID_PRIVATE_KEY = 'smoke-private';
+// Lets tests drive the real ingestEmailItem route, key and all.
+process.env.EMAIL_INGEST_KEY = 'smoke-ingest-key';
 
 const { ensureSeeded } = require(path.join(API_ROOT, 'src/lib/seed.js'));
 const { ROUTES, recordMisses } = require(path.join(API_ROOT, 'src/functions/hero.js'));

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -499,12 +499,15 @@ test('Approvals opens with what is waiting on the parent, at the top', async ({ 
   await pickPerson(page, 'Peter');
 
   const tiles = page.locator('#p-tab-approvals .parent-section').first().locator('.stat-tile');
-  await expect(tiles).toHaveCount(2);
+  await expect(tiles).toHaveCount(3);
   await expect(tiles.first()).toContainText('Awaiting approval');
   await expect(tiles.nth(1)).toContainText('Reward requests');
+  await expect(tiles.nth(2)).toContainText('From email');
   const a = await tiles.first().boundingBox();
   const b = await tiles.nth(1).boundingBox();
+  const c = await tiles.nth(2).boundingBox();
   expect(Math.abs(a.y - b.y)).toBeLessThan(4);
+  expect(Math.abs(a.y - c.y)).toBeLessThan(4);
 
   const headings = await page.locator('#p-tab-approvals .parent-section-title').allTextContents();
   expect(headings[0]).toMatch(/Today, by kid/);
@@ -1811,4 +1814,136 @@ test('tapping a day expands its agenda inline, without leaving the screen', asyn
   // Tapping the open day again closes it, so the grid never gets stuck open.
   await busy.click();
   await expect(agenda).toContainText('Tap a day');
+});
+
+// ───────────────────────── Email proposals (#41) ─────────────────────────
+
+// Drives the real ingest route with the harness key, exactly as the email
+// Function will. Distinct externalRefs per test: the store lives for the
+// whole run and same-email ingests are deliberately idempotent.
+async function seedProposal(page, overrides) {
+  return page.evaluate(async (extra) => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    const start = new Date();
+    start.setDate(start.getDate() + 2);
+    start.setHours(9, 0, 0, 0);
+    return post(Object.assign({
+      action: 'ingestEmailItem', ingestKey: 'smoke-ingest-key',
+      classification: 'kid-choice', type: 'event',
+      startAt: start.toISOString(),
+    }, extra));
+  }, overrides);
+}
+
+test('an email proposal reaches the parent queue with its payment details', async ({ page }) => {
+  await seedProposal(page, {
+    externalRef: 'smoke-email-hike', title: 'Smoke Track Hike', personId: 'ollie',
+    summary: 'Overnight hike with the unit.',
+    payments: [{ description: 'Hike fee', amount: '$5', bank: 'Westpac', bsb: '036-022', account: '624871', reference: 'Ollie' }],
+  });
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const tile = page.locator('#p-stat-proposals .stat-num');
+  await expect(tile).not.toHaveText('0');
+
+  const card = page.locator('#p-proposals .parent-card').filter({ hasText: 'Smoke Track Hike' });
+  await expect(card).toBeVisible();
+  await expect(card).toContainText('waiting on Ollie');
+  await expect(card).toContainText('Hike fee — $5');
+  await expect(card).toContainText('BSB: 036-022');
+  // The deadline the parent can adjust is a real input, prefilled or not.
+  await expect(card.locator('input.proposal-due')).toBeVisible();
+});
+
+test('a kid can put a hand up, and the parent card shows it', async ({ page }) => {
+  await seedProposal(page, {
+    externalRef: 'smoke-email-camp', title: 'Smoke Scout Camp', personId: 'toby',
+  });
+  await page.reload();
+  await pickPerson(page, 'Toby');
+
+  const kidCard = page.locator('#k-proposals .task').filter({ hasText: 'Smoke Scout Camp' });
+  await expect(kidCard).toBeVisible();
+  await kidCard.getByRole('button', { name: /I want to go/ }).click();
+  await expect(kidCard).toContainText('You said yes');
+
+  await page.getByRole('button', { name: /Switch/ }).click();
+  await pickPerson(page, 'Peter');
+  const parentCard = page.locator('#p-proposals .parent-card').filter({ hasText: 'Smoke Scout Camp' });
+  await expect(parentCard).toContainText('wants to go');
+});
+
+test('approving a proposal puts it on the calendar, badged as from email', async ({ page }) => {
+  await seedProposal(page, {
+    externalRef: 'smoke-email-fair', title: 'Smoke School Fair', personId: 'ollie',
+  });
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-proposals .parent-card').filter({ hasText: 'Smoke School Fair' });
+  await card.getByRole('button', { name: /Approve/ }).click();
+  await expect(card).toBeHidden();
+
+  await page.getByRole('button', { name: /^Calendar$/ }).first().click();
+  await expect(page.locator('#p-calendar-grid .cal-cell').first()).toBeVisible();
+  await page.evaluate(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 2);
+    parentCalendarSelectedDay = d.getFullYear() + '-'
+      + String(d.getMonth() + 1).padStart(2, '0') + '-'
+      + String(d.getDate()).padStart(2, '0');
+    renderParentCalendar();
+  });
+  const agenda = page.locator('#p-calendar-agenda');
+  const row = agenda.locator('.parent-list-row').filter({ hasText: 'Smoke School Fair' });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText('📧 from email');
+});
+
+test('declining a proposal removes it and publishes nothing', async ({ page }) => {
+  await seedProposal(page, {
+    externalRef: 'smoke-email-disco', title: 'Smoke School Disco', personId: 'ollie',
+  });
+  await page.reload();
+  await pickPerson(page, 'Peter');
+
+  const card = page.locator('#p-proposals .parent-card').filter({ hasText: 'Smoke School Disco' });
+  await card.getByRole('button', { name: /Decline/ }).click();
+  // The in-app confirm, never a native dialog.
+  await page.locator('#ask-modal').getByRole('button', { name: /Decline/ }).click();
+  await expect(card).toBeHidden();
+
+  await page.getByRole('button', { name: /^Calendar$/ }).first().click();
+  await expect(page.locator('#p-calendar-grid .cal-cell').first()).toBeVisible();
+  await page.evaluate(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 2);
+    parentCalendarSelectedDay = d.getFullYear() + '-'
+      + String(d.getMonth() + 1).padStart(2, '0') + '-'
+      + String(d.getDate()).padStart(2, '0');
+    renderParentCalendar();
+  });
+  await expect(page.locator('#p-calendar-agenda')).not.toContainText('Smoke School Disco');
+});
+
+test('a parent-direct email never asks the kid', async ({ page }) => {
+  await seedProposal(page, {
+    externalRef: 'smoke-email-ipad', title: 'Smoke iPad Payment',
+    classification: 'parent-direct', personId: 'toby',
+  });
+  await page.reload();
+  await pickPerson(page, 'Toby');
+  await expect(page.locator('#k-proposals')).not.toContainText('Smoke iPad Payment');
+
+  await page.getByRole('button', { name: /Switch/ }).click();
+  await pickPerson(page, 'Peter');
+  const card = page.locator('#p-proposals .parent-card').filter({ hasText: 'Smoke iPad Payment' });
+  await expect(card).toBeVisible();
+  await expect(card).toContainText('needs a parent');
+  await expect(card).not.toContainText('waiting on');
 });


### PR DESCRIPTION
Part 2 of 3 for #41, on top of #241's proposal API. This is everything the family sees.

## Parent HQ · Approvals
- Third stat tile — **From email** — beside the existing two, warming up when something is pending; the approvals badge at the top counts proposals too.
- One card per pending proposal: 📧 title, classification tag (`kids choose` / `needs a parent`), when and who, extracted summary, sender line, **payment details in a clear bordered block** (bank, BSB, account, reference — displayed for the parent to act on, never paid automatically), a prep-list preview, and adult actions.
- An editable **Prep due** `datetime-local` input, prefilled with the proposed deadline — the parent's value wins on approve. Half-edited values survive background re-renders, same as approval notes.
- Kid-choice cards show who's being waited on: `waiting on <kid>`, `🙋 wants to go`, or `said not this time` — and a parent can always approve over the top.
- Approve reports calendar clashes in the toast; Decline confirms in-app and publishes nothing.

## Kid Home
- "📧 Coming up — want to go?" card for kid-choice proposals, with **🙋 I want to go!** / **Not for me**. Answering only changes who is waiting; after a yes the card reads "waiting on your grown-ups".

## Everywhere else
- Approved and informational items carry a **📧 from email** marker on kid event cards and parent agenda rows.

## Tests
The smoke server now sets `EMAIL_INGEST_KEY`, so tests drive the real ingest route end to end. Five new tests: the queue card with payment details, the kid hand-up round trip into the parent card, approve-to-calendar with the badge, decline publishing nothing, and parent-direct never asking the kid. The stat-tile test now expects three tiles on one row. **80 smoke tests + all logic tests + frontend checks pass locally.**

Next: PR C — the Gmail-reading timer Function. #41 stays open until it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_