### PR TITLE
Drop temperature from the extraction call — Sonnet 5 rejects it

### DIFF
--- a/api/src/lib/emailPipeline.js
+++ b/api/src/lib/emailPipeline.js
@@ -182,7 +182,9 @@ async function extractProposals(email, attachmentBlocks, kids, tz) {
   const response = await client.messages.create({
     model: EXTRACT_MODEL,
     max_tokens: 3000,
-    temperature: 0,
+    // No temperature: Sonnet 5 removed the sampling parameters and rejects
+    // them with a 400. Triage keeps temperature 0 because Haiku 4.5 still
+    // accepts it and a deterministic yes/no is worth having.
     system: 'Extract structured family-calendar items from one email and its attachments. Return JSON only.',
     messages: [{ role: 'user', content }],
   });

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2617,6 +2617,9 @@ async function main() {
   // The deep read carried the PDF but never the oversized attachment.
   const extractCall = ingestLlmCalls.find((call) => call.model === emailPipeline.EXTRACT_MODEL);
   assert.ok(extractCall, 'extraction ran');
+  // Sonnet 5 rejects sampling parameters with a 400 - this cost a live run.
+  assert.strictEqual(extractCall.temperature, undefined,
+    'the extraction call must not send temperature');
   const blockTypes = extractCall.messages[0].content.map((block) => block.type);
   assert.deepStrictEqual(blockTypes, ['text', 'document'], 'prompt plus the PDF, nothing else');
   assert.ok(!fetchLog.some((u) => u.includes('att-huge')), 'the 99MB attachment was never fetched');


### PR DESCRIPTION
The live run finally reached extraction and returned:

> `400 invalid_request_error: temperature is deprecated for this model`

Sonnet 5 removed the sampling parameters (`temperature` / `top_p` / `top_k`) and rejects them outright. Haiku 4.5 still accepts them — which is exactly why triage succeeded and extraction failed on the same run.

- Extraction call no longer sends `temperature`.
- Triage keeps `temperature: 0`, since Haiku accepts it and a deterministic relevant/not-relevant answer is worth having. The asymmetry is commented so it doesn't get "corrected" back.
- Test asserts the extraction call sends no temperature — this one cost a live debugging round, so it's worth pinning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_