### PR TITLE
A one-off backfill window so the first run has real mail to work with (#247)

### DIFF
--- a/api/src/functions/emailIngest.js
+++ b/api/src/functions/emailIngest.js
@@ -17,6 +17,10 @@ const pipeline = require('../lib/emailPipeline');
 const EMAIL_INGEST_SCHEDULE = process.env.EMAIL_INGEST_SCHEDULE || '0 0 21-23,0-14 * * *';
 
 const STATE_DOC_ID = 'email-ingest-state';
+// Three weeks of a family inbox comfortably exceeds 200, and a silently
+// truncated sweep reads exactly like a complete one - so this is raised, and
+// hitting it is logged.
+const MAX_MESSAGES = Number(process.env.EMAIL_MAX_MESSAGES) || 500;
 const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 4 * 1024 * 1024;
 const PROCESSED_IDS_KEPT = 300;
@@ -78,8 +82,23 @@ async function runEmailIngest(log = () => {}) {
   const watermarkMs = Number(state.watermarkMs) || (Date.now() - 24 * 60 * 60 * 1000);
   const processed = new Set(Array.isArray(state.processedIds) ? state.processedIds : []);
 
-  const sinceSeconds = Math.floor((watermarkMs - WATERMARK_OVERLAP_MS) / 1000);
-  const refs = await gmail.listMessagesSince(token, sinceSeconds);
+  // A backfill sweep, once per distinct value of EMAIL_LOOKBACK_DAYS. Left to
+  // apply on every run it would re-scan weeks of mail hourly, and since
+  // processedIds only holds the last few hundred ids, anything older would be
+  // re-triaged forever. Change the number to sweep again.
+  const requestedLookback = Number(process.env.EMAIL_LOOKBACK_DAYS);
+  const lookbackDays = Number.isFinite(requestedLookback) && requestedLookback > 0
+    ? requestedLookback : null;
+  const backfilling = lookbackDays !== null && state.lookbackDoneFor !== lookbackDays;
+
+  const sinceMs = backfilling
+    ? Date.now() - lookbackDays * 24 * 60 * 60 * 1000
+    : watermarkMs - WATERMARK_OVERLAP_MS;
+  if (backfilling) log(`emailIngest: backfilling ${lookbackDays} days`);
+  const refs = await gmail.listMessagesSince(token, Math.floor(sinceMs / 1000), MAX_MESSAGES);
+  if (refs.length >= MAX_MESSAGES) {
+    log(`emailIngest: hit the ${MAX_MESSAGES}-message cap - older mail in this window was not read`);
+  }
 
   const kids = await listKids();
   let maxInternalMs = watermarkMs;
@@ -167,9 +186,10 @@ async function runEmailIngest(log = () => {}) {
     watermarkMs: maxInternalMs,
     processedIds: [...processed].slice(-PROCESSED_IDS_KEPT),
     lastRunAt: new Date().toISOString(),
+    lookbackDoneFor: backfilling ? lookbackDays : (state.lookbackDoneFor ?? null),
   });
 
-  const summary = { skipped: false, checked: refs.length, relevant, ingested, duplicates };
+  const summary = { skipped: false, checked: refs.length, relevant, ingested, duplicates, backfilled: backfilling };
   log(`emailIngest: ${JSON.stringify(summary)}`);
   return summary;
 }

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2636,6 +2636,32 @@ async function main() {
   assert.strictEqual(ingestLlmCalls.length, 0, 'already-processed messages are not re-read');
   console.log('✓ a second run re-reads nothing and creates nothing');
 
+  // A backfill sweep widens the window once per distinct EMAIL_LOOKBACK_DAYS
+  // value, then hands back to the watermark - otherwise every hourly run would
+  // re-scan weeks of mail and re-triage anything past the processedIds window.
+  fetchLog.length = 0;
+  process.env.EMAIL_LOOKBACK_DAYS = '21';
+  const backfill = await runEmailIngest();
+  assert.strictEqual(backfill.backfilled, true, 'the first run at a new value backfills');
+  const listUrl = fetchLog.find((u) => u.includes('/messages?q='));
+  const afterSeconds = Number(decodeURIComponent(listUrl).match(/after:(\d+)/)[1]);
+  const daysBack = (Date.now() / 1000 - afterSeconds) / 86400;
+  assert.ok(daysBack > 20.5 && daysBack < 21.5, `expected a ~21 day window, got ${daysBack.toFixed(1)}`);
+
+  fetchLog.length = 0;
+  const afterBackfill = await runEmailIngest();
+  assert.strictEqual(afterBackfill.backfilled, false, 'the same value does not sweep twice');
+  const nextListUrl = fetchLog.find((u) => u.includes('/messages?q='));
+  const nextAfter = Number(decodeURIComponent(nextListUrl).match(/after:(\d+)/)[1]);
+  assert.ok((Date.now() / 1000 - nextAfter) / 86400 < 1, 'back to the watermark window');
+
+  process.env.EMAIL_LOOKBACK_DAYS = '30';
+  const secondBackfill = await runEmailIngest();
+  assert.strictEqual(secondBackfill.backfilled, true, 'a changed value sweeps again');
+  delete process.env.EMAIL_LOOKBACK_DAYS;
+  console.log('✓ a backfill window runs once per value, then hands back to the watermark');
+
+
   global.fetch = realFetch;
   emailPipeline.resetEmailClientFactory();
 

--- a/docs/email-import-setup.md
+++ b/docs/email-import-setup.md
@@ -67,6 +67,26 @@ Save; the Function App restarts itself.
 - Payment details from emails are **displayed** on the proposal card for
   you to pay manually. Nothing is ever paid automatically.
 
+## Sweeping older mail (first run, or a catch-up)
+
+With no history, a run only looks back 24 hours - which on a quiet day finds
+nothing, and "working, nothing to report" looks identical to "broken". To sweep
+a few weeks instead, add an app setting:
+
+| Setting | Value |
+|---|---|
+| `EMAIL_LOOKBACK_DAYS` | e.g. `21` |
+
+The sweep runs **once per value**. After it, the next run goes back to reading
+only new mail; change the number (say to `30`) if you want another sweep. It is
+left in place safely - it does not re-scan every hour, which would re-read the
+same weeks of mail over and over.
+
+Anything already imported comes back as a duplicate rather than a second card,
+so a sweep can overlap earlier runs harmlessly. `EMAIL_MAX_MESSAGES` (default
+500) caps how many messages one run reads; if a sweep hits the cap, the run
+logs that older mail in the window went unread.
+
 ## Troubleshooting
 
 - **Nothing appears**: Function App → the `emailIngest` function →

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Fixes #247.

With no watermark, the first run looks back only 24 hours — so on a quiet day it finds nothing, and "working, nothing to report" is indistinguishable from broken.

- **`EMAIL_LOOKBACK_DAYS`** sweeps that many days instead of the watermark, **once per distinct value** (tracked as `lookbackDoneFor` in the state doc). Applying it on every run would re-scan weeks hourly and — since `processedIds` only holds the last few hundred ids — re-triage older mail forever, burning tokens. Change the number to sweep again.
- Message cap raised to a configurable **`EMAIL_MAX_MESSAGES`** (default 500; 200 is easily under three weeks of a family inbox), and **hitting it is now logged** so a truncated sweep can't read as a complete one.
- Run summary reports `backfilled`.

Re-processing stays safe: ingest ids are deterministic, so anything already imported returns as a duplicate rather than a second card.

**Tests:** assert the widened `after:` window is ~21 days, that the same value doesn't sweep twice, and that a changed value sweeps again. Full logic suite passes.

**Docs:** `email-import-setup.md` gains a "Sweeping older mail" section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_