### PR TITLE
A capped run walks the window instead of re-reading its newest mail

### DIFF
--- a/api/src/functions/emailIngest.js
+++ b/api/src/functions/emailIngest.js
@@ -71,8 +71,9 @@ function slug(text) {
 }
 
 // options lets the diagnostic route run a small, bounded sweep on demand:
-// maxMessages caps the batch so the HTTP call cannot outlive its timeout, and
-// lookbackDays forces a window without spending the env var's one-shot.
+// maxMessages caps how many UNREAD-BY-US messages one run works through (so
+// the HTTP call cannot outlive its timeout), and lookbackDays forces a window
+// without spending the env var's one-shot.
 async function runEmailIngest(log = () => {}, options = {}) {
   const missing = configMissing();
   if (missing.length) {
@@ -101,15 +102,20 @@ async function runEmailIngest(log = () => {}, options = {}) {
     && (Number.isFinite(askedLookback) || state.lookbackDoneFor !== lookbackDays);
   const spendsOneShot = backfilling && !Number.isFinite(askedLookback);
 
-  const maxMessages = Number(options.maxMessages) > 0 ? Number(options.maxMessages) : MAX_MESSAGES;
+  // The batch cap limits how many messages this run READS, not how many it
+  // lists. Listing is cheap metadata; capping it there would be worse than
+  // useless for a backfill, because Gmail returns newest first - every run
+  // would re-list the same newest N, find them all already processed, and
+  // never walk backwards through the window.
+  const batchLimit = Number(options.maxMessages) > 0 ? Number(options.maxMessages) : MAX_MESSAGES;
   const sinceMs = backfilling
     ? Date.now() - lookbackDays * 24 * 60 * 60 * 1000
     : watermarkMs - WATERMARK_OVERLAP_MS;
   if (backfilling) log(`emailIngest: sweeping ${lookbackDays} days`);
-  const refs = await gmail.listMessagesSince(token, Math.floor(sinceMs / 1000), maxMessages);
+  const refs = await gmail.listMessagesSince(token, Math.floor(sinceMs / 1000), MAX_MESSAGES);
   log(`emailIngest: ${refs.length} messages in the window`);
-  if (refs.length >= maxMessages) {
-    log(`emailIngest: hit the ${maxMessages}-message cap - older mail in this window was not read`);
+  if (refs.length >= MAX_MESSAGES) {
+    log(`emailIngest: hit the ${MAX_MESSAGES}-message list cap - older mail in this window was not listed`);
   }
 
   const kids = await listKids();
@@ -118,8 +124,14 @@ async function runEmailIngest(log = () => {}, options = {}) {
   let ingested = 0;
   let duplicates = 0;
 
+  let readThisRun = 0;
+  let unread = 0;
   for (const ref of refs) {
     if (processed.has(ref.id)) continue;
+    // Out of budget for this run: count what is left so a truncated sweep
+    // never reads as a finished one, and let the next run pick it up.
+    if (readThisRun >= batchLimit) { unread += 1; continue; }
+    readThisRun += 1;
     let msg;
     try {
       msg = await gmail.getMessage(token, ref.id);
@@ -203,7 +215,11 @@ async function runEmailIngest(log = () => {}, options = {}) {
     lookbackDoneFor: spendsOneShot ? lookbackDays : (state.lookbackDoneFor ?? null),
   });
 
-  const summary = { skipped: false, checked: refs.length, relevant, ingested, duplicates, backfilled: backfilling };
+  if (unread) log(`emailIngest: ${unread} message(s) in the window still unread - run again to continue`);
+  const summary = {
+    skipped: false, listed: refs.length, read: readThisRun, stillUnread: unread,
+    relevant, ingested, duplicates, backfilled: backfilling,
+  };
   log(`emailIngest: ${JSON.stringify(summary)}`);
   return summary;
 }

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2604,7 +2604,7 @@ async function main() {
 
   const run1 = await runEmailIngest();
   assert.strictEqual(run1.skipped, false);
-  assert.strictEqual(run1.checked, 2, 'both new messages were checked');
+  assert.strictEqual(run1.read, 2, 'both new messages were read');
   assert.strictEqual(run1.relevant, 1, 'only the scouts email survived triage');
   assert.strictEqual(run1.ingested, 2, 'one email produced two proposals');
   assert.strictEqual(run1.duplicates, 0);
@@ -2681,6 +2681,39 @@ async function main() {
   assert.ok(capUrl.includes('maxResults=50'), 'the cap bounds the batch, not the page size');
   delete process.env.EMAIL_LOOKBACK_DAYS;
   console.log('✓ an explicit sweep window always runs and keeps the one-shot intact');
+
+  // A capped run must WALK the window, not re-read its newest messages every
+  // time. Gmail lists newest first, so capping the listing would make every
+  // run skip the same already-processed head and never reach older mail.
+  gmailStore.messages = [
+    { id: 'walk-1', threadId: 't1' }, { id: 'walk-2', threadId: 't2' },
+    { id: 'walk-3', threadId: 't3' }, { id: 'walk-4', threadId: 't4' },
+  ];
+  gmailStore.messages.forEach((m) => {
+    gmailStore.full[m.id] = {
+      id: m.id, threadId: m.threadId, internalDate: String(Date.now() - 60000),
+      payload: {
+        mimeType: 'text/plain',
+        headers: [{ name: 'From', value: 'promo@nothing.example' }, { name: 'Subject', value: 'Nothing here' }],
+        body: { data: b64url('nothing relevant') },
+      },
+    };
+  });
+  const seenIds = [];
+  emailPipeline.setEmailClientFactory(() => ({
+    messages: { create: async () => ({ content: [{ type: 'text', text: '{"relevant":false}' }] }) },
+  }));
+  const walkA = await runEmailIngest((line) => {
+    const m = /could not read message (\S+)/.exec(line); if (m) seenIds.push(m[1]);
+  }, { lookbackDays: 5, maxMessages: 2 });
+  assert.strictEqual(walkA.read, 2, 'the cap bounds what one run reads');
+  assert.strictEqual(walkA.stillUnread, 2, 'and reports what it left behind');
+  const walkB = await runEmailIngest(() => {}, { lookbackDays: 5, maxMessages: 2 });
+  assert.strictEqual(walkB.read, 2, 'the next run reads the two it had not seen');
+  assert.strictEqual(walkB.stillUnread, 0, 'and the window is now clear');
+  const walkC = await runEmailIngest(() => {}, { lookbackDays: 5, maxMessages: 2 });
+  assert.strictEqual(walkC.read, 0, 'a third run finds nothing left to read');
+  console.log('✓ a capped run walks the window instead of re-reading its newest mail');
 
 
   global.fetch = realFetch;


### PR DESCRIPTION
A 60-message sweep hit Azure's four-minute HTTP ceiling (`504`). Retrying with a smaller batch wouldn't have helped, which is the real bug: **the cap was applied when *listing* messages, and Gmail lists newest first.** Every run would fetch the same newest N, skip them all as already processed, and never reach older mail — the backfill could not walk.

- The batch cap now limits how many messages a run **reads**. Listing covers the full window (cheap metadata), so each run genuinely picks up where the last one stopped.
- Summary reports `listed` / `read` / `stillUnread`, and leftovers are logged — a truncated sweep can't read as a finished one.

**Tests:** a capped run reads its budget and reports the remainder; the next run reads the rest; a third finds nothing left.

This is what was blocking the actual goal — reaching the Scouts thread from 10 and 24 Aug. With this, repeated small runs walk back through the three-week window without timing out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_