### PR TITLE
Offer the Cubs Lazer Blaze night to both boys (#265)

### DIFF
--- a/.github/workflows/add-lazer-blaze.yml
+++ b/.github/workflows/add-lazer-blaze.yml
@@ -1,0 +1,27 @@
+# Manually-triggered one-shot: put the Cubs Lazer Blaze night (14 Sept 2026)
+# into the LIVE app as a proposal both boys can answer. Wipes nothing.
+#
+# Normally the email pipeline would do this by itself, but the app's Gmail
+# refresh token has expired, so no sweep can read the mail. This posts the same
+# payload through the same ingest action.
+# Never runs on its own - workflow_dispatch only.
+name: Add Lazer Blaze proposal
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  add-lazer-blaze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Offer the Lazer Blaze night to both boys
+        env:
+          EMAIL_INGEST_KEY: ${{ secrets.EMAIL_INGEST_KEY }}
+        run: node scripts/add-lazer-blaze.mjs

--- a/scripts/add-lazer-blaze.mjs
+++ b/scripts/add-lazer-blaze.mjs
@@ -1,0 +1,95 @@
+// One-shot: put the Cubs Lazer Blaze night into the LIVE app as a proposal the
+// boys can say yes to. Run from a GitHub Actions runner (the dev container's
+// egress policy cannot reach azurewebsites.net).
+//
+// Why this is written by hand rather than imported. The email is in Gmail and
+// the email pipeline exists to do exactly this - but the live app's Gmail
+// refresh token has expired ("invalid_grant: Token has been expired or
+// revoked"), so no sweep can read any mail until it is reconnected. That is a
+// credential, and credentials are not an agent's to rotate. This posts the same
+// payload the pipeline would have posted, through the same ingest action, so
+// nothing about the app is special-cased for it.
+//
+// The email (michael@portereng.com.au, 7 Sept 2026, "Cubs, Lazer Blaze activity
+// 14 Sept 2026"): end of term 3 activity night at Lazer Blaze, Southlands in
+// Willetton, Monday 14 Sept. Arrive by 5:40pm, first game 6pm. Pay at Lazer
+// Blaze direct on the night. Y3 forms for both boys have already been returned.
+//
+// classification 'kid-choice' with personId null is what puts it to BOTH kids:
+// each answers for themselves, and a parent still approves before it reaches
+// the calendar.
+//
+// Idempotent. The externalRef follows the pipeline's own convention
+// (gmail-<threadId>:<startAt to the minute>), so ingest hashes it to the same
+// document id every time - a second run returns duplicate:true rather than a
+// second card, and a future automatic sweep of the same email lands on the same
+// id instead of duplicating this.
+const API = process.env.API_URL || 'https://herotasks-func-dev.azurewebsites.net/api/hero';
+const INGEST_KEY = process.env.EMAIL_INGEST_KEY;
+
+if (!INGEST_KEY) {
+  console.error('EMAIL_INGEST_KEY is not set - the ingest action refuses without it.');
+  process.exit(1);
+}
+
+// 17:40 Perth (UTC+8) on Monday 14 September 2026 = 09:40Z. "Arrive by 5:40pm"
+// is the time the family has to be somewhere, so it is the event's start; the
+// 6pm first game is detail, and lives in the notes.
+const START_AT = '2026-09-14T09:40:00.000Z';
+const THREAD_ID = '1a07c1cef8648ed7';
+
+const post = async (body) => {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  if (json && json.ok === false) throw new Error(`${body.action}: ${json.error}`);
+  return json;
+};
+
+const result = await post({
+  action: 'ingestEmailItem',
+  ingestKey: INGEST_KEY,
+  classification: 'kid-choice',
+  externalRef: `gmail-${THREAD_ID}:${START_AT.slice(0, 16)}`,
+  type: 'event',
+  title: 'Cubs — Lazer Blaze',
+  startAt: START_AT,
+  // Nobody named: the invitation went to the whole Cub pack, so it is offered
+  // to both boys and each answers for themselves.
+  personId: null,
+  summary: 'End of term 3 Cubs activity night at Lazer Blaze, Southlands, Willetton. Pay at Lazer Blaze on the night.',
+  notes: [
+    'Arrive by 5:40pm — first game 6pm.',
+    'Lazer Blaze, Southlands Shopping Centre, Willetton.',
+    'Pay at Lazer Blaze direct on the night (no amount given in the email).',
+    'Y3 activity forms for Toby and Oliver have already been signed and sent.',
+  ].join('\n'),
+  // No payments[] on purpose: the email names no amount, and the payments block
+  // exists to carry real bank details. "Pay on the night" is in the notes where
+  // it belongs rather than invented as a figure.
+  from: 'michael@portereng.com.au',
+  subject: 'Cubs, Lazer Blaze activity 14 Sept 2026',
+  receivedAt: '2026-09-07T13:44:17.000Z',
+});
+
+console.log(result.duplicate
+  ? 'already there - no second card created'
+  : 'created the proposal');
+console.log(JSON.stringify({
+  id: result.item && result.item.id,
+  title: result.item && result.item.title,
+  startAt: result.item && result.item.startAt,
+  classification: result.item && result.item.classification,
+  proposalState: result.item && result.item.proposalState,
+  personId: result.item && result.item.personId,
+}, null, 2));
+
+const state = await post({ action: 'state' });
+console.log(`\npending proposals now: ${(state.proposals || []).length}`);
+for (const p of state.proposals || []) {
+  console.log(`  ${p.title} | ${p.startAt} | ${p.classification} | ${p.proposalState}`);
+}
+console.log('DONE');


### PR DESCRIPTION
Closes #265

> **User story**
> As a kid, I want to see the Cubs Lazer Blaze night in the app and say I want to go, so that once Mum or Dad says yes it turns up on everyone's calendar.

## Pete's ask

> "add to hero tasks the laser tag activity for both the boys so that they can say they want to go in the app and then it will appear for all of us in the calendar email is in Gmail"

## The email

michael@portereng.com.au, 7 Sept — *"Cubs, Lazer Blaze activity 14 Sept 2026"*. End of term 3 activity night at Lazer Blaze, Southlands in Willetton, **Monday 14 Sept**. Arrive by 5:40pm, first game 6pm. Pay at Lazer Blaze on the night. You've already sent the Y3 forms for both boys.

## What changed

**Nothing needed building.** The email-proposal feature already does exactly what was asked: a `kid-choice` proposal with no named kid is offered to *both* boys, each answers for themselves, a parent approves, and it lands on everyone's calendar badged as from email.

What stopped it happening by itself: **the live app's Gmail refresh token has expired.** The import run fails with `invalid_grant: Token has been expired or revoked`, so no sweep can read any mail at all. That's a credential to reconnect, not an agent's to rotate — see below.

So this posts the one item through the same `ingestEmailItem` action the pipeline uses, with the details read from the email.

Deliberate details:

- **`personId` is null.** The invitation went to the whole pack, so it's offered to both boys rather than guessed at.
- **`externalRef` follows the pipeline's own convention** — `gmail-<threadId>:<start to the minute>` — so ingest hashes it to the same document id every time. Running it twice returns `duplicate: true`, and a future automatic sweep of this same email lands on this item instead of creating a second card.
- **No `payments[]`.** The email names no amount, and that block exists to carry real bank details. "Pay at Lazer Blaze on the night" is in the notes rather than invented as a figure.
- **17:40 Perth is the start**, because "arrive by 5:40pm" is when the family has to be somewhere. The 6pm first game is in the notes.

## Tested

Drove the real `hero.js` ingest logic against a mock Cosmos, end to end:

```
created the proposal
  Cubs — Lazer Blaze | 2026-09-14T09:40:00.000Z | kid-choice | proposed
second run  → already there - no second card created
offered to: both boys
after both said yes: kid-interested
  responses: [{toby, wants:true}, {ollie, wants:true}]
after Peter approved → on the calendar: 1
  Cubs — Lazer Blaze | 2026-09-14T09:40:00.000Z | kind: event | source: email
pending proposals left: 0
```

Plus `node api/test-logic.js`, `node scripts/check-frontend.js`, `node scripts/check-design.js`, and every workflow file parsing.

## After merge

Run **Add Lazer Blaze proposal** (Actions → workflow_dispatch) once. Both boys then see it and can say they want to go; it reaches the calendar when a parent approves.

## Two things for you

1. **The Gmail token needs reconnecting** before the email import works again — until then no email reaches the app by itself. Worth a separate look.
2. **Cubs is already a weekly Monday 5:30pm event**, so 14 Sept will show both Cubs and Lazer Blaze. If the Lazer Blaze night *replaces* normal Cubs that week, say the word and I'll suppress that occurrence.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD)_