### PR TITLE
Flip repository visibility from a workflow

### DIFF
--- a/.github/workflows/repo-visibility.yml
+++ b/.github/workflows/repo-visibility.yml
@@ -1,0 +1,43 @@
+# Manually-triggered: flip this repository between private and public.
+#
+# Why it exists: the repository being public is how a scraper found the owner's
+# email and cold-mailed him about an unrelated "quant framework" project. The
+# app holds no secrets in its code, but there is no reason for a family's chore
+# app to be readable by everyone either.
+#
+# It is a workflow rather than a one-off click so the change is recorded, and so
+# it can be put back the same way. Never runs on its own.
+name: Set repository visibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      visibility:
+        description: Repository visibility
+        required: true
+        default: private
+        type: choice
+        options:
+          - private
+          - public
+
+permissions:
+  contents: read
+
+jobs:
+  set-visibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set visibility
+        env:
+          # The built-in GITHUB_TOKEN cannot change repository settings; this is
+          # the same personal token auto-merge.yml already uses.
+          GH_TOKEN: ${{ secrets.HEROTASK_GITHUB_TOKEN }}
+          VISIBILITY: ${{ inputs.visibility }}
+        run: |
+          set -euo pipefail
+          echo "Before: $(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}" \
+            -f visibility="${VISIBILITY}" --jq '.visibility' > /tmp/after
+          echo "After:  $(cat /tmp/after)"
+          test "$(cat /tmp/after)" = "${VISIBILITY}"


### PR DESCRIPTION
A scraper found the owner's email through this repository being public and cold-mailed him about an unrelated project. Nothing in the code is secret — no keys, no tokens, and the family's data lives in Azure behind PINs — but a family chore app has no reason to be world-readable.

- Dispatch-only workflow that PATCHes the repository's visibility, with a `private`/`public` choice input so it can be put back the same way.
- Uses `HEROTASK_GITHUB_TOKEN`, the same personal token `auto-merge.yml` uses: the built-in `GITHUB_TOKEN` cannot change repository settings.
- Prints the visibility before and after and fails if the change did not take.

Worth knowing: private repositories get 2,000 free Actions minutes a month. This pipeline runs CI, deploys and an auto-merge check often enough that the cadence may need trimming later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Unyyk122KERHSTBDMtUNCg)_