### PR TITLE
Skip one night of a repeating event (#267)

### DIFF
--- a/api/src/functions/hero.js
+++ b/api/src/functions/hero.js
@@ -48,6 +48,7 @@ function localMinutes(now = new Date()) {
 }
 
 const HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const DUE_REMINDER_SCHEDULE = '0 */15 * * * *';
 const VOICE_INTENT_CONFIRMATION_THRESHOLD = 0.6;
 
@@ -440,6 +441,11 @@ async function validatePlanningPayload(req, currentItem = null) {
     prepDueBy: null,
     externalRef: null,
     allDay: false,
+    // Household-local dates (YYYY-MM-DD) this weekly series does NOT run on.
+    // One night off is not the end of a series: Cubs replaced by a Lazer Blaze
+    // night is still Cubs every other Monday, so the exception belongs on the
+    // series rather than forcing a delete-and-recreate.
+    skipDates: [],
   };
 
   if (!currentItem || req.type !== undefined) {
@@ -505,6 +511,16 @@ async function validatePlanningPayload(req, currentItem = null) {
     } else {
       return { ok: false, error: "recurrence must be 'weekly' or null" };
     }
+  }
+
+  // Skipped dates only mean anything on a repeating item. Same rule as a
+  // chore's weekday list: a field that belongs to one shape is cleared when the
+  // item leaves that shape, rather than lying dormant and surprising someone
+  // who turns repetition back on.
+  if (next.recurrence !== 'weekly') {
+    next.skipDates = [];
+  } else if (!Array.isArray(next.skipDates)) {
+    next.skipDates = [];
   }
 
   // Per-event override for when prep is due. Absent, the rule is the last
@@ -863,6 +879,14 @@ function occurrenceShift(item, k) {
   };
 }
 
+// One night off. A skipped occurrence is not on the calendar, its prep is not
+// live, and the sweep records no prep miss for it - all three follow from this
+// one predicate, because the calendar and the sweep both read occurrences
+// through here.
+function isOccurrenceSkipped(item, dateStr) {
+  return Array.isArray(item.skipDates) && item.skipDates.includes(dateStr);
+}
+
 function currentOccurrence(item, now = new Date()) {
   if (item.recurrence !== 'weekly') {
     return { startAt: item.startAt, endAt: item.endAt || null, prepDueBy: item.prepDueBy || null,
@@ -872,6 +896,9 @@ function currentOccurrence(item, now = new Date()) {
   for (let k = 0; k < MAX_OCCURRENCES; k += 1) {
     const occ = occurrenceShift(item, k);
     const date = todayStr(new Date(occ.startAt));
+    // A skipped week is not "the next one up" - the prep for a night that is
+    // not happening must never be the live list.
+    if (isOccurrenceSkipped(item, date)) continue;
     if (date >= nowDate) return { ...occ, date };
   }
   const last = occurrenceShift(item, MAX_OCCURRENCES - 1);
@@ -1089,6 +1116,49 @@ async function updatePlanningItem(req) {
   await planningItems.item(req.planningItemId, HOUSEHOLD_ID).replace(validated.item);
   const { conflicts, suggestedTimes } = await getConflictsForItem(validated.item);
   return { ok: true, item: validated.item, conflicts, suggestedTimes };
+}
+
+// Take one night out of a weekly series, or put it back. Deliberately NOT a
+// delete: deleting the item deletes the whole series, and "Lazer Blaze instead
+// of Cubs this week" is one night off a series that otherwise carries on.
+//
+// The date is the occurrence's household-local date, which is what the calendar
+// already labels every occurrence with (occurrenceDate), so a client never does
+// timezone maths to name the night it means.
+async function skipOccurrence(req) {
+  await requireParent(req.parentId, req.parentPin);
+  const date = String(req.occurrenceDate || '').trim();
+  if (!DATE_RE.test(date)) return { ok: false, error: 'occurrenceDate must be YYYY-MM-DD' };
+
+  const planningItems = container('planningItems');
+  const { resource: item } = await planningItems
+    .item(req.planningItemId, HOUSEHOLD_ID)
+    .read()
+    .catch(() => ({ resource: null }));
+  if (!item || item.active === false) return { ok: false, error: 'Planning item not found' };
+  if (item.recurrence !== 'weekly') {
+    return { ok: false, error: 'Only a repeating event has occurrences to skip' };
+  }
+
+  // The date has to BE one of this series' nights. Without this a typo silently
+  // writes a skip that matches nothing and the night it was meant to remove
+  // stays on the calendar, which looks exactly like the feature not working.
+  const dates = [];
+  for (let k = 0; k < MAX_OCCURRENCES; k += 1) {
+    dates.push(todayStr(new Date(occurrenceShift(item, k).startAt)));
+  }
+  if (!dates.includes(date)) {
+    return { ok: false, error: 'That date is not one of this event\u2019s nights' };
+  }
+
+  const current = Array.isArray(item.skipDates) ? item.skipDates : [];
+  const skip = req.skip === undefined ? true : !!req.skip;
+  item.skipDates = skip
+    ? [...new Set([...current, date])].sort()
+    : current.filter((d) => d !== date);
+
+  await planningItems.item(req.planningItemId, HOUSEHOLD_ID).replace(item);
+  return { ok: true, item, skipped: skip };
 }
 
 async function deletePlanningItem(req) {
@@ -1396,6 +1466,7 @@ async function calendar(req) {
       const occStart = new Date(occ.startAt);
       if (occStart.getTime() > end.getTime()) break;
       if (occStart.getTime() < start.getTime()) continue;
+      if (isOccurrenceSkipped(item, todayStr(occStart))) continue;
       const row = {
         ...item,
         kind: item.type,
@@ -2337,6 +2408,7 @@ const ROUTES = {
   addPlanningItem,
   updatePlanningItem,
   deletePlanningItem,
+  skipOccurrence,
   ingestEmailItem,
   respondProposal,
   decideProposal,
@@ -2422,4 +2494,4 @@ app.timer('choreDueReminder', {
   },
 });
 
-module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, recordMisses, sendWindowNudges, sendEveningSummary, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, isWindowNotOpenYet, resolveWindow, currentOccurrence };
+module.exports = { getState, calcStreak, calcBadges, ROUTES, updateQuietHours, isInQuietHours, sendDueReminders, recordMisses, sendWindowNudges, sendEveningSummary, todayStr, localMinutes, HOUSEHOLD_TZ, DEFAULT_WINDOWS, isWindowClosed, isWindowNotOpenYet, resolveWindow, currentOccurrence, isOccurrenceSkipped };

--- a/api/test-logic.js
+++ b/api/test-logic.js
@@ -2331,6 +2331,85 @@ async function main() {
     'and it is the next one');
   console.log('\u2713 a weekly event expands into weekly occurrences with one live prep date');
 
+  // One night off. "Lazer Blaze instead of Cubs this week" is a single
+  // occurrence removed from a series that otherwise carries on - not a delete,
+  // which would take the whole series with it.
+  const skipDate = occurrences[1].occurrenceDate;
+  const otherDates = occurrences.filter((o) => o.occurrenceDate !== skipDate)
+    .map((o) => o.occurrenceDate);
+
+  const badDate = await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: '14th of Sept',
+  });
+  assert.strictEqual(badDate.ok, false, 'a date that is not a date is refused');
+
+  const notANight = await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: '2019-01-01',
+  });
+  assert.strictEqual(notANight.ok, false,
+    'a well-formed date that is not one of this series nights is refused - a silent no-op would look exactly like the feature not working');
+  console.log('\u2713 skipping refuses a date that is not one of the event\u2019s nights');
+
+  const nightOff = await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: skipDate,
+  });
+  assert.strictEqual(nightOff.ok, true, 'the parent can take one night out');
+  assert.deepStrictEqual(nightOff.item.skipDates, [skipDate], 'and it is recorded on the series');
+
+  const afterSkip = await R.calendar({ parentId: 'peter', parentPin: '1234', start: calFrom, end: calTo });
+  const leftOnCalendar = afterSkip.items.filter((i) => i.id === weekly.item.id)
+    .map((i) => i.occurrenceDate);
+  assert.ok(!leftOnCalendar.includes(skipDate), 'the skipped night is off the calendar');
+  assert.deepStrictEqual(leftOnCalendar, otherDates,
+    'and every other week is untouched - skipping one night is not deleting the series');
+  console.log('\u2713 one night comes off a weekly series and the rest of it stays');
+
+  // Putting it back is the same call with skip:false, so a mis-tap is one tap
+  // to undo rather than rebuilding the series.
+  const restored = await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: skipDate, skip: false,
+  });
+  assert.strictEqual(restored.ok, true);
+  assert.deepStrictEqual(restored.item.skipDates, [], 'the skip is lifted');
+  const afterRestore = await R.calendar({ parentId: 'peter', parentPin: '1234', start: calFrom, end: calTo });
+  assert.strictEqual(afterRestore.items.filter((i) => i.id === weekly.item.id).length, 4,
+    'and the night is back');
+  console.log('\u2713 a skipped night can be put back');
+
+  // The prep for a night that is not happening must never be the live list -
+  // otherwise a kid is asked to pack for an event that was called off.
+  const nextUp = currentOccurrence(weekly.item).date;
+  await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: nextUp,
+  });
+  const { resource: skippedDoc } = await mockContainer('planningItems')
+    .item(weekly.item.id, HOUSEHOLD_ID).read();
+  const movedOn = currentOccurrence(skippedDoc).date;
+  assert.notStrictEqual(movedOn, nextUp, 'the live occurrence moves past a skipped night');
+  assert.ok(movedOn > nextUp, 'and moves forward, not back');
+  await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: weekly.item.id, occurrenceDate: nextUp, skip: false,
+  });
+  console.log('\u2713 a skipped night is never the live prep occurrence');
+
+  // A one-off has no other occurrence to keep, so there is nothing to skip.
+  const oneOff = await R.addPlanningItem({
+    parentId: 'peter', parentPin: '1234', type: 'event', title: 'One-off thing',
+    personId: 'toby', startAt: cubsStart2.toISOString(),
+  });
+  const noSeries = await R.skipOccurrence({
+    parentId: 'peter', parentPin: '1234',
+    planningItemId: oneOff.item.id, occurrenceDate: currentOccurrence(oneOff.item).date,
+  });
+  assert.strictEqual(noSeries.ok, false, 'a one-off event has no occurrences to skip');
+  console.log('\u2713 only a repeating event has a night to skip');
+
   // Week one: tick, confirm, paid. The id carries the occurrence date.
   const occ1 = currentOccurrence(weekly.item).date;
   await R.tickPrepItem({ personId: 'ollie', pin: '1234', planningItemId: weekly.item.id, itemIndex: 0, done: true });

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -458,6 +458,24 @@ document, expanded into occurrences by `calendar()` exactly as a weekly chore
 is; the event's own `startAt` anchors the weekday and time, and `prepDueBy`
 shifts week by week with the occurrence. Deleting the item deletes the series.
 
+**One night off is not the end of a series.** `skipDates` holds household-local
+`YYYY-MM-DD` dates the series does not run on, set by `skipOccurrence`
+(`skip: false` puts a night back). Cubs replaced by a Lazer Blaze night is still
+Cubs every other Monday, so the exception lives on the series rather than
+forcing a delete-and-recreate. The rule is enforced in exactly two places, and
+everything else follows from them:
+
+- `calendar()` drops a skipped occurrence, so it is not on anyone's calendar.
+- `currentOccurrence()` steps past one, so a skipped night is never the live
+  prep list and `recordMisses` records no prep miss for it. A kid must never be
+  asked to pack for a night that was called off.
+
+`skipOccurrence` refuses a date that is not one of that series' nights. A
+well-formed date that matches nothing would write a skip silently and leave the
+night on the calendar, which looks exactly like the feature not working. The
+field is cleared whenever an item stops repeating, the same rule a chore's
+weekday list follows.
+
 The week-two behaviour is the design:
 
 - **Each week earns separately.** Prep completion and miss ids carry the

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3503,6 +3503,11 @@ function renderParentCalendar() {
                     + (item.kind === 'event'
                         ? '<button class="btn ghost small" onclick="parentToggleChecklist(\'' + jsq(item.id) + '\')">🎒 Checklist</button>'
                         : '')
+                    // One night off a repeating series. Only on a repeating
+                    // item, because a one-off has no other occurrence to keep.
+                    + (item.recurrence === 'weekly'
+                        ? '<button class="btn ghost small" onclick="parentSkipOccurrence(\'' + jsq(item.id) + '\', \'' + jsq(item.occurrenceDate) + '\')">Skip this one</button>'
+                        : '')
                     + '<button class="btn ghost small" onclick="parentEditPlanningItem(\'' + jsq(item.id) + '\')">Edit</button>'
                     + '<button class="btn red-ghost small" onclick="parentDeletePlanningItem(\'' + jsq(item.id) + '\')">Delete</button>'
                     + '</div>'
@@ -3512,6 +3517,34 @@ function renderParentCalendar() {
                   ? '<div class="cal-checklist-wrap">' + renderParentCalendarChecklists(item) + '</div>'
                   : '');
           }).join('') + '</div>');
+}
+
+// Take this one night out of a repeating series, leaving every other week
+// alone. Confirmed rather than instant: it removes something from everyone's
+// calendar, and "Delete" sits right beside it.
+async function parentSkipOccurrence(itemId, occurrenceDate) {
+  var item = (parentCalendarItems || []).find(function(i) {
+    return i.id === itemId && i.occurrenceDate === occurrenceDate;
+  });
+  var when = new Date(occurrenceDate + 'T12:00:00')
+    .toLocaleDateString([], { weekday: 'long', day: 'numeric', month: 'short' });
+  var label = item ? item.title : 'this event';
+  if (!await askConfirm('Skip ' + label + ' on ' + when + '? Every other week stays.', 'Skip it')) return;
+  try {
+    await api({
+      action: 'skipOccurrence',
+      parentId: session.personId,
+      parentPin: session.pin,
+      planningItemId: itemId,
+      occurrenceDate: occurrenceDate,
+      skip: true,
+    });
+  } catch (e) {
+    toast('Could not skip that one right now.');
+    return;
+  }
+  toast('Skipped ' + when + '.');
+  await loadParentCalendar();
 }
 
 function parentToggleChecklist(itemId) {

--- a/tests/smoke/smoke.spec.js
+++ b/tests/smoke/smoke.spec.js
@@ -1148,6 +1148,47 @@ test('a window that has not opened refuses the completion at the API', async ({ 
   expect(verdict.stateOpensAt, 'and the opening time to render').toBe('14:30');
 });
 
+// One night off a repeating series. "Lazer Blaze instead of Cubs this week" is
+// a single occurrence removed - the series itself carries on, so this must not
+// behave like Delete, which takes the whole thing.
+test('a parent can skip one night of a repeating event and keep the rest', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    const post = (b) => fetch('https://herotasks-func-dev.azurewebsites.net/api/hero', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(b),
+    }).then((r) => r.json());
+    // Next week, so every occurrence in range is in the future.
+    const startAt = new Date(Date.now() + 7 * 86400000).toISOString();
+    const added = await post({
+      action: 'addPlanningItem', parentId: 'peter', parentPin: '1234',
+      type: 'event', title: 'Skippable Club', personId: 'toby',
+      startAt, recurrence: 'weekly',
+    });
+    const range = (from, to) => post({
+      action: 'calendar', parentId: 'peter', parentPin: '1234',
+      start: new Date(Date.now() + from * 86400000).toISOString(),
+      end: new Date(Date.now() + to * 86400000).toISOString(),
+    });
+    const before = (await range(0, 28)).items
+      .filter((i) => i.id === added.item.id).map((i) => i.occurrenceDate);
+
+    const skipped = await post({
+      action: 'skipOccurrence', parentId: 'peter', parentPin: '1234',
+      planningItemId: added.item.id, occurrenceDate: before[1], skip: true,
+    });
+    const after = (await range(0, 28)).items
+      .filter((i) => i.id === added.item.id).map((i) => i.occurrenceDate);
+
+    await post({ action: 'deletePlanningItem', parentId: 'peter', parentPin: '1234', planningItemId: added.item.id });
+    return { before, after, skippedDate: before[1], ok: skipped.ok };
+  });
+
+  expect(seeded.ok, 'the API accepts the skip').toBe(true);
+  expect(seeded.before.length, 'the series ran every week to begin with').toBeGreaterThan(2);
+  expect(seeded.after, 'the skipped night is gone').not.toContain(seeded.skippedDate);
+  expect(seeded.after, 'and only that one night went')
+    .toEqual(seeded.before.filter((d) => d !== seeded.skippedDate));
+});
+
 // The refusal is the API's, not just the row's - a stale page that still shows
 // a tick cannot sneak a completion past a shut window.
 test('a shut window refuses the completion at the API', async ({ page }) => {


### PR DESCRIPTION
Closes #267

> **User story**
> As a parent, I want to take one night out of a repeating event, so that when Lazer Blaze replaces Cubs on 14 Sept the calendar shows the one that's actually happening — and Cubs carries on every other Monday.

## Pete's ask

> "yes laser blaze is instead of cubs"

## What changed

A weekly event was all or nothing — *"Deleting the item deletes the series"* — so there was no way to say "not this week".

`skipDates` holds household-local `YYYY-MM-DD` dates the series doesn't run on, set by a new parent action `skipOccurrence`. `skip: false` puts a night back, so a mis-tap is one tap to undo rather than rebuilding the series.

**The rule is enforced in exactly two places and everything else follows:**

- `calendar()` drops a skipped occurrence, so it's on nobody's calendar.
- `currentOccurrence()` steps past one — so a skipped night is never the live prep list, and `recordMisses` writes no prep miss for it. A kid must never be asked to pack for a night that was called off, and never be marked as having missed packing for it.

`skipOccurrence` refuses a date that isn't one of that series' nights. A well-formed date matching nothing would write a skip silently and leave the night on the calendar — which looks exactly like the feature not working. The field is cleared whenever an item stops repeating, the same rule a chore's weekday list follows.

**In the app:** a **Skip this one** button on a repeating event's agenda row, behind the in-app confirm rather than instant, because it removes something from everyone's calendar and Delete sits right beside it. Only on repeating items — a one-off has no other occurrence to keep.

## Tested

- `node api/test-logic.js` — all logic tests passed
- `node scripts/check-frontend.js` — passed
- `node scripts/check-design.js` — passed
- Playwright smoke suite — **86 passed**

New coverage: the calendar dropping only that night and keeping every other week, putting a night back, the live prep occurrence moving past a skipped night, both refusals (malformed date, and a valid date that isn't one of the series' nights), a one-off having nothing to skip, and a smoke test proving skip is not delete.

Checked the calendar test actually bites: removing the skip line from the expansion makes `the skipped night is off the calendar` fail.

Docs updated in `docs/design-system.md` under **Repeating events**.

## After merge

I'll skip Cubs on **Mon 14 Sept** on the live app, so that Monday shows Lazer Blaze only and Cubs resumes the following week.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD)_