### PR TITLE
Read only Gmail's Primary tab

### DIFF
--- a/api/src/lib/gmail.js
+++ b/api/src/lib/gmail.js
@@ -36,10 +36,18 @@ async function gmailGet(token, path) {
   return res.json();
 }
 
+// Which Gmail tab to read. Primary only, by design: the school and club mail
+// that matters lands there, while Promotions, Social and Updates are where
+// marketing lives - and marketing is what the first live sweep wrongly turned
+// into calendar items. Set EMAIL_GMAIL_CATEGORY to another tab name, or to
+// 'all', to widen it without a deploy.
+const GMAIL_CATEGORY = String(process.env.EMAIL_GMAIL_CATEGORY || 'primary').trim();
+
 // Everything since the watermark, spam and trash excluded, newest runs capped
 // so one enormous backlog cannot blow the Function's time budget.
 async function listMessagesSince(token, epochSeconds, cap = 200) {
-  const q = `after:${epochSeconds} -in:spam -in:trash`;
+  const category = GMAIL_CATEGORY && GMAIL_CATEGORY !== 'all' ? ` category:${GMAIL_CATEGORY}` : '';
+  const q = `after:${epochSeconds} -in:spam -in:trash${category}`;
   const out = [];
   let pageToken = null;
   do {

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2542,7 +2542,11 @@ async function main() {
       return json({ access_token: 'test-access-token' });
     }
     if (u.includes('/messages?q=')) {
-      assert.ok(decodeURIComponent(u).includes('-in:spam'), 'spam and trash stay excluded');
+      const query = decodeURIComponent(u);
+      assert.ok(query.includes('-in:spam'), 'spam and trash stay excluded');
+      // Primary only: Promotions and Updates are where marketing lives, and
+      // the first live sweep turned a swim-school promo into a calendar item.
+      assert.ok(query.includes('category:primary'), 'only the Primary tab is read');
       return json({ messages: gmailStore.messages });
     }
     if (u.includes('/attachments/')) {

--- a/docs/email-import-setup.md
+++ b/docs/email-import-setup.md
@@ -87,6 +87,20 @@ so a sweep can overlap earlier runs harmlessly. `EMAIL_MAX_MESSAGES` (default
 500) caps how many messages one run reads; if a sweep hits the cap, the run
 logs that older mail in the window went unread.
 
+## Which mail gets read
+
+Only Gmail's **Primary** tab, minus spam and trash. Promotions, Social and
+Updates are skipped: that is where marketing lives, and the first live sweep
+turned a swim-school "free trial" promo into a calendar item. School, club and
+scouts mail lands in Primary.
+
+If something legitimate is being filed into another tab, widen it with an app
+setting rather than a deploy:
+
+| Setting | Value |
+|---|---|
+| `EMAIL_GMAIL_CATEGORY` | another tab name (e.g. `updates`), or `all` for every tab |
+
 ## Troubleshooting
 
 - **Nothing appears**: Function App → the `emailIngest` function →


### PR DESCRIPTION
The first successful live sweep imported a swim-school "FREE trial" promo as a calendar item (twice — two branches of the same chain) and flagged a museum newsletter as relevant. Both came from **Promotions/Updates**.

Gmail has already done this classification work. `category:primary` is a sharper filter than anything the triage prompt can express, and it's free — those messages are never fetched, never read, never charged for.

- Search now carries `category:primary`; spam and trash stay excluded as before.
- **`EMAIL_GMAIL_CATEGORY`** widens it (another tab name, or `all`) without a deploy, in case something legitimate turns out to be filed elsewhere.
- Test asserts the query carries `category:primary`.
- Docs: a "Which mail gets read" section explaining the choice and the escape hatch.

Next after this lands: re-run the sweep reaching far enough back to actually reach the Scouts thread (10 and 24 Aug) — the 25-message cap only got a few days deep, so the case we care about, including the hike-vs-camp split, hasn't been tested yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_