### PR TITLE
School lunches run Sunday to Thursday (#261)

### DIFF
--- a/.github/workflows/set-lunch-days.yml
+++ b/.github/workflows/set-lunch-days.yml
@@ -1,0 +1,22 @@
+# Manually-triggered maintenance job: move the school-lunch chore on the LIVE
+# app to Sunday-Thursday evening, in place. Unlike "Seed demo data" this wipes
+# nothing - points, completions and the calendar are untouched.
+# Never runs on its own - workflow_dispatch only.
+name: Set lunch days
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  set-lunch-days:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Move school lunches to Sun-Thu
+        run: node scripts/set-lunch-days.mjs

--- a/scripts/lunch-chore.mjs
+++ b/scripts/lunch-chore.mjs
@@ -1,0 +1,19 @@
+// The one description of the school-lunch chore, shared by the full re-seed
+// (seed-demo.mjs) and the in-place fix (set-lunch-days.mjs). It lives in its
+// own file because seed-demo.mjs wipes the app the moment it is imported -
+// importing the constants from there would run the wipe.
+//
+// A lunch is made the EVENING BEFORE the school day it is for, so the week
+// sits one day earlier than the school week: Sunday evening makes Monday's,
+// Thursday evening makes Friday's. Friday evening is off - there is no
+// Saturday school day to pack for.
+//
+// Weekday numbers are the API's: 0=Sunday .. 6=Saturday.
+export const LUNCH_TITLE = "Make tomorrow's school lunches";
+export const LUNCH_DAYS = [0, 1, 2, 3, 4];
+
+// Any chore already in the household that IS this one, whatever it is called
+// today. The live chores were seeded as "Make school lunches"; matching on the
+// word rather than the exact title means the rename lands on them too, and
+// re-running after the rename is a no-op rather than a duplicate.
+export const isLunchChore = (task) => /lunch/i.test(task.title || '');

--- a/scripts/seed-demo.mjs
+++ b/scripts/seed-demo.mjs
@@ -9,6 +9,8 @@
 //      points, the night-before deadline and the per-event override.
 //
 // Times are written in UTC but MEAN Perth (UTC+8): 17:30 Perth = 09:30Z.
+import { LUNCH_TITLE, LUNCH_DAYS } from './lunch-chore.mjs';
+
 const API = process.env.API_URL || 'https://herotasks-func-dev.azurewebsites.net/api/hero';
 const PIN = process.env.PARENT_PIN || '1234';
 const parent = { parentId: 'peter', parentPin: PIN };
@@ -58,14 +60,14 @@ for (const item of cal.items || []) {
   console.log('deleted calendar item:', item.title);
 }
 
-// ---- 2. chores: school lunches, Mon-Fri, evening window ----
+// ---- 2. chores: school lunches, Sun-Thu, evening window (lunch-chore.mjs) ----
 for (const kid of ['toby', 'ollie']) {
   await post({
     action: 'addTask', ...parent, kidId: kid,
-    title: 'Make school lunches', points: 5,
-    cycle: 'weekly', days: [1, 2, 3, 4, 5], windowId: 'evening',
+    title: LUNCH_TITLE, points: 5,
+    cycle: 'weekly', days: LUNCH_DAYS, windowId: 'evening',
   });
-  console.log(`chore: Make school lunches (${kid}, Mon-Fri, evening)`);
+  console.log(`chore: ${LUNCH_TITLE} (${kid}, Sun-Thu, evening)`);
 }
 
 // ---- 3. events with prep ----

--- a/scripts/set-lunch-days.mjs
+++ b/scripts/set-lunch-days.mjs
@@ -1,0 +1,62 @@
+// Moves the school-lunch chore on the LIVE app to Sunday-Thursday evening, in
+// place. Run from a GitHub Actions runner (the dev container's egress policy
+// cannot reach azurewebsites.net).
+//
+// Why this exists at all: editing scripts/seed-demo.mjs only changes households
+// created AFTERWARDS, and the real one already exists - the same trap that made
+// #88's avatars ship green and change nothing. Re-seeding would fix the days but
+// wipe every point the kids have earned, which is not an acceptable price for a
+// schedule tweak. So this updates the chores that are already there and touches
+// nothing else.
+//
+// Idempotent: a chore already on the right title and days is skipped, so running
+// it twice is safe.
+import { LUNCH_TITLE, LUNCH_DAYS, isLunchChore } from './lunch-chore.mjs';
+
+const API = process.env.API_URL || 'https://herotasks-func-dev.azurewebsites.net/api/hero';
+const PIN = process.env.PARENT_PIN || '1234';
+const parent = { parentId: 'peter', parentPin: PIN };
+
+const post = async (body) => {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  if (json && json.ok === false) throw new Error(`${body.action}: ${json.error}`);
+  return json;
+};
+
+const sameDays = (a, b) =>
+  Array.isArray(a) && a.length === b.length && [...a].sort().every((d, i) => d === [...b].sort()[i]);
+
+const state = await post({ action: 'state' });
+const lunches = (state.tasks || []).filter(isLunchChore);
+
+if (!lunches.length) {
+  console.log('no school-lunch chore found - nothing to do');
+}
+
+let changed = 0;
+for (const task of lunches) {
+  if (task.title === LUNCH_TITLE && task.cycle === 'weekly' && sameDays(task.days, LUNCH_DAYS)) {
+    console.log(`already right: ${task.title} (${task.kidId})`);
+    continue;
+  }
+  // cycle goes with days on purpose: the API clears `days` on any chore whose
+  // cycle is not weekly, so sending the days without the cycle would silently
+  // do nothing to a chore someone had switched to Every day.
+  await post({
+    action: 'updateTask', ...parent, taskId: task.id,
+    title: LUNCH_TITLE, cycle: 'weekly', days: LUNCH_DAYS,
+  });
+  changed += 1;
+  console.log(`updated: ${task.kidId} -> ${LUNCH_TITLE}, Sun-Thu`);
+}
+
+const after = await post({ action: 'state' });
+for (const task of (after.tasks || []).filter(isLunchChore)) {
+  console.log(`now: ${task.kidId} | ${task.title} | days=${JSON.stringify(task.days)} | ${task.cycle}`);
+}
+console.log(`DONE - ${changed} chore(s) changed`);


### PR DESCRIPTION
Closes #261

> **User story**
> As a parent, I want the kids' "make school lunches" chore to land Sunday through Thursday evening, so each lunch is made the night before the school day it's for — and nobody makes a lunch on Friday night for a school day that doesn't exist.

## Pete's ask

> "I want the kids make lunches tasks to be Sunday to Thursday and then they're ready for the corresponding school day"

## What changed

**The chore week shifts back one day.** Days move from `[1,2,3,4,5]` (Mon–Fri) to `[0,1,2,3,4]` (Sun–Thu). Sunday evening packs Monday's lunch, Thursday evening packs Friday's. Friday evening comes off — there was never a Saturday school day to pack for — and Monday's lunch is now made ahead instead of never being made ahead at all.

**The title becomes "Make tomorrow's school lunches".** "Make school lunches" on a Sunday evening reads like a mistake to a kid; the new title says which day it's for, which is the whole point of the shift.

**A dispatch-only workflow applies it to the live app, in place.** This is the part that actually matters. Editing `seed-demo.mjs` alone would have changed nothing — a seed only applies to households created afterwards, and the real one already exists. That is precisely the trap that made #88's avatars ship green and change nothing on the live app. The other option, re-running "Seed demo data", would fix the days but wipe every point the kids have earned, which is not an acceptable price for a schedule tweak.

So:

- `scripts/lunch-chore.mjs` — the one description of the chore (title, days, and how to recognise an existing one), in its own file. It is not exported from `seed-demo.mjs` on purpose: that script wipes the app the moment it is imported.
- `scripts/set-lunch-days.mjs` — reads live state, finds the lunch chores, updates title/cycle/days via `updateTask`, and prints the before and after. Touches nothing else.
- `.github/workflows/set-lunch-days.yml` — `workflow_dispatch` only, same shape as `seed-demo.yml`, run from a runner because the dev container's egress can't reach `azurewebsites.net`.
- `scripts/seed-demo.mjs` — now reads from the shared file, so a future re-seed is right too.

Two details worth naming:

- It matches on the word "lunch" rather than the exact title, so it lands on the existing `Make school lunches` rows *and* no-ops when re-run after the rename.
- It sends `cycle: 'weekly'` alongside the days. The API clears `days` on any chore whose cycle isn't weekly, so sending days alone would silently do nothing to a chore someone had switched to "Every day".

No app code changed — the frontend day picker already offers Sunday and `daysLabel` already renders it.

## Tested

- `node api/test-logic.js` — all logic tests passed
- `node scripts/check-frontend.js` — passed
- `node scripts/check-design.js` — passed
- Playwright smoke suite — **83 passed**
- `scripts/set-lunch-days.mjs` dry-run twice against a stub API: first run updated both kids and left an unrelated "Feed the dog" chore alone; second run reported `already right` for both and `DONE - 0 chore(s) changed`.

## After merge

Run **Set lunch days** (Actions → workflow_dispatch) once to move the two live chores. Nothing is wiped — points, completions and the calendar are untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD)_