### PR TITLE
The evening window opens at 2:30pm (#263)

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -78,10 +78,17 @@ function isInQuietHours(quietHours, now = new Date()) {
 // record on purpose - ensureSeeded() only writes when the household is absent,
 // so seeding them would do nothing for a household created weeks ago. A
 // household may override them; when it has not, these apply immediately.
+//
+// A window may also carry `opensAt`. Without it a window is open from local
+// midnight - which is what every window meant before, so morning and after
+// school are unchanged. Evening carries one because of what an evening chore
+// actually is: school lunches are made for TOMORROW, and a lunch packed at
+// 8am is packed for the day the kid is about to leave for. Opening at 14:30
+// (the school day is over) means the tick and the work land together.
 const DEFAULT_WINDOWS = Object.freeze([
   Object.freeze({ id: 'morning',     label: 'Morning',      closesAt: '08:30' }),
   Object.freeze({ id: 'afterschool', label: 'After school', closesAt: '18:00' }),
-  Object.freeze({ id: 'evening',     label: 'Evening',      closesAt: '21:00' }),
+  Object.freeze({ id: 'evening',     label: 'Evening',      opensAt: '14:30', closesAt: '21:00' }),
 ]);
 
 // What a chore with no window set means. Existing chores predate the concept,
@@ -112,6 +119,16 @@ function resolveWindow(windows, windowId) {
 function isWindowClosed(windowDef, now = new Date()) {
   if (!windowDef || !HHMM_RE.test(windowDef.closesAt || '')) return false;
   return localMinutes(now) >= hhmmToMinutes(windowDef.closesAt);
+}
+
+// Whether the window has not started yet today. The mirror of isWindowClosed,
+// and deliberately a SEPARATE state from closed: "come back at 2:30" and "you
+// missed it" are opposite messages, and a row that renders one as the other
+// teaches the kid the wrong thing. A window with no opensAt is never early -
+// that is the pre-opensAt meaning, kept for every window that has none.
+function isWindowNotOpenYet(windowDef, now = new Date()) {
+  if (!windowDef || !HHMM_RE.test(windowDef.opensAt || '')) return false;
+  return localMinutes(now) < hhmmToMinutes(windowDef.opensAt);
 }
 
 async function getHouseholdQuietHours() {
@@ -224,7 +241,7 @@ async function getState() {
     // truth than the API acts on. Stale-while-open is acceptable - the display
     // refreshes on every state fetch, and a submit against a window that shut
     // in between gets the API's own refusal with a clear message.
-    windows: windows.map((w) => ({ ...w, closed: isWindowClosed(w) })),
+    windows: windows.map((w) => ({ ...w, closed: isWindowClosed(w), notOpenYet: isWindowNotOpenYet(w) })),
     fallbackWindowId: FALLBACK_WINDOW_ID,
     people: people.map((p) => ({ id: p.id, name: p.name, emoji: p.emoji, role: p.role, hasPin: !!p.pin })),
     rewards: rewardDocs.map((r) => ({ id: r.id, title: r.title, cost: r.cost, needsApproval: r.needsApproval })),
@@ -1476,6 +1493,15 @@ async function completeTask(req) {
   if (chore.cycle !== 'oneoff') {
     const windows = await getHouseholdWindows();
     const choreWindow = resolveWindow(windows, chore.windowId);
+    // Early is not the same as late. Nothing is forfeited here - the window is
+    // still coming, so this is a "not yet", and no miss is ever recorded for it.
+    if (isWindowNotOpenYet(choreWindow)) {
+      return {
+        ok: false,
+        error: `The ${String(choreWindow.label).toLowerCase()} window opens at ${choreWindow.opensAt}.`,
+        windowNotOpenYet: true,
+      };
+    }
     if (isWindowClosed(choreWindow)) {
       return {
         ok: false,
@@ -2396,4 +2422,4 @@ app.timer('choreDueReminder', {
   },
 });
 
-module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, recordMisses, sendWindowNudges, sendEveningSummary, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, resolveWindow, currentOccurrence };
+module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, recordMisses, sendWindowNudges, sendEveningSummary, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, isWindowNotOpenYet, resolveWindow, currentOccurrence };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -108,6 +108,26 @@ async function main() {
   process.env.VAPID_PRIVATE_KEY = 'test-vapid-private-key';
   await ensureSeeded();
 
+  // The pinned clock reads ~noon (see the top of this file), and the DEFAULT
+  // evening window opens at 14:30 - so with the shipped defaults every chore on
+  // the fallback window would be refused as "not open yet" and dozens of tests
+  // about approval, points and streaks would fail for a reason none of them is
+  // asserting. Those tests are about the CLOSE, so the household runs on
+  // windows with no opensAt, which is what a window meant before the field
+  // existed. The opening rule has its own block further down, driven by
+  // explicit clocks so it is deterministic whatever hour CI runs.
+  const OPEN_ALL_DAY_WINDOWS = [
+    { id: 'morning', label: 'Morning', closesAt: '08:30' },
+    { id: 'afterschool', label: 'After school', closesAt: '18:00' },
+    { id: 'evening', label: 'Evening', closesAt: '21:00' },
+  ];
+  {
+    const { resource: seeded } = await mockContainer('households')
+      .item(HOUSEHOLD_ID, HOUSEHOLD_ID).read();
+    seeded.windows = OPEN_ALL_DAY_WINDOWS;
+    await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(seeded);
+  }
+
   const peopleMap = getMap('people');
   assert.strictEqual(peopleMap.size, 4, 'expected 4 seeded people');
   const toby = peopleMap.get('toby');
@@ -1805,6 +1825,7 @@ async function main() {
   const { execFileSync } = require('child_process');
   const perthProbe = execFileSync(process.execPath, ['-e', `
     const h = require(${JSON.stringify(path.join(__dirname, 'src/functions/hero.js'))});
+    const EVENING = { id: 'evening', label: 'Evening', opensAt: '14:30', closesAt: '21:00' };
     const out = {
       beforeSchool: h.todayStr(new Date('2026-08-23T23:30:00Z')),
       midnightMins: h.localMinutes(new Date('2026-08-23T16:00:00Z')),
@@ -1814,6 +1835,14 @@ async function main() {
       quietMidMorning: h.isInQuietHours({ start: '21:00', end: '07:00' }, new Date('2026-08-24T02:00:00Z')),
       windowShutLateEvening: h.isWindowClosed({ id: 'evening', closesAt: '21:00' }, new Date('2026-08-24T13:30:00Z')),
       windowOpenAfternoon:  h.isWindowClosed({ id: 'evening', closesAt: '21:00' }, new Date('2026-08-24T06:00:00Z')),
+      shippedEvening: h.DEFAULT_WINDOWS.find((w) => w.id === 'evening'),
+      otherWindowsHaveNoOpen: h.DEFAULT_WINDOWS.filter((w) => w.id !== 'evening').every((w) => !w.opensAt),
+      // 08:00 Perth, 14:00 Perth (half an hour early) and 15:00 Perth.
+      earlyAtBreakfast:  h.isWindowNotOpenYet(EVENING, new Date('2026-08-24T00:00:00Z')),
+      earlyAtTwo:        h.isWindowNotOpenYet(EVENING, new Date('2026-08-24T06:00:00Z')),
+      earlyAtThree:      h.isWindowNotOpenYet(EVENING, new Date('2026-08-24T07:00:00Z')),
+      shutAtThree:       h.isWindowClosed(EVENING, new Date('2026-08-24T07:00:00Z')),
+      noOpensAtIsNeverEarly: h.isWindowNotOpenYet({ id: 'x', label: 'X', closesAt: '21:00' }, new Date('2026-08-24T00:00:00Z')),
     };
     process.stdout.write(JSON.stringify(out));
   `], {
@@ -1840,6 +1869,21 @@ async function main() {
   assert.strictEqual(perth.windowShutLateEvening, true, '9:30pm is past a 21:00 close');
   assert.strictEqual(perth.windowOpenAfternoon, false, '2pm is not');
   console.log('\u2713 a window closes on the household clock, not UTC');
+
+  // The other end of the same window. Evening opens at 14:30 because an evening
+  // chore is done for TOMORROW - school lunches packed at 8am are packed for the
+  // day the kid is already leaving for. Early is not late: nothing is forfeited.
+  assert.strictEqual(perth.shippedEvening.opensAt, '14:30', 'the shipped evening window opens at 14:30');
+  assert.strictEqual(perth.shippedEvening.closesAt, '21:00', 'and still closes at 21:00');
+  assert.strictEqual(perth.otherWindowsHaveNoOpen, true,
+    'morning and after school carry no opening time - unchanged by this');
+  assert.strictEqual(perth.earlyAtBreakfast, true, '8am is before the evening window opens');
+  assert.strictEqual(perth.earlyAtTwo, true, 'so is 2pm - the edge is 14:30, not 14:00');
+  assert.strictEqual(perth.earlyAtThree, false, '3pm is inside it');
+  assert.strictEqual(perth.shutAtThree, false, 'and 3pm is not past its close either');
+  assert.strictEqual(perth.noOpensAtIsNeverEarly, false,
+    'a window with no opening time is never early - the meaning every window had before');
+  console.log('\u2713 the evening window is a 14:30-21:00 band on the household clock');
 
   // -------------------------------------------------------------------------
   // Windows. The rule: submit inside the window or the points are gone - no
@@ -1901,8 +1945,52 @@ async function main() {
     'a chore with no window falls back to the evening window rather than escaping the rule');
   console.log('\u2713 legacy chores without a window are held to the fallback window');
 
-  // Put the windows back for anything that runs after this.
-  household.windows = null;
+  // Put the windows back for anything that runs after this - the open-all-day
+  // set this file runs on, not null, which would restore the shipped defaults
+  // and their 14:30 opening.
+  household.windows = OPEN_ALL_DAY_WINDOWS;
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
+
+  // -------------------------------------------------------------------------
+  // Opening times, at the API. The clock facts are asserted in the Perth probe
+  // above; this is the behaviour built on them. An opening time of 23:59 has
+  // not arrived at the pinned ~noon whatever hour CI runs, which is the mirror
+  // of the closesAt '00:00' trick the shut-window tests use.
+  household.windows = [
+    { id: 'morning', label: 'Morning', closesAt: '08:30' },
+    { id: 'afterschool', label: 'After school', closesAt: '18:00' },
+    { id: 'evening', label: 'Evening', opensAt: '23:59', closesAt: '23:59' },
+  ];
+  await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
+
+  await ROUTES.addTask({
+    parentId: 'peter', parentPin: '1234', kidId: 'ollie',
+    title: 'Too early chore', points: 4, cycle: 'daily', windowId: 'evening',
+  });
+  const earlyChore = (await ROUTES.state()).tasks.find((t) => t.title === 'Too early chore');
+  const earlyTick = await ROUTES.completeTask({ taskId: earlyChore.id, personId: 'ollie', pin: '1234' });
+  assert.strictEqual(earlyTick.ok, false, 'a window that has not opened refuses the completion');
+  assert.strictEqual(earlyTick.windowNotOpenYet, true, 'and says so machine-readably');
+  assert.notStrictEqual(earlyTick.windowClosed, true, 'without ever calling it a miss');
+  console.log('\u2713 a window that has not opened refuses the tick - and never as a miss');
+
+  const earlyState = await ROUTES.state();
+  const earlyWindow = earlyState.windows.find((w) => w.id === 'evening');
+  assert.strictEqual(earlyWindow.notOpenYet, true, 'state tells the client the window is early');
+  assert.strictEqual(earlyWindow.opensAt, '23:59', 'and carries the opening time to render');
+  assert.ok(earlyState.windows.every((w) => typeof w.notOpenYet === 'boolean'),
+    'every window carries the flag - the server is the only clock, same as closed');
+  console.log('\u2713 state carries opensAt and notOpenYet so the browser never computes either');
+
+  // The sweep must not turn an unopened window into a miss. A miss is a
+  // forfeit, and nothing has been forfeited while the window is still coming.
+  await require('./src/functions/hero.js').recordMisses();
+  const sweptEarly = (await ROUTES.state()).completions
+    .filter((c) => c.taskId === earlyChore.id && c.status === 'missed');
+  assert.strictEqual(sweptEarly.length, 0, 'a chore whose window has not opened is not swept as missed');
+  console.log('\u2713 the miss sweep leaves a not-yet-open chore alone');
+
+  household.windows = OPEN_ALL_DAY_WINDOWS;
   await mockContainer('households').item(HOUSEHOLD_ID, HOUSEHOLD_ID).replace(household);
 
   // -------------------------------------------------------------------------

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -323,11 +323,17 @@ deadline.
 
 Three named windows for the whole household, not a clock per chore:
 
-| Window | Closes |
-|---|---|
-| Morning | 08:30 |
-| After school | 18:00 |
-| Evening | 21:00 |
+| Window | Opens | Closes |
+|---|---|---|
+| Morning | — | 08:30 |
+| After school | — | 18:00 |
+| Evening | 14:30 | 21:00 |
+
+`opensAt` is optional. A window without one is open from local midnight, which
+is what every window meant before the field existed. Evening carries one
+because of what an evening chore *is*: school lunches are made for **tomorrow**,
+and a lunch packed at 8am is packed for the day the kid is already leaving for.
+Opening at 14:30 puts the tick and the work in the same afternoon.
 
 Defaults live in `DEFAULT_WINDOWS` in `hero.js`, overridable per household via
 a `windows` array on the household record — in code rather than the seed,
@@ -338,20 +344,36 @@ day is the honest reading of that.
 
 Rules that must not drift:
 
-- **The server is the only clock.** `state.windows[].closed` is computed
-  API-side and the frontend renders it; `completeTask` refuses a shut window
-  with `windowClosed: true`. The browser never computes shutness from its own
-  clock — a phone in the wrong timezone would show a different truth than the
-  API acts on.
+- **The server is the only clock.** `state.windows[].closed` and
+  `state.windows[].notOpenYet` are computed API-side and the frontend renders
+  them; `completeTask` refuses a shut window with `windowClosed: true` and one
+  that has not opened with `windowNotOpenYet: true`. The browser never computes
+  either from its own clock — a phone in the wrong timezone would show a
+  different truth than the API acts on.
+- **Early is not late.** They are opposite messages and must never share a
+  style. A shut window is a forfeit: greyed, danger red, points struck through,
+  `❌`. A window that has not opened is a *hold*: greyed, muted text, `🔒`,
+  "Opens 2:30pm", points untouched — and `recordMisses` never writes a miss for
+  it, because nothing has been forfeited while the window is still coming.
 - **A miss stays on screen.** The row greys, says why, strikes the points —
   it does not vanish. A miss that disappears overnight teaches nothing.
 - **One-offs are separate.** They carry their own `dueBy` and overdue display;
   folding the two mechanisms together is a decision, not a default.
 - **Tests pin the clock.** "Now" is part of behaviour, so `test-logic.js` and
   the smoke server pin `HOUSEHOLD_TIMEZONE` to a fixed-offset zone where local
-  time is ~noon — morning has always shut, evening is always open, whatever
-  hour CI runs. A window of `closesAt: '00:00'` is shut at every moment of the
-  day, which is the deterministic way to test refusal.
+  time is ~noon. At noon: **morning** has always shut, **after school** is
+  always open, and **evening** has not opened yet — all three states, whatever
+  hour CI runs. So a test that merely needs a tickable chore must name
+  `afterschool`; leaving the window off falls back to evening and the tick is
+  refused as early. A window of `closesAt: '00:00'` is shut at every moment of
+  the day and one of `opensAt: '23:59'` has never opened at noon — the
+  deterministic ways to test each refusal.
+
+  `test-logic.js` additionally runs its household on windows with no `opensAt`,
+  because the pinned noon is before 14:30 and dozens of tests about approval,
+  points and streaks would otherwise fail for a reason none of them asserts.
+  The opening rule has its own block, driven by explicit clocks in the real
+  Perth zone.
 
 ### Misses — the record that points were not earned
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -728,6 +728,12 @@ button:disabled { cursor: not-allowed; opacity: 0.65; }
 .task.overdue .sub  { color: var(--danger); font-weight: var(--weight-medium); }
 /* A shut window. Dimmed but still on the list - a miss that vanished overnight
    would teach nothing; one that sits there until tomorrow is the record. */
+/* Not open yet. Dimmed like a miss because it cannot be ticked, but never in
+   the danger colour: "come back at 2:30" and "you missed it" are opposite
+   messages, and the points are still there to be earned. */
+.task.not-open-yet { opacity: 0.6; }
+.task.not-open-yet .tick { cursor: default; }
+.task.not-open-yet .sub  { color: var(--ink-muted); }
 .task.missed { opacity: 0.6; }
 .task.missed .tick { border-color: var(--danger); cursor: default; }
 .task.missed .sub  { color: var(--danger); font-weight: var(--weight-medium); }
@@ -2721,13 +2727,15 @@ function glanceChoreCard(item) {
     ? (c.status === 'approved' ? 'Done — points banked! 💰' : c.status === 'queued' ? 'Saved offline — syncing soon 📡' : 'Waiting for a grown-up to check ⏳')
     : '';
   var ws = choreWindowState(task, c);
-  if (!c && ws) sub = ws.missed ? ws.missedText : (sub ? sub + ' · ' + ws.stake : ws.stake);
   var missed = !!(ws && ws.missed);
+  var notOpenYet = !!(ws && ws.notOpenYet);
+  if (!c && ws) sub = missed ? ws.missedText : notOpenYet ? ws.notOpenYetText : (sub ? sub + ' · ' + ws.stake : ws.stake);
   var action = c
     ? ((c.status === 'pending' || c.status === 'queued') ? 'undoTask(\'' + c.id + '\')' : '')
-    : (missed ? '' : 'doTask(\'' + task.id + '\')');
+    : (missed || notOpenYet ? '' : 'doTask(\'' + task.id + '\')');
   if (missed) tickIcon = '❌';
-  return '<div class="task ' + cls + (missed ? ' missed' : '') + '">'
+  else if (notOpenYet) tickIcon = '🔒';
+  return '<div class="task ' + cls + (missed ? ' missed' : '') + (notOpenYet ? ' not-open-yet' : '') + '">'
     + '<button class="tick" ' + (action ? 'onclick="' + action + '"' : 'disabled') + '>' + tickIcon + '</button>'
     + '<div class="info">'
     + '<div class="title">' + esc(task.title) + '</div>'
@@ -3696,18 +3704,22 @@ function renderTaskList(elId, tasks, emptyEmoji, emptyLine1, emptyLine2) {
     // dueBy mechanics.
     var ws = choreWindowState(t, c);
     var missed = !!(ws && ws.missed);
+    // Early, not late. The row is held rather than lost: no tick yet, but the
+    // points are still on the table and nothing is struck through.
+    var notOpenYet = !!(ws && ws.notOpenYet);
     var sub = c
       ? (c.status === 'approved' ? 'Done — points banked! 💰' : c.status === 'queued' ? 'Saved offline — syncing soon 📡' : 'Waiting for a grown-up to check ⏳')
       : (t.cycle === 'weekly'
           ? (t.days && t.days.length ? 'On ' + daysLabel(t.days) : 'Any time this week')
           : '');
-    if (!c && ws) sub = missed ? ws.missedText : (sub ? sub + ' · ' + ws.stake : ws.stake);
+    if (!c && ws) sub = missed ? ws.missedText : notOpenYet ? ws.notOpenYetText : (sub ? sub + ' · ' + ws.stake : ws.stake);
     if (!c && t.dueBy) sub = isOverdue ? '⚠️ Overdue — was due ' + formatDue(t.dueBy) : 'Due ' + formatDue(t.dueBy);
     var action = c
       ? ((c.status === 'pending' || c.status === 'queued') ? 'undoTask(\'' + c.id + '\')' : '')
-      : (missed ? '' : 'doTask(\'' + t.id + '\')');
+      : (missed || notOpenYet ? '' : 'doTask(\'' + t.id + '\')');
     if (missed) tickIcon = '❌';
-    return '<div class="task ' + cls + ' ' + (isOverdue ? 'overdue' : '') + (missed ? ' missed' : '') + '">'
+    else if (notOpenYet) tickIcon = '🔒';
+    return '<div class="task ' + cls + ' ' + (isOverdue ? 'overdue' : '') + (missed ? ' missed' : '') + (notOpenYet ? ' not-open-yet' : '') + '">'
       + '<button class="tick" ' + (action ? 'onclick="' + action + '"' : 'disabled') + '>' + tickIcon + '</button>'
       + '<div class="info">'
       + '<div class="title">' + esc(t.title) + '</div>'
@@ -4322,7 +4334,7 @@ function renderParent(person) {
   if (windowSel) {
     var windowCurrent = windowSel.value;
     windowSel.innerHTML = ((state.windows) || []).map(function(w) {
-      return '<option value="' + w.id + '">' + esc(w.label) + ' — by ' + w.closesAt + '</option>';
+      return '<option value="' + w.id + '">' + esc(w.label) + ' — ' + windowLabel(w) + '</option>';
     }).join('');
     // Default new chores to the fallback window rather than the first option,
     // so an untouched form matches what the API would assume anyway.
@@ -5391,13 +5403,22 @@ function choreWindow(t) {
   return windows.length ? windows[windows.length - 1] : null;
 }
 
-function windowLabel(w) {
-  if (!w) return '';
-  var mins = hhmmToMinutes(w.closesAt);
+// "9pm", "2:30pm" - the chip form. Minutes are dropped when they are zero,
+// because "9:00pm" is a clock and "9pm" is how the household says it.
+function hhmmTo12(value) {
+  var mins = hhmmToMinutes(value);
   var h = Math.floor(mins / 60), m = mins % 60;
   var ampm = h >= 12 ? 'pm' : 'am';
   var h12 = h % 12 === 0 ? 12 : h % 12;
-  return 'closes ' + h12 + (m ? ':' + String(m).padStart(2, '0') : '') + ' ' + ampm;
+  return h12 + (m ? ':' + String(m).padStart(2, '0') : '') + ampm;
+}
+
+// A window with both ends reads as a span - "2:30pm-9pm" - rather than two
+// sentences. One with only a close keeps the wording it has always had.
+function windowLabel(w) {
+  if (!w) return '';
+  if (w.opensAt) return hhmmTo12(w.opensAt) + '\u2013' + hhmmTo12(w.closesAt);
+  return 'closes ' + hhmmTo12(w.closesAt);
 }
 
 function hhmmToMinutes(value) {
@@ -5412,6 +5433,10 @@ function isWindowShut(w) {
   return !!(w && w.closed);
 }
 
+function isWindowNotOpenYet(w) {
+  return !!(w && w.notOpenYet);
+}
+
 // The window facts a chore row needs, shared by the Home glance card and the
 // Missions lists so the two can never drift apart. Null for one-offs - they
 // carry their own dueBy mechanics.
@@ -5421,8 +5446,10 @@ function choreWindowState(task, completion) {
   if (!w) return null;
   return {
     missed: !completion && isWindowShut(w),
+    notOpenYet: !completion && isWindowNotOpenYet(w),
     stake: windowLabel(w),
     missedText: 'Missed — ' + String(w.label || '').toLowerCase() + ' window closed at ' + w.closesAt,
+    notOpenYetText: 'Opens ' + hhmmTo12(w.opensAt),
   };
 }
 

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -532,6 +532,9 @@ test('a Waiting on you row leads to its approval card', async ({ page }) => {
     await post({
       action: 'addTask', parentId: 'peter', parentPin: '1234',
       kidId: 'toby', title: 'Feed the dog', points: 3, cycle: 'daily',
+      // afterschool is the window the pinned clock leaves open (see the window
+      // tests). This test is about approval, not about which window it is in.
+      windowId: 'afterschool',
     });
     const state = await post({ action: 'state' });
     const task = state.tasks.find((t) => t.title === 'Feed the dog');
@@ -1041,10 +1044,11 @@ test('a completion counts for its own day, not the whole week', async ({ page })
   expect(verdict.legacyWednesday, 'a chore with no named days keeps the weekly rule').toBe(true);
 });
 
-// Windows are what make the points real: submit before the close or they are
-// gone for the day. The server is the only clock - the harness pins household
-// time to ~noon, so 'morning' has always shut and 'evening' is always open,
-// whatever hour CI runs at.
+// Windows are what make the points real: submit inside the window or the points
+// are gone for the day. The server is the only clock - the harness pins
+// household time to ~noon, so 'morning' has always shut, 'afterschool' (closes
+// 18:00, no opening time) is always open, and 'evening' (14:30-21:00) has not
+// opened yet, whatever hour CI runs at. All three states, deterministically.
 test('a chore states its window and stake, and a shut window reads as missed', async ({ page }) => {
   await page.evaluate(async () => {
     const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
@@ -1054,7 +1058,7 @@ test('a chore states its window and stake, and a shut window reads as missed', a
     }).then((r) => r.json());
     await post({
       action: 'addTask', parentId: 'peter', parentPin: '1234',
-      kidId: 'toby', title: 'Feed the fish', points: 2, cycle: 'daily', windowId: 'evening',
+      kidId: 'toby', title: 'Feed the fish', points: 2, cycle: 'daily', windowId: 'afterschool',
     });
     await post({
       action: 'addTask', parentId: 'peter', parentPin: '1234',
@@ -1071,7 +1075,7 @@ test('a chore states its window and stake, and a shut window reads as missed', a
   // Open window: the row names its stake and can be ticked.
   const open = page.locator('.task', { hasText: 'Feed the fish' }).first();
   await expect(open).toBeVisible();
-  await expect(open).toContainText(/closes 9\s?pm/i);
+  await expect(open).toContainText(/closes 6\s?pm/i);
   await expect(open.locator('.tick')).toBeEnabled();
 
   // Shut window: greyed, says missed, tick disabled, points struck through.
@@ -1079,6 +1083,69 @@ test('a chore states its window and stake, and a shut window reads as missed', a
   await expect(missed).toBeVisible();
   await expect(missed).toContainText(/missed/i);
   await expect(missed.locator('.tick')).toBeDisabled();
+});
+
+// The other end of a window. Evening opens at 14:30 because an evening chore is
+// done for TOMORROW - school lunches packed at 8am are packed for the day the
+// kid is already leaving for. Early must not read as missed: the points are
+// still there, so the row says when to come back and nothing is struck through.
+test('a window that has not opened yet says when, and never reads as a miss', async ({ page }) => {
+  await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'toby', title: 'Pack the lunchbox', points: 5, cycle: 'daily', windowId: 'evening',
+    });
+  });
+  await page.reload();
+  await pickPerson(page, 'Toby');
+
+  const early = page.locator('.task.not-open-yet', { hasText: 'Pack the lunchbox' }).first();
+  await expect(early).toBeVisible();
+  await expect(early).toContainText(/opens 2:30\s?pm/i);
+  await expect(early.locator('.tick')).toBeDisabled();
+  // A miss is a forfeit. This is not one, so none of that styling applies.
+  await expect(early).not.toHaveClass(/\bmissed\b/);
+  await expect(early).not.toContainText(/missed/i);
+});
+
+// The refusal is the API's here too - and it is its own answer, not the
+// shut-window one wearing a different label.
+test('a window that has not opened refuses the completion at the API', async ({ page }) => {
+  const verdict = await page.evaluate(async () => {
+    const post = (body) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => r.json());
+    await post({
+      action: 'addTask', parentId: 'peter', parentPin: '1234',
+      kidId: 'ollie', title: 'Rinse the bottles', points: 2, cycle: 'daily', windowId: 'evening',
+    });
+    const state = await post({ action: 'state' });
+    const task = state.tasks.find((t) => t.title === 'Rinse the bottles');
+    const refusal = await post({ action: 'completeTask', taskId: task.id, personId: 'ollie', pin: '1234' });
+    await post({ action: 'deleteTask', parentId: 'peter', parentPin: '1234', taskId: task.id });
+    const evening = (state.windows || []).find((w) => w.id === 'evening');
+    return {
+      ok: refusal.ok,
+      notOpenYet: refusal.windowNotOpenYet,
+      closed: refusal.windowClosed,
+      error: refusal.error,
+      stateSaysEarly: evening && evening.notOpenYet,
+      stateOpensAt: evening && evening.opensAt,
+    };
+  });
+  expect(verdict.ok, 'the API refuses a completion before the window opens').toBe(false);
+  expect(verdict.notOpenYet, 'and flags it as early').toBe(true);
+  expect(verdict.closed, 'never as a shut window').not.toBe(true);
+  expect(verdict.error, 'the message says when to come back').toMatch(/opens at 14:30/i);
+  expect(verdict.stateSaysEarly, 'state carries the flag so the browser never computes it').toBe(true);
+  expect(verdict.stateOpensAt, 'and the opening time to render').toBe('14:30');
 });
 
 // The refusal is the API's, not just the row's - a stale page that still shows
@@ -1235,6 +1302,8 @@ test('the Today header shows the real date, and a submitted chore is struck thro
     await post({
       action: 'addTask', parentId: 'peter', parentPin: '1234',
       kidId: 'toby', title: 'Sweep the porch', points: 2, cycle: 'daily',
+      // Open at the pinned clock, so the tick below is about the strike-through.
+      windowId: 'afterschool',
     });
   });
   await page.reload();
@@ -1620,7 +1689,7 @@ test('a kid card reports status as pills, not paragraphs', async ({ page }) => {
     const post = (b) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(b),
     }).then((r) => r.json());
-    await post({ action: 'addTask', parentId: 'peter', parentPin: '1234', kidId: 'toby', title: 'Pill check chore', points: 3, cycle: 'daily' });
+    await post({ action: 'addTask', parentId: 'peter', parentPin: '1234', kidId: 'toby', title: 'Pill check chore', points: 3, cycle: 'daily', windowId: 'afterschool' });
     const st = await post({ action: 'state' });
     const t = st.tasks.find((x) => x.title === 'Pill check chore');
     await post({ action: 'completeTask', personId: 'toby', pin: '1234', taskId: t.id });


### PR DESCRIPTION
Closes #263

> **User story**
> As a parent, I want evening chores to only be tickable between 2:30pm and 9pm, so the kids can't tick tomorrow's lunches off at breakfast and then not make them.

## Pete's ask

> "the time for that activity needs to be between half past two pm and 9 pm at night for the next day otherwise they miss that window"

## What changed

A window only ever said when it **closed**. So "Evening" meant "any time today up to 9pm" — a kid could tick "Make tomorrow's school lunches" at breakfast, bank the points, and no lunch got made.

Windows now carry an optional `opensAt`. Without one a window is open from local midnight — exactly what every window meant before — so **Morning and After school are unchanged**. Evening becomes a **14:30–21:00** band.

| Window | Opens | Closes |
|---|---|---|
| Morning | — | 08:30 |
| After school | — | 18:00 |
| Evening | **14:30** | 21:00 |

Asked one question before building — whether the band should apply to all Evening chores or only lunches — and went with household-wide on no preference. Lunches are the only Evening chores today, so nothing else changes now, and it keeps the dropdown at three options rather than adding a fourth window for one chore.

**Early is deliberately not late.** They're opposite messages and share no styling:

- `completeTask` refuses with `windowNotOpenYet` — its own flag, never `windowClosed`
- the row greys with a 🔒 and "Opens 2:30pm" in muted text, not danger red, and the points are **not** struck through — they're still there to be earned
- `recordMisses` leaves it alone: nothing is forfeited while the window is still coming, and a miss is a forfeit

`state.windows[]` carries `opensAt` and `notOpenYet` so the browser never computes either — the same rule `closed` already followed.

## The tests

The harness pins local time to ~noon, which is now *before* the evening window opens. Three things moved honestly rather than being loosened:

- **`test-logic.js` runs its household on windows with no `opensAt`.** Dozens of tests about approval, points and streaks would otherwise fail on a rule none of them asserts. The opening rule gets its own block instead, driven by explicit clocks in the real Perth zone.
- **Three smoke tests that just needed a tickable chore** left the window off and fell back to evening. They now name `afterschool`, which the pinned clock leaves open — the convention the window tests already use.
- Noon now yields all three states deterministically: morning shut, after school open, evening not yet open.

New coverage: the shipped band and its 14:30 edge in the Perth zone (including that 14:00 is still early), the API refusal and its flag, the state fields, the miss sweep leaving an unopened window alone, and a smoke test that the row says "Opens 2:30pm" and never reads as missed.

I checked the new test actually bites: stubbing out the gate makes `a window that has not opened refuses the completion` fail.

## Tested

- `node api/test-logic.js` — all logic tests passed
- `node scripts/check-frontend.js` — passed
- `node scripts/check-design.js` — passed
- Playwright smoke suite — **85 passed**

Docs updated in `docs/design-system.md`: the window table, the early-vs-late rule, and what the pinned clock now means for anyone writing a test.

## After merge

Nothing to run — this is app code, so the Azure deploy ships it. The two live lunch chores are already on the Evening window, so they pick up the 2:30pm opening automatically.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD)_