### PR TITLE
The email-reading timer: Gmail to proposals, attachments included (#41)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "@azure/cosmos": "^4.2.0",
         "@azure/functions": "^4.5.1",
         "@azure/identity": "^4.5.0",
+        "adm-zip": "^0.6.0",
         "web-push": "^3.6.7"
       },
       "engines": {
@@ -362,6 +363,15 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,7 @@
     "@azure/cosmos": "^4.2.0",
     "@azure/functions": "^4.5.1",
     "@azure/identity": "^4.5.0",
+    "adm-zip": "^0.6.0",
     "web-push": "^3.6.7"
   },
   "engines": {

--- a/api/src/functions/emailIngest.js
+++ b/api/src/functions/emailIngest.js
@@ -1,0 +1,188 @@
+// The timer that reads the family inbox and turns what it finds into
+// proposals (#41). Runs hourly inside the household's waking hours; each run
+// picks up where the last one's watermark left off, triages every new email
+// cheaply, deep-reads the relevant ones with their attachments, and hands the
+// results to hero.js's ingestEmailItem - the same gate the tests drive, so
+// idempotency, classification behaviour and notifications live in one place.
+
+const { app } = require('@azure/functions');
+const { container } = require('../lib/cosmos');
+const { HOUSEHOLD_ID } = require('../lib/seed');
+const { ROUTES, HOUSEHOLD_TZ } = require('./hero');
+const gmail = require('../lib/gmail');
+const pipeline = require('../lib/emailPipeline');
+
+// Hourly, 21:00-23:00 and 00:00-14:00 UTC = 05:00-22:00 in Perth (UTC+8,
+// no DST). Overridable per environment without a deploy.
+const EMAIL_INGEST_SCHEDULE = process.env.EMAIL_INGEST_SCHEDULE || '0 0 21-23,0-14 * * *';
+
+const STATE_DOC_ID = 'email-ingest-state';
+const MAX_ATTACHMENTS = 5;
+const MAX_ATTACHMENT_BYTES = 4 * 1024 * 1024;
+const PROCESSED_IDS_KEPT = 300;
+// The after: query is re-run from an hour before the watermark, so a message
+// that landed mid-run cannot fall between two runs; processedIds and the
+// deterministic ingest ids make the overlap harmless.
+const WATERMARK_OVERLAP_MS = 60 * 60 * 1000;
+
+const REQUIRED_ENV = ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET', 'GMAIL_REFRESH_TOKEN', 'EMAIL_INGEST_KEY', 'LLM_API_KEY'];
+
+function configMissing() {
+  return REQUIRED_ENV.filter((key) => !String(process.env[key] || '').trim());
+}
+
+// The watermark doc lives in the households container: it is only ever read
+// by id, and getState reads its own household doc by id too, so nothing that
+// queries whole containers ever sees it.
+async function readIngestState() {
+  const { resource } = await container('households')
+    .item(STATE_DOC_ID, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  return resource;
+}
+
+async function writeIngestState(state) {
+  await container('households').items.upsert({
+    id: STATE_DOC_ID,
+    householdId: HOUSEHOLD_ID,
+    ...state,
+  });
+}
+
+async function listKids() {
+  const { resources } = await container('people')
+    .items.query({
+      query: 'SELECT * FROM c WHERE c.householdId = @h',
+      parameters: [{ name: '@h', value: HOUSEHOLD_ID }],
+    })
+    .fetchAll();
+  return resources
+    .filter((p) => p.role === 'kid')
+    .map((p) => ({ id: p.id, name: p.name }));
+}
+
+function slug(text) {
+  return String(text || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 60);
+}
+
+async function runEmailIngest(log = () => {}) {
+  const missing = configMissing();
+  if (missing.length) {
+    log(`emailIngest skipped - missing app settings: ${missing.join(', ')}`);
+    return { skipped: true, missing };
+  }
+
+  const token = await gmail.getAccessToken();
+  const state = (await readIngestState()) || {};
+  const watermarkMs = Number(state.watermarkMs) || (Date.now() - 24 * 60 * 60 * 1000);
+  const processed = new Set(Array.isArray(state.processedIds) ? state.processedIds : []);
+
+  const sinceSeconds = Math.floor((watermarkMs - WATERMARK_OVERLAP_MS) / 1000);
+  const refs = await gmail.listMessagesSince(token, sinceSeconds);
+
+  const kids = await listKids();
+  let maxInternalMs = watermarkMs;
+  let relevant = 0;
+  let ingested = 0;
+  let duplicates = 0;
+
+  for (const ref of refs) {
+    if (processed.has(ref.id)) continue;
+    let msg;
+    try {
+      msg = await gmail.getMessage(token, ref.id);
+    } catch (err) {
+      // One unreadable message must not stall the whole inbox; unprocessed,
+      // it is retried next run via the overlap window.
+      log(`emailIngest: could not read message ${ref.id}: ${err.message}`);
+      continue;
+    }
+    const internalMs = Number(msg.internalDate) || Date.now();
+    const email = {
+      id: ref.id,
+      threadId: msg.threadId || ref.id,
+      from: gmail.header(msg.payload, 'From'),
+      subject: gmail.header(msg.payload, 'Subject'),
+      receivedAt: new Date(internalMs).toISOString(),
+      bodyText: gmail.extractBodyText(msg.payload),
+    };
+
+    try {
+      const triage = await pipeline.triageEmail(email);
+      if (triage.relevant) {
+        relevant += 1;
+        const blocks = [];
+        for (const att of gmail.listAttachments(msg.payload).slice(0, MAX_ATTACHMENTS)) {
+          if (att.size > MAX_ATTACHMENT_BYTES) continue;
+          try {
+            const attachment = await gmail.getAttachment(token, ref.id, att.attachmentId);
+            const block = pipeline.attachmentToBlock(att, attachment.data);
+            if (block) blocks.push(block);
+          } catch (err) {
+            log(`emailIngest: attachment ${att.filename} on ${ref.id} skipped: ${err.message}`);
+          }
+        }
+        const extraction = await pipeline.extractProposals(email, blocks, kids, HOUSEHOLD_TZ);
+        for (const item of extraction.items) {
+          const result = await ROUTES.ingestEmailItem({
+            ingestKey: process.env.EMAIL_INGEST_KEY,
+            classification: item.classification,
+            type: item.type || 'event',
+            title: item.title,
+            personId: item.personId || null,
+            startAt: item.startAt,
+            endAt: item.endAt || null,
+            allDay: !!item.allDay,
+            summary: item.summary || '',
+            payments: item.payments || [],
+            prepLists: item.prepLists || [],
+            adultActions: item.adultActions || [],
+            proposedPrepDueBy: item.proposedPrepDueBy || null,
+            // Per item, not per thread: one scouts email carries several
+            // events, and a chase-up in the same thread re-mentioning one of
+            // them lands on the same ref and dedupes.
+            externalRef: `gmail-${email.threadId}:${slug(item.title)}`,
+            from: email.from,
+            subject: email.subject,
+            receivedAt: email.receivedAt,
+          });
+          if (result.ok && result.duplicate) duplicates += 1;
+          else if (result.ok) ingested += 1;
+          else log(`emailIngest: '${item.title}' refused: ${result.error}`);
+        }
+      }
+    } catch (err) {
+      // Triage or extraction failing on one email should not block the rest,
+      // but the message stays unprocessed so the next run retries it.
+      log(`emailIngest: pipeline failed on ${ref.id}: ${err.message}`);
+      continue;
+    }
+
+    processed.add(ref.id);
+    if (internalMs > maxInternalMs) maxInternalMs = internalMs;
+  }
+
+  await writeIngestState({
+    watermarkMs: maxInternalMs,
+    processedIds: [...processed].slice(-PROCESSED_IDS_KEPT),
+    lastRunAt: new Date().toISOString(),
+  });
+
+  const summary = { skipped: false, checked: refs.length, relevant, ingested, duplicates };
+  log(`emailIngest: ${JSON.stringify(summary)}`);
+  return summary;
+}
+
+app.timer('emailIngest', {
+  schedule: EMAIL_INGEST_SCHEDULE,
+  handler: async (_timer, context) => {
+    try {
+      await runEmailIngest((line) => context.log(line));
+    } catch (err) {
+      context.error(err);
+    }
+  },
+});
+
+module.exports = { runEmailIngest, configMissing, EMAIL_INGEST_SCHEDULE };

--- a/api/src/lib/emailPipeline.js
+++ b/api/src/lib/emailPipeline.js
@@ -1,0 +1,205 @@
+// The two-stage read of one email. Stage one is a cheap yes/no - is there
+// anything here for this family's kids - so the expensive read only happens
+// on the emails that earn it. Stage two reads the full body AND the
+// attachments (the value in a scouts email is the PDF, not the covering
+// note) and returns structured items ready for ingestEmailItem.
+
+const Anthropic = require('@anthropic-ai/sdk');
+const AdmZip = require('adm-zip');
+
+const TRIAGE_MODEL = 'claude-haiku-4-5';
+const EXTRACT_MODEL = 'claude-sonnet-5';
+
+const defaultCreateClient = (apiKey) => new Anthropic({ apiKey });
+let createClient = defaultCreateClient;
+
+function setEmailClientFactory(factory) {
+  createClient = typeof factory === 'function' ? factory : defaultCreateClient;
+}
+
+function resetEmailClientFactory() {
+  createClient = defaultCreateClient;
+}
+
+function responseText(response) {
+  return Array.isArray(response && response.content)
+    ? response.content
+      .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+      .map((block) => block.text)
+      .join('\n')
+      .trim()
+    : '';
+}
+
+function extractJsonObject(text) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) return null;
+  try { return JSON.parse(trimmed); } catch {}
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  try { return JSON.parse(trimmed.slice(start, end + 1)); } catch { return null; }
+}
+
+// "Relevant" is deliberately wide: anything about the kids' activities,
+// school, clubs, events, or money owed for any of those. Missing a scout camp
+// costs far more than one wasted deep read.
+async function triageEmail(email) {
+  const client = createClient(process.env.LLM_API_KEY);
+  const response = await client.messages.create({
+    model: TRIAGE_MODEL,
+    max_tokens: 120,
+    temperature: 0,
+    system: 'You screen one family inbox email. Return JSON only.',
+    messages: [{
+      role: 'user',
+      content: [
+        'Is this email relevant to organising a family’s kids - activities,',
+        'events, school, clubs, camps, or payments/forms for any of those?',
+        'Newsletters that only announce dates still count as relevant.',
+        'Marketing, receipts for unrelated purchases, and adult-only mail do not.',
+        '',
+        `From: ${email.from}`,
+        `Subject: ${email.subject}`,
+        '',
+        String(email.bodyText || '').slice(0, 4000),
+        '',
+        'Return JSON: {"relevant": true|false, "why": "one short sentence"}',
+      ].join('\n'),
+    }],
+  });
+  const parsed = extractJsonObject(responseText(response));
+  return {
+    relevant: !!(parsed && parsed.relevant),
+    why: parsed && parsed.why ? String(parsed.why) : '',
+  };
+}
+
+// A .xlsx is a zip of XML; the packing lists that arrive this way are flat
+// text in disguise. Pull every cell string rather than modelling the sheet.
+function xlsxToText(buffer) {
+  try {
+    const zip = new AdmZip(buffer);
+    const texts = [];
+    zip.getEntries().forEach((entry) => {
+      if (!/^xl\/(sharedStrings\.xml|worksheets\/sheet\d+\.xml)$/.test(entry.entryName)) return;
+      const xml = entry.getData().toString('utf8');
+      const matches = xml.match(/<t[^>]*>([^<]*)<\/t>/g) || [];
+      matches.forEach((m) => {
+        const inner = m.replace(/<[^>]+>/g, '').trim();
+        if (inner) texts.push(inner);
+      });
+    });
+    return texts.join('\n');
+  } catch {
+    return '';
+  }
+}
+
+// One attachment -> one Claude content block, or null when the type carries
+// nothing readable. data arrives base64url from the Gmail API.
+function attachmentToBlock(att, base64UrlData) {
+  const data = String(base64UrlData || '').replace(/-/g, '+').replace(/_/g, '/');
+  if (!data) return null;
+  const name = String(att.filename || '').toLowerCase();
+  const mime = String(att.mimeType || '').toLowerCase();
+  if (mime === 'application/pdf' || name.endsWith('.pdf')) {
+    return { type: 'document', source: { type: 'base64', media_type: 'application/pdf', data } };
+  }
+  const imageTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+  if (imageTypes.includes(mime)) {
+    return { type: 'image', source: { type: 'base64', media_type: mime, data } };
+  }
+  if (name.endsWith('.xlsx') || mime.includes('spreadsheetml')) {
+    const text = xlsxToText(Buffer.from(data, 'base64'));
+    if (!text) return null;
+    return { type: 'text', text: `Attachment ${att.filename} (spreadsheet contents):\n${text.slice(0, 8000)}` };
+  }
+  return null;
+}
+
+function buildExtractionPrompt(email, kids, tz, nowIso) {
+  const kidLines = kids.map((kid) => `- ${kid.id}: ${kid.name}`).join('\n');
+  return [
+    'Read this family-inbox email (attachments included as separate blocks)',
+    'and extract every distinct kid-relevant event, activity, or action as an',
+    'item. Return JSON only.',
+    '',
+    `Household timezone: ${tz}. Current time: ${nowIso}.`,
+    'Kids:',
+    kidLines || '- none',
+    '',
+    `From: ${email.from}`,
+    `Subject: ${email.subject}`,
+    `Received: ${email.receivedAt}`,
+    '',
+    'Body:',
+    String(email.bodyText || '').slice(0, 12000),
+    '',
+    'Return JSON with this shape:',
+    '{"items":[{"classification":"kid-choice|parent-direct|informational",',
+    '"type":"event","title":"string","personId":"kid-id-or-null",',
+    '"startAt":"ISO with timezone offset","endAt":"ISO-or-null","allDay":false,',
+    '"summary":"2-3 plain sentences a parent can decide from",',
+    '"payments":[{"description":"","amount":"","bank":"","accountName":"","bsb":"","account":"","reference":""}],',
+    '"prepLists":[{"personId":"kid-id","items":[{"text":""}],"points":0}],',
+    '"adultActions":[{"text":""}],',
+    '"proposedPrepDueBy":"ISO-or-null"}]}',
+    '',
+    'Rules:',
+    '- One item per distinct event. A single email can carry several.',
+    '- classification: kid-choice = an optional activity the kid can choose to',
+    '  join (hikes, camps, discos); parent-direct = needs a parent decision or',
+    '  money/forms regardless of kid interest (fees, purchases, permissions',
+    '  with cost); informational = dates and announcements with nothing to',
+    '  decide (club newsletters, term dates).',
+    '- personId: the kid the item is for, matched by name in the email or its',
+    '  attachments; null when it is for the whole family or unclear.',
+    '- startAt/endAt: local wall time in the household timezone, written with',
+    '  its UTC offset. Multi-day camps: startAt first day, endAt last day.',
+    '- payments: copy bank details exactly as written (they are displayed to a',
+    '  parent to pay manually - never invent or normalise digits). Omit fields',
+    '  the email does not state.',
+    '- prepLists: packing/prep lists found in the email or attachments, as',
+    '  short tickable lines for the kid the item is for. points stays 0 - the',
+    '  parents decide what preparation is worth.',
+    '- adultActions: things only a parent can do (pay, sign, submit a form).',
+    '- proposedPrepDueBy: when preparation should be done by, judged from the',
+    '  event’s scale: an ordinary evening activity -> 18:00 the day before;',
+    '  a day trip -> 18:00 the day before; an overnight camp or trip -> 18:00',
+    '  two to three days before. null when there is nothing to prepare.',
+    '- Skip anything already in the past. Return {"items":[]} when nothing',
+    '  qualifies.',
+  ].join('\n');
+}
+
+async function extractProposals(email, attachmentBlocks, kids, tz) {
+  const client = createClient(process.env.LLM_API_KEY);
+  const content = [
+    { type: 'text', text: buildExtractionPrompt(email, kids, tz, new Date().toISOString()) },
+    ...attachmentBlocks,
+  ];
+  const response = await client.messages.create({
+    model: EXTRACT_MODEL,
+    max_tokens: 3000,
+    temperature: 0,
+    system: 'Extract structured family-calendar items from one email and its attachments. Return JSON only.',
+    messages: [{ role: 'user', content }],
+  });
+  const parsed = extractJsonObject(responseText(response));
+  const items = parsed && Array.isArray(parsed.items) ? parsed.items : [];
+  return {
+    items: items.filter((item) => item && item.title && item.startAt && item.classification),
+  };
+}
+
+module.exports = {
+  triageEmail,
+  extractProposals,
+  attachmentToBlock,
+  xlsxToText,
+  setEmailClientFactory,
+  resetEmailClientFactory,
+  TRIAGE_MODEL,
+  EXTRACT_MODEL,
+};

--- a/api/src/lib/gmail.js
+++ b/api/src/lib/gmail.js
@@ -1,0 +1,125 @@
+// Minimal Gmail REST v1 client over the platform fetch. Auth is a refresh
+// token the owner minted once through Google's consent screen; the Function
+// swaps it for a short-lived access token on every run. No Gmail SDK: four
+// endpoints and some MIME walking do not justify a dependency tree.
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+async function getAccessToken() {
+  const body = new URLSearchParams({
+    client_id: process.env.GMAIL_CLIENT_ID,
+    client_secret: process.env.GMAIL_CLIENT_SECRET,
+    refresh_token: process.env.GMAIL_REFRESH_TOKEN,
+    grant_type: 'refresh_token',
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`Gmail token refresh failed: ${res.status} ${await res.text().catch(() => '')}`);
+  }
+  const data = await res.json();
+  if (!data.access_token) throw new Error('Gmail token refresh returned no access_token');
+  return data.access_token;
+}
+
+async function gmailGet(token, path) {
+  const res = await fetch(`${GMAIL_BASE}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Gmail GET ${path.split('?')[0]} failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// Everything since the watermark, spam and trash excluded, newest runs capped
+// so one enormous backlog cannot blow the Function's time budget.
+async function listMessagesSince(token, epochSeconds, cap = 200) {
+  const q = `after:${epochSeconds} -in:spam -in:trash`;
+  const out = [];
+  let pageToken = null;
+  do {
+    const page = await gmailGet(token, `/messages?q=${encodeURIComponent(q)}&maxResults=50${pageToken ? `&pageToken=${pageToken}` : ''}`);
+    out.push(...(page.messages || []));
+    pageToken = page.nextPageToken || null;
+  } while (pageToken && out.length < cap);
+  return out.slice(0, cap);
+}
+
+function getMessage(token, id) {
+  return gmailGet(token, `/messages/${id}?format=full`);
+}
+
+function getAttachment(token, messageId, attachmentId) {
+  return gmailGet(token, `/messages/${messageId}/attachments/${encodeURIComponent(attachmentId)}`);
+}
+
+function header(payload, name) {
+  const match = ((payload && payload.headers) || [])
+    .find((h) => String(h.name || '').toLowerCase() === name.toLowerCase());
+  return match ? match.value : '';
+}
+
+function decodeB64Url(data) {
+  return Buffer.from(String(data || '').replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function walkParts(part, visit) {
+  if (!part) return;
+  visit(part);
+  (part.parts || []).forEach((child) => walkParts(child, visit));
+}
+
+// text/plain wins; otherwise the HTML part with the tags stripped. Triage and
+// extraction read prose, not markup.
+function extractBodyText(payload) {
+  let plain = '';
+  let html = '';
+  walkParts(payload, (part) => {
+    const data = part.body && part.body.data;
+    if (!data) return;
+    if (part.mimeType === 'text/plain' && !plain) plain = decodeB64Url(data).toString('utf8');
+    if (part.mimeType === 'text/html' && !html) html = decodeB64Url(data).toString('utf8');
+  });
+  if (plain.trim()) return plain.trim();
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function listAttachments(payload) {
+  const out = [];
+  walkParts(payload, (part) => {
+    if (part.filename && part.body && part.body.attachmentId) {
+      out.push({
+        filename: part.filename,
+        mimeType: part.mimeType || '',
+        attachmentId: part.body.attachmentId,
+        size: part.body.size || 0,
+      });
+    }
+  });
+  return out;
+}
+
+module.exports = {
+  getAccessToken,
+  listMessagesSince,
+  getMessage,
+  getAttachment,
+  header,
+  decodeB64Url,
+  extractBodyText,
+  listAttachments,
+};

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2465,6 +2465,200 @@ async function main() {
   assert.strictEqual(ghostDecide.ok, false);
   console.log('✓ responding/deciding on a missing proposal fails cleanly');
 
+  // -------------------------------------------------------------------------
+  // The email ingest Function (#41 part 3). Gmail is mocked at the fetch
+  // layer and Claude at the client factory, so the run under test is the real
+  // pipeline: watermark, triage, attachments, extraction, ingest, dedupe.
+
+  const { runEmailIngest, configMissing } = require('./src/functions/emailIngest.js');
+  const emailPipeline = require('./src/lib/emailPipeline.js');
+
+  // Fail closed: no Gmail credentials = a logged skip, never a crash and
+  // never a half-configured network call.
+  delete process.env.GMAIL_CLIENT_ID;
+  const skipped = await runEmailIngest();
+  assert.strictEqual(skipped.skipped, true);
+  assert.ok(skipped.missing.includes('GMAIL_CLIENT_ID'));
+  console.log('✓ emailIngest skips cleanly when unconfigured');
+
+  process.env.GMAIL_CLIENT_ID = 'test-client';
+  process.env.GMAIL_CLIENT_SECRET = 'test-secret';
+  process.env.GMAIL_REFRESH_TOKEN = 'test-refresh';
+  process.env.LLM_API_KEY = 'test-llm-key';
+  // EMAIL_INGEST_KEY is already 'test-ingest-key' from the proposal tests.
+  assert.deepStrictEqual(configMissing(), []);
+
+  const b64url = (text) => Buffer.from(text, 'utf8').toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+  const scoutStart = new Date(at('09:00').getTime() + 6 * 86400000);
+  const scoutsBody = 'Hi families, two events this term. Bibbulmun hike and Manjedal camp. Fees to Westpac BSB 036-022 acct 624871.';
+  const gmailStore = {
+    messages: [
+      { id: 'msg-scouts', threadId: 'thread-scouts' },
+      { id: 'msg-shoes', threadId: 'thread-shoes' },
+    ],
+    full: {
+      'msg-scouts': {
+        id: 'msg-scouts', threadId: 'thread-scouts',
+        internalDate: String(Date.now() - 60000),
+        payload: {
+          mimeType: 'multipart/mixed',
+          headers: [
+            { name: 'From', value: 'leader@scouts.example' },
+            { name: 'Subject', value: 'Term 3 events' },
+          ],
+          parts: [
+            { mimeType: 'text/plain', body: { data: b64url(scoutsBody) } },
+            { mimeType: 'application/pdf', filename: 'camp.pdf', body: { attachmentId: 'att-pdf', size: 1000 } },
+            { mimeType: 'application/octet-stream', filename: 'huge.bin', body: { attachmentId: 'att-huge', size: 99 * 1024 * 1024 } },
+          ],
+        },
+      },
+      'msg-shoes': {
+        id: 'msg-shoes', threadId: 'thread-shoes',
+        internalDate: String(Date.now() - 30000),
+        payload: {
+          mimeType: 'text/html',
+          headers: [
+            { name: 'From', value: 'promo@shoes.example' },
+            { name: 'Subject', value: 'SALE 50% off' },
+          ],
+          body: { data: b64url('<p>Buy <b>shoes</b> now</p>') },
+        },
+      },
+    },
+  };
+
+  const fetchLog = [];
+  const realFetch = global.fetch;
+  global.fetch = async (url, opts) => {
+    const u = String(url);
+    fetchLog.push(u);
+    const json = (obj) => ({ ok: true, status: 200, json: async () => obj, text: async () => JSON.stringify(obj) });
+    if (u.startsWith('https://oauth2.googleapis.com/token')) {
+      const params = new URLSearchParams(String(opts.body));
+      assert.strictEqual(params.get('refresh_token'), 'test-refresh');
+      return json({ access_token: 'test-access-token' });
+    }
+    if (u.includes('/messages?q=')) {
+      assert.ok(decodeURIComponent(u).includes('-in:spam'), 'spam and trash stay excluded');
+      return json({ messages: gmailStore.messages });
+    }
+    if (u.includes('/attachments/')) {
+      return json({ data: b64url('%PDF-1.4 fake camp form') });
+    }
+    const msgMatch = u.match(/\/messages\/([^/?]+)\?format=full/);
+    if (msgMatch) return json(gmailStore.full[msgMatch[1]]);
+    throw new Error('unexpected fetch in test: ' + u);
+  };
+
+  const ingestLlmCalls = [];
+  emailPipeline.setEmailClientFactory(() => ({
+    messages: {
+      create: async (req) => {
+        ingestLlmCalls.push(req);
+        if (req.model === emailPipeline.TRIAGE_MODEL) {
+          const prompt = req.messages[0].content;
+          const relevant = /scouts|Bibbulmun/i.test(prompt);
+          return { content: [{ type: 'text', text: JSON.stringify({ relevant, why: 'test' }) }] };
+        }
+        // Extraction: two events out of the one scouts email, the second with
+        // a payment block and a prep list drawn from the attachment.
+        const hikeStart = new Date(scoutStart);
+        const campStart = new Date(scoutStart.getTime() + 12 * 86400000);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              items: [
+                {
+                  classification: 'kid-choice', type: 'event', title: 'Bibbulmun Track Hike',
+                  personId: 'ollie', startAt: hikeStart.toISOString(), endAt: null,
+                  summary: 'Overnight hike, $5.',
+                  payments: [{ description: 'Hike fee', amount: '$5', bank: 'Westpac', bsb: '036-022', account: '624871', reference: 'Ollie' }],
+                  prepLists: [], adultActions: [{ text: 'Pay $5 hike fee' }],
+                  proposedPrepDueBy: new Date(hikeStart.getTime() - 86400000).toISOString(),
+                },
+                {
+                  classification: 'kid-choice', type: 'event', title: 'Manjedal Scout Camp',
+                  personId: 'ollie', startAt: campStart.toISOString(),
+                  endAt: new Date(campStart.getTime() + 2 * 86400000).toISOString(),
+                  summary: 'Three-day camp, $100.',
+                  payments: [{ description: 'Camp fee', amount: '$100', bank: 'Westpac', bsb: '036-022', account: '624871', reference: 'Ollie' }],
+                  prepLists: [{ personId: 'ollie', items: [{ text: 'Pack sleeping bag' }], points: 0 }],
+                  adultActions: [{ text: 'Pay $100 camp fee' }],
+                  proposedPrepDueBy: new Date(campStart.getTime() - 3 * 86400000).toISOString(),
+                },
+              ],
+            }),
+          }],
+        };
+      },
+    },
+  }));
+
+  const run1 = await runEmailIngest();
+  assert.strictEqual(run1.skipped, false);
+  assert.strictEqual(run1.checked, 2, 'both new messages were checked');
+  assert.strictEqual(run1.relevant, 1, 'only the scouts email survived triage');
+  assert.strictEqual(run1.ingested, 2, 'one email produced two proposals');
+  assert.strictEqual(run1.duplicates, 0);
+
+  const afterRun = await getState();
+  const hikeProp = afterRun.proposals.find((p) => p.title === 'Bibbulmun Track Hike');
+  const campProp = afterRun.proposals.find((p) => p.title === 'Manjedal Scout Camp');
+  assert.ok(hikeProp && campProp, 'both events are pending proposals');
+  assert.strictEqual(campProp.payments[0].bsb, '036-022', 'bank details travelled through');
+  assert.strictEqual(campProp.prepLists[0].items[0].text, 'Pack sleeping bag');
+  assert.strictEqual(hikeProp.sourceMeta.from, 'leader@scouts.example');
+  console.log('✓ one scouts email becomes two pending proposals, payments and prep intact');
+
+  // The deep read carried the PDF but never the oversized attachment.
+  const extractCall = ingestLlmCalls.find((call) => call.model === emailPipeline.EXTRACT_MODEL);
+  assert.ok(extractCall, 'extraction ran');
+  const blockTypes = extractCall.messages[0].content.map((block) => block.type);
+  assert.deepStrictEqual(blockTypes, ['text', 'document'], 'prompt plus the PDF, nothing else');
+  assert.ok(!fetchLog.some((u) => u.includes('att-huge')), 'the 99MB attachment was never fetched');
+  console.log('✓ attachments ride along as document blocks, size-capped');
+
+  // The promo email cost one triage call and nothing more.
+  const triageCalls = ingestLlmCalls.filter((call) => call.model === emailPipeline.TRIAGE_MODEL);
+  assert.strictEqual(triageCalls.length, 2, 'every new email is triaged once');
+  assert.strictEqual(ingestLlmCalls.length, 3, 'irrelevant mail never reaches the extractor');
+  console.log('✓ triage gates the expensive read');
+
+  // Second run: same inbox, nothing new - processedIds and the watermark
+  // mean no re-triage, and the deterministic ids would dedupe anyway.
+  ingestLlmCalls.length = 0;
+  const run2 = await runEmailIngest();
+  assert.strictEqual(run2.ingested, 0);
+  assert.strictEqual(ingestLlmCalls.length, 0, 'already-processed messages are not re-read');
+  console.log('✓ a second run re-reads nothing and creates nothing');
+
+  global.fetch = realFetch;
+  emailPipeline.resetEmailClientFactory();
+
+  // Attachment block mapping, including the xlsx-is-a-zip path.
+  const { attachmentToBlock, xlsxToText } = emailPipeline;
+  const pdfBlock = attachmentToBlock({ filename: 'form.pdf', mimeType: 'application/pdf' }, b64url('%PDF'));
+  assert.strictEqual(pdfBlock.type, 'document');
+  assert.strictEqual(pdfBlock.source.media_type, 'application/pdf');
+  const imgBlock = attachmentToBlock({ filename: 'photo.jpg', mimeType: 'image/jpeg' }, b64url('jpegbytes'));
+  assert.strictEqual(imgBlock.type, 'image');
+  const AdmZip = require('adm-zip');
+  const zip = new AdmZip();
+  zip.addFile('xl/sharedStrings.xml', Buffer.from('<sst><si><t>Sleeping bag</t></si><si><t>Torch</t></si></sst>'));
+  zip.addFile('xl/worksheets/sheet1.xml', Buffer.from('<worksheet><is><t>Water bottle</t></is></worksheet>'));
+  const xlsxB64url = zip.toBuffer().toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+  const xlsxBlock = attachmentToBlock({ filename: 'packing.xlsx', mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }, xlsxB64url);
+  assert.strictEqual(xlsxBlock.type, 'text');
+  assert.ok(/Sleeping bag/.test(xlsxBlock.text) && /Torch/.test(xlsxBlock.text) && /Water bottle/.test(xlsxBlock.text));
+  assert.strictEqual(attachmentToBlock({ filename: 'setup.exe', mimeType: 'application/octet-stream' }, b64url('MZ')), null,
+    'unreadable types are dropped, not sent');
+  assert.strictEqual(xlsxToText(Buffer.from('not a zip')), '', 'a corrupt xlsx degrades to empty, not a throw');
+  console.log('✓ attachments map to the right Claude blocks; junk is dropped');
+
   console.log('\nALL LOGIC TESTS PASSED');
 }
 

--- a/docs/email-import-setup.md
+++ b/docs/email-import-setup.md
@@ -1,0 +1,101 @@
+# Email import — one-time setup (#41)
+
+The `emailIngest` timer Function reads the family Gmail inbox hourly between
+5am and 10pm Perth time, triages every new email, deep-reads the relevant
+ones (attachments included), and drops what it finds into the app as
+proposals for the kids and parents to act on.
+
+The code ships with the app, but it **does nothing until five app settings
+exist** on the Function App. Missing settings = the run logs a skip and
+exits; nothing is ever half-configured.
+
+## What Pete does once (~15 minutes)
+
+### 1. Create a Google OAuth client
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) →
+   your existing project (or make one called `hero-tasks`).
+2. **APIs & Services → Library** → search **Gmail API** → Enable.
+3. **APIs & Services → OAuth consent screen**: user type **External**,
+   fill in the app name (`Hero Tasks`), your email in both contact fields,
+   save through the steps. Under **Test users**, add the Gmail address the
+   app should read.
+4. **APIs & Services → Credentials → Create credentials → OAuth client ID**:
+   application type **Web application**, name `hero-tasks-gmail`. Under
+   **Authorized redirect URIs** add exactly:
+   `https://developers.google.com/oauthplayground`
+5. Copy the **Client ID** and **Client Secret** it shows you.
+
+### 2. Mint the refresh token (OAuth playground)
+
+1. Go to [developers.google.com/oauthplayground](https://developers.google.com/oauthplayground).
+2. Click the ⚙️ gear (top right) → tick **Use your own OAuth credentials**
+   → paste the Client ID and Client Secret from step 1.
+3. In the left panel, scroll to **Gmail API v1** and tick
+   `https://www.googleapis.com/auth/gmail.readonly` (read-only — the app can
+   never send, delete, or change anything).
+4. Click **Authorize APIs**, sign in with the family Gmail account, allow.
+5. Click **Exchange authorization code for tokens**.
+6. Copy the **Refresh token** shown. (Ignore the access token — it expires
+   in an hour; the refresh token is the one that lasts.)
+
+### 3. Add the app settings
+
+Azure Portal → the Function App (`herotasks-func-dev`) →
+**Settings → Environment variables** → add:
+
+| Setting | Value |
+|---|---|
+| `GMAIL_CLIENT_ID` | from step 1 |
+| `GMAIL_CLIENT_SECRET` | from step 1 |
+| `GMAIL_REFRESH_TOKEN` | from step 2 |
+| `EMAIL_INGEST_KEY` | any long random string (e.g. from a password generator) — it locks the ingest route so only the timer can feed the app |
+| `LLM_API_KEY` | already set for voice reminders — check it exists |
+
+Save; the Function App restarts itself.
+
+### 4. Done — what to expect
+
+- Within the hour (5am–10pm Perth), the timer runs. First run reads the
+  last 24 hours of mail; after that it picks up from where it left off.
+- Kid-choice finds (hikes, camps, discos) ping the kid **and** the parents;
+  the kid gets a "want to go?" card, parents get the proposal card and can
+  approve over the top at any time.
+- Parent-direct finds (fees, forms, purchases) go straight to the parents.
+- Informational finds (club newsletters with dates) land directly on the
+  calendar with a 📧 mark — no approval step.
+- Payment details from emails are **displayed** on the proposal card for
+  you to pay manually. Nothing is ever paid automatically.
+
+## Troubleshooting
+
+- **Nothing appears**: Function App → the `emailIngest` function →
+  **Invocations**. A "skipped - missing app settings" line names exactly
+  which setting is absent.
+- **`Gmail token refresh failed: 400`**: the refresh token was revoked or
+  the consent screen is still in "Testing" with the token >7 days old.
+  Either publish the consent screen (**OAuth consent screen → Publish
+  app**) or re-mint the token (step 2) — published apps' refresh tokens
+  do not expire.
+- **Same event proposed twice**: only happens if it arrived in two separate
+  email threads with different titles. Decline the extra one; declined
+  proposals never come back (same thread + same title always dedupes).
+- **Pausing the whole thing**: delete the `EMAIL_INGEST_KEY` app setting.
+  The timer keeps running but skips harmlessly until you restore it.
+
+## For the agent (how it hangs together)
+
+- `api/src/functions/emailIngest.js` — the timer (NCRONTAB
+  `0 0 21-23,0-14 * * *` UTC = hourly 05:00–22:00 Perth; override with the
+  `EMAIL_INGEST_SCHEDULE` app setting). Watermark + processed-ids live in a
+  `email-ingest-state` doc in the `households` container (read by id only,
+  so no household query ever sees it).
+- `api/src/lib/gmail.js` — token refresh, message listing/reading,
+  attachment fetch, MIME walking. Read-only scope.
+- `api/src/lib/emailPipeline.js` — haiku triage, then sonnet extraction
+  with attachments as native document/image blocks (xlsx unzipped to text
+  via adm-zip). Returns items shaped for `ingestEmailItem`.
+- Writes go through `ROUTES.ingestEmailItem` in-process — same idempotency,
+  classification behaviour, and pushes as the tested route. `externalRef`
+  is `gmail-<threadId>:<title-slug>`, so chase-up emails in the same thread
+  dedupe while two events in one email stay distinct.


### PR DESCRIPTION
Part 3 of 3 for #41 — the Function that actually reads the inbox and feeds the proposal pipeline from #241/#242.

## What it does
- **`emailIngest` timer** runs hourly 5am–10pm Perth (`0 0 21-23,0-14 * * *` UTC; `EMAIL_INGEST_SCHEDULE` app setting overrides). Fails closed with a logged skip naming exactly which of the five app settings is missing. One unreadable email never stalls the rest — it's retried next run via the watermark overlap.
- **`lib/gmail.js`** — refresh-token OAuth with the **read-only** Gmail scope, watermarked listing (spam/trash excluded, hour of overlap so nothing falls between runs), MIME walking for body text and attachments. Four REST endpoints over `fetch`, no SDK.
- **`lib/emailPipeline.js`** — cheap haiku triage gates an expensive sonnet deep read. PDFs and images ride along as native document/image blocks; xlsx packing lists are unzipped to text (adm-zip — the one new dependency). Extraction returns items with classification, payment details **copied verbatim** (displayed to a parent, never paid automatically), prep lists, and a prep deadline judged from event scale (evening → night before; camp → 2–3 days out).
- Writes go through **`ROUTES.ingestEmailItem` in-process** — the same tested gate: idempotency, classification behaviour, quiet-hours pushes all live in one place. `externalRef` is `gmail-<threadId>:<title-slug>`, so a chase-up in the same thread dedupes while two events in one email stay distinct.
- Watermark + processed-ids live in an `email-ingest-state` doc in the `households` container (only ever read by id, invisible to every query).

## Setup
`docs/email-import-setup.md` walks Pete through the one-time Google consent (~15 min) and the five app settings. Until those exist, the deployed timer skips harmlessly.

## Tests
Logic tests mock Gmail at the fetch layer and Claude at the client factory, so the run under test is the real pipeline: unconfigured skip, one scouts email → two proposals with payments and prep intact, size cap leaving a 99MB attachment unfetched, triage gating the extractor, an idempotent second run, and the attachment→block mapping including corrupt-xlsx fallback. Full logic suite passes locally.

Once this and #242 land, #41 closes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_