### PR TITLE
Agenda rows wrap on narrow screens instead of crushing the title (#244)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1132,6 +1132,9 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .parent-list-row {
   display: flex;
+  /* Wrap, don't crush: on a phone the action buttons drop to their own line
+     below the details instead of squeezing the text column to nothing (#244). */
+  flex-wrap: wrap;
   align-items: flex-start;
   gap: var(--space-3);
   padding: var(--space-3);
@@ -1140,6 +1143,10 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 }
 .parent-list-row + .parent-list-row { margin-top: 0; }
 .parent-list-row .btn.small { flex: none; }
+/* A real basis keeps the text readable; when copy + buttons cannot share the
+   line, the buttons wrap rather than the words. */
+.parent-list-row .parent-copy { flex: 1 1 11rem; }
+.parent-list-row .parent-actions { margin-top: 0; margin-left: auto; }
 /* Only rows that lead somewhere become buttons; these strip the UA chrome so
    they sit flush with the inert rows beside them, and signal they are tappable. */
 button.parent-list-row {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1133,7 +1133,8 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 .parent-list-row {
   display: flex;
   /* Wrap, don't crush: on a phone the action buttons drop to their own line
-     below the details instead of squeezing the text column to nothing (#244). */
+     below the details instead of squeezing the text column to nothing
+     (issue 244). */
   flex-wrap: wrap;
   align-items: flex-start;
   gap: var(--space-3);

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -1947,3 +1947,44 @@ test('a parent-direct email never asks the kid', async ({ page }) => {
   await expect(card).toContainText('needs a parent');
   await expect(card).not.toContainText('waiting on');
 });
+
+// #244: on a phone-width screen the agenda row's three action buttons crushed
+// the text column to nothing and rendered over the title. The row must wrap:
+// buttons drop below the details when there is no room beside them.
+test('agenda action buttons never sit over the event title on a phone', async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await seedCalendar(page);
+  await openParentCalendar(page);
+  await page.evaluate(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 2);
+    parentCalendarSelectedDay = d.getFullYear() + '-'
+      + String(d.getMonth() + 1).padStart(2, '0') + '-'
+      + String(d.getDate()).padStart(2, '0');
+    renderParentCalendar();
+  });
+
+  // seedCalendar has run for several earlier tests by now, so the day holds
+  // one 'Soccer match' per run of it - any single row will do.
+  const row = page.locator('#p-calendar-agenda .parent-list-row').filter({ hasText: 'Soccer match' }).first();
+  const title = row.locator('.parent-list-title');
+  await expect(title).toBeVisible();
+  const titleBox = await title.boundingBox();
+  for (const name of [/Checklist/, /^Edit$/, /^Delete$/]) {
+    const btn = row.getByRole('button', { name });
+    await expect(btn).toBeVisible();
+    const btnBox = await btn.boundingBox();
+    const overlaps = !(
+      btnBox.x >= titleBox.x + titleBox.width
+      || btnBox.x + btnBox.width <= titleBox.x
+      || btnBox.y >= titleBox.y + titleBox.height
+      || btnBox.y + btnBox.height <= titleBox.y
+    );
+    expect(overlaps, `button ${name} must not cover the title`).toBe(false);
+  }
+
+  // The text column keeps a readable width - before the fix the time/who line
+  // stacked one character per line.
+  const subBox = await row.locator('.sub').first().boundingBox();
+  expect(subBox.width).toBeGreaterThan(120);
+});


### PR DESCRIPTION
Fixes #244 — on a phone, the day agenda's Checklist/Edit/Delete buttons shared one non-wrapping flex line with the event details, squeezed the text column to a few characters (the time/who line stacked letter-by-letter), and rendered over the title.

## Fix
- `.parent-list-row` now wraps; `.parent-copy` gets a real flex basis (11rem) inside list rows, so the words keep readable width and it's the buttons that drop to a new line — right-aligned — when space runs out.
- `.parent-actions` loses its stacked-card top margin inside a list row; that margin is what pushed the buttons down over the title.
- Desktop unchanged: with room, buttons stay inline exactly as before.

## Test
New phone-viewport (393px) smoke test reproduces the bug (it fails on main): selects the seeded day, measures bounding boxes, and asserts none of the three buttons intersects the title and the time/who line keeps a readable width. Full suite: 81 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_