### PR TITLE
Take Cubs off 14 Sept, because that night is Lazer Blaze (#267)

### DIFF
--- a/.github/workflows/skip-cubs-for-lazer-blaze.yml
+++ b/.github/workflows/skip-cubs-for-lazer-blaze.yml
@@ -1,0 +1,22 @@
+# Manually-triggered one-shot: take Cubs off Monday 14 Sept 2026 on the LIVE
+# app, because that night is the Lazer Blaze activity instead. A skip, not a
+# delete - every other Monday's Cubs is untouched.
+# Never runs on its own - workflow_dispatch only.
+name: Skip Cubs for Lazer Blaze
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  skip-cubs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Take Cubs off 14 Sept
+        run: node scripts/skip-cubs-for-lazer-blaze.mjs

--- a/scripts/skip-cubs-for-lazer-blaze.mjs
+++ b/scripts/skip-cubs-for-lazer-blaze.mjs
@@ -1,0 +1,72 @@
+// One-shot: take Cubs off Monday 14 September 2026 on the LIVE app, because
+// that night IS the Lazer Blaze activity rather than a normal Cubs meeting.
+// Run from a GitHub Actions runner (the dev container's egress policy cannot
+// reach azurewebsites.net).
+//
+// This is a skip, not a delete: Cubs runs every other Monday exactly as it did.
+// Deleting the item would take the whole series with it.
+//
+// Idempotent - skipping a night that is already skipped leaves it skipped.
+const API = process.env.API_URL || 'https://herotasks-func-dev.azurewebsites.net/api/hero';
+const PIN = process.env.PARENT_PIN || '1234';
+const parent = { parentId: 'peter', parentPin: PIN };
+
+// The Lazer Blaze night. Household-local date, which is what the calendar
+// labels every occurrence with, so no timezone maths happens here.
+const NIGHT = '2026-09-14';
+
+const post = async (body) => {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  if (json && json.ok === false) throw new Error(`${body.action}: ${json.error}`);
+  return json;
+};
+
+const range = async (fromDays, toDays) => post({
+  action: 'calendar', ...parent,
+  start: new Date(Date.now() + fromDays * 86400000).toISOString(),
+  end: new Date(Date.now() + toDays * 86400000).toISOString(),
+});
+
+const before = await range(-1, 60);
+const cubs = (before.items || []).find((i) =>
+  i.kind === 'event' && i.recurrence === 'weekly' && /cubs/i.test(i.title || ''));
+
+if (!cubs) {
+  console.log('no weekly Cubs event found - nothing to skip');
+  process.exit(0);
+}
+
+const nights = (before.items || [])
+  .filter((i) => i.id === cubs.id).map((i) => i.occurrenceDate).sort();
+console.log(`Cubs ("${cubs.title}") currently runs on: ${nights.join(', ')}`);
+
+if (!nights.includes(NIGHT)) {
+  // Either already skipped, or the series does not land on that Monday at all.
+  // Both are "nothing to do", but they are not the same thing, so say which.
+  console.log(`${NIGHT} is not currently a Cubs night - already skipped, or the series does not fall on it. Nothing to do.`);
+  process.exit(0);
+}
+
+await post({
+  action: 'skipOccurrence', ...parent,
+  planningItemId: cubs.id, occurrenceDate: NIGHT, skip: true,
+});
+console.log(`skipped Cubs on ${NIGHT}`);
+
+const after = await range(-1, 60);
+const left = (after.items || [])
+  .filter((i) => i.id === cubs.id).map((i) => i.occurrenceDate).sort();
+console.log(`Cubs now runs on: ${left.join(', ')}`);
+
+const lazer = (after.items || []).filter((i) => /lazer/i.test(i.title || ''));
+console.log(`\non ${NIGHT}:`);
+for (const i of (after.items || []).filter((x) => x.occurrenceDate === NIGHT || String(x.startAt).startsWith(NIGHT))) {
+  console.log(`  ${i.title} | ${i.startAt} | ${i.kind}`);
+}
+console.log(`\nLazer Blaze on the calendar: ${lazer.length} (0 until a parent approves the proposal)`);
+console.log('DONE');


### PR DESCRIPTION
Follows #267 / #268.

> **User story**
> As a parent, I want Monday 14 September to show the Lazer Blaze night and not a normal Cubs meeting, so the calendar says what's actually happening.

## Pete's ask

> "yes laser blaze is instead of cubs"

## What changed

#268 gave the app the *ability* to skip one night of a repeating event. This applies it to the live household.

A dispatch-only workflow skips that single occurrence using the `skipOccurrence` action. The alternatives don't work:

- editing a seed changes nothing for a household that already exists;
- deleting the Cubs item takes the whole weekly series with it.

The skip is the only thing that removes one night and leaves the rest.

Details worth naming:

- **It finds the weekly Cubs event rather than hardcoding an id** — ids are generated.
- **It distinguishes "already skipped" from "the series doesn't fall on that night".** Both mean nothing to do, but they aren't the same thing, and a run that can't tell them apart would quietly hide a wrong date.
- **It prints the nights before and after**, so the run's log is the evidence rather than a claim.

## Tested

Drove the real `hero.js` logic against a mock Cosmos with a weekly Monday Cubs:

```
Cubs currently runs on: 09-07, 09-14, 09-21, 09-28, 10-05, 10-12, 10-19, 10-26, 11-02
skipped Cubs on 2026-09-14
Cubs now runs on:       09-07,        09-21, 09-28, 10-05, 10-12, 10-19, 10-26, 11-02

second run → "2026-09-14 is not currently a Cubs night ... Nothing to do."
```

Plus `node api/test-logic.js`, `node scripts/check-frontend.js`, `node scripts/check-design.js`, and every workflow file parsing.

## After merge

Run **Skip Cubs for Lazer Blaze** once. Then 14 Sept shows Lazer Blaze only (once you approve the boys' proposal), and Cubs resumes on the 21st.

You can also do this yourself from now on — a repeating event's agenda row has a **Skip this one** button.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ7nBkUnChdRfMPp1Xy8bD)_